### PR TITLE
automaintainer: search for and add new CLI tools as bundled plugins to supe…

### DIFF
--- a/plugins/dotbot/install-guidance.json
+++ b/plugins/dotbot/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "dotbot",
+  "binary": "dotbot",
+  "check": "which dotbot",
+  "install_steps": [
+    "pip install dotbot",
+    "Or: brew install dotbot",
+    "Or: uv tool install dotbot",
+    "Verify: dotbot --version",
+    "supercli plugins install ./plugins/dotbot --on-conflict replace --json"
+  ],
+  "note": "Source: https://github.com/anishathalye/dotbot (7k+ stars). Written in Python. Also available via pip, brew, and as a git submodule."
+}

--- a/plugins/dotbot/meta.json
+++ b/plugins/dotbot/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Dotfile bootstrapping tool that makes installing dotfiles as easy as git clone && ./install. Supports declarative YAML/JSON configs with link, create, shell, clean directives. Plugin system for extensibility. Works on any freshly installed system with zero external dependencies.",
+  "tags": ["dotbot", "dotfiles", "configuration", "python", "bootstrapping", "productivity", "backup"],
+  "has_learn": true
+}

--- a/plugins/dotbot/plugin.json
+++ b/plugins/dotbot/plugin.json
@@ -1,0 +1,218 @@
+{
+  "name": "dotbot",
+  "version": "0.1.0",
+  "description": "Dotfile bootstrapping tool — link, create, shell, and clean for declarative dotfile management",
+  "source": "https://github.com/anishathalye/dotbot",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "dotbot"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "dotbot",
+    "binary": "dotbot",
+    "check": "which dotbot",
+    "install_steps": [
+      "pip install dotbot",
+      "Or: brew install dotbot",
+      "Or: uv tool install dotbot",
+      "Verify: dotbot --version",
+      "supercli plugins install ./plugins/dotbot --on-conflict replace --json"
+    ],
+    "note": "Source: https://github.com/anishathalye/dotbot (7k stars). Written in Python."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "dotbot",
+      "resource": "self",
+      "action": "version",
+      "description": "Print dotbot version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dotbot",
+        "missingDependencyHelp": "Install dotbot: pip install dotbot",
+        "baseArgs": ["--version"]
+      },
+      "args": []
+    },
+    {
+      "namespace": "dotbot",
+      "resource": "install",
+      "action": "run",
+      "description": "Install dotfiles using a configuration file",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dotbot",
+        "missingDependencyHelp": "Install dotbot: pip install dotbot",
+        "baseArgs": [],
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "config",
+          "type": "string",
+          "required": true,
+          "description": "Path to configuration file (e.g. install.conf.yaml)"
+        },
+        {
+          "name": "dry-run",
+          "type": "boolean",
+          "required": false,
+          "description": "Show what would be done without making changes"
+        },
+        {
+          "name": "only",
+          "type": "string",
+          "required": false,
+          "description": "Only run specified directives (comma-separated)"
+        },
+        {
+          "name": "except",
+          "type": "string",
+          "required": false,
+          "description": "Run all directives except specified ones (comma-separated)"
+        },
+        {
+          "name": "plugin",
+          "type": "string",
+          "required": false,
+          "description": "Load a plugin (can be specified multiple times)"
+        },
+        {
+          "name": "base-directory",
+          "type": "string",
+          "required": false,
+          "description": "Base directory for dotfiles (defaults to config file directory)"
+        }
+      ]
+    },
+    {
+      "namespace": "dotbot",
+      "resource": "install",
+      "action": "link",
+      "description": "Run only the link directive from a config file",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dotbot",
+        "missingDependencyHelp": "Install dotbot: pip install dotbot",
+        "baseArgs": ["--only", "link"]
+      },
+      "args": [
+        {
+          "name": "config",
+          "type": "string",
+          "required": true,
+          "description": "Path to configuration file"
+        },
+        {
+          "name": "dry-run",
+          "type": "boolean",
+          "required": false,
+          "description": "Dry run without making changes"
+        }
+      ]
+    },
+    {
+      "namespace": "dotbot",
+      "resource": "install",
+      "action": "shell",
+      "description": "Run only the shell directive from a config file",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dotbot",
+        "missingDependencyHelp": "Install dotbot: pip install dotbot",
+        "baseArgs": ["--only", "shell"]
+      },
+      "args": [
+        {
+          "name": "config",
+          "type": "string",
+          "required": true,
+          "description": "Path to configuration file"
+        },
+        {
+          "name": "dry-run",
+          "type": "boolean",
+          "required": false,
+          "description": "Dry run without making changes"
+        }
+      ]
+    },
+    {
+      "namespace": "dotbot",
+      "resource": "install",
+      "action": "create",
+      "description": "Run only the create directive from a config file",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dotbot",
+        "missingDependencyHelp": "Install dotbot: pip install dotbot",
+        "baseArgs": ["--only", "create"]
+      },
+      "args": [
+        {
+          "name": "config",
+          "type": "string",
+          "required": true,
+          "description": "Path to configuration file"
+        },
+        {
+          "name": "dry-run",
+          "type": "boolean",
+          "required": false,
+          "description": "Dry run without making changes"
+        }
+      ]
+    },
+    {
+      "namespace": "dotbot",
+      "resource": "install",
+      "action": "clean",
+      "description": "Run only the clean directive from a config file",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dotbot",
+        "missingDependencyHelp": "Install dotbot: pip install dotbot",
+        "baseArgs": ["--only", "clean"]
+      },
+      "args": [
+        {
+          "name": "config",
+          "type": "string",
+          "required": true,
+          "description": "Path to configuration file"
+        },
+        {
+          "name": "dry-run",
+          "type": "boolean",
+          "required": false,
+          "description": "Dry run without making changes"
+        }
+      ]
+    },
+    {
+      "namespace": "dotbot",
+      "resource": "_",
+      "action": "_",
+      "description": "_ _ via dotbot",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dotbot",
+        "missingDependencyHelp": "Install dotbot: pip install dotbot",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "Additional dotbot arguments"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/dotbot/skills/quickstart/SKILL.md
+++ b/plugins/dotbot/skills/quickstart/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: dotbot
+description: Use this skill when the user wants to manage dotfiles, bootstrap configuration, create symbolic links, or automate dotfile installation using dotbot.
+---
+
+# Dotbot Plugin
+
+Dotfile bootstrapping tool that makes installing dotfiles as easy as `git clone && ./install`. Uses declarative YAML/JSON configuration files with link, create, shell, and clean directives.
+
+## Commands
+
+### Installation
+- `dotbot install run` — Run dotbot with a configuration file (supports --dry-run, --only, --except)
+- `dotbot install link` — Run only the link directive from a config file
+- `dotbot install shell` — Run only the shell directive from a config file
+- `dotbot install create` — Run only the create directive from a config file
+- `dotbot install clean` — Run only the clean directive from a config file
+
+## Usage Examples
+- "dotbot -c install.conf.yaml"
+- "dotbot -c install.conf.yaml --dry-run"
+- "dotbot -c install.conf.yaml --only link"
+
+## Installation
+
+```bash
+pip install dotbot
+```
+
+## Examples
+
+```bash
+dotbot --version
+dotbot -c install.conf.yaml
+dotbot -c install.conf.yaml --dry-run
+dotbot -c install.conf.yaml --only link,create
+dotbot -c install.conf.yaml --except shell
+```
+
+## Key Features
+- Declarative YAML/JSON configuration
+- Symbolic and hard link management
+- Directory creation with mode support
+- Shell command execution with descriptions
+- Dead symlink cleanup
+- Extensive plugin system
+- Dry-run support for safe testing

--- a/plugins/gum/install-guidance.json
+++ b/plugins/gum/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "gum",
+  "binary": "gum",
+  "check": "which gum",
+  "install_steps": [
+    "brew install gum",
+    "Or: go install github.com/charmbracelet/gum@latest",
+    "Or download from https://github.com/charmbracelet/gum/releases",
+    "Verify: gum --version",
+    "supercli plugins install ./plugins/gum --on-conflict replace --json"
+  ],
+  "note": "Gum is part of the Charm ecosystem. Source: https://github.com/charmbracelet/gum (18k+ stars). Written in Go."
+}

--- a/plugins/gum/meta.json
+++ b/plugins/gum/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "A tool for glamorous shell scripts — style, format, join, and render tables with charm. Features color styling, markdown formatting, table rendering, file picker, and interactive prompts. Part of the Charm ecosystem.",
+  "tags": ["gum", "shell", "terminal", "styling", "formatting", "go", "charmbracelet", "interactive"],
+  "has_learn": true
+}

--- a/plugins/gum/plugin.json
+++ b/plugins/gum/plugin.json
@@ -1,0 +1,357 @@
+{
+  "name": "gum",
+  "version": "0.1.0",
+  "description": "A tool for glamorous shell scripts — style, format, and interact like a charm",
+  "source": "https://github.com/charmbracelet/gum",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "gum"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "gum",
+    "binary": "gum",
+    "check": "which gum",
+    "install_steps": [
+      "brew install gum",
+      "Or: go install github.com/charmbracelet/gum@latest",
+      "Or download binary from https://github.com/charmbracelet/gum/releases",
+      "Verify: gum --version",
+      "supercli plugins install ./plugins/gum --on-conflict replace --json"
+    ],
+    "note": "Available via Homebrew, Go install, and direct binary download. Source: https://github.com/charmbracelet/gum (18k stars). Written in Go."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "gum",
+      "resource": "self",
+      "action": "version",
+      "description": "Print gum version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "gum",
+        "missingDependencyHelp": "Install gum: brew install gum",
+        "baseArgs": ["--version"]
+      },
+      "args": []
+    },
+    {
+      "namespace": "gum",
+      "resource": "style",
+      "action": "apply",
+      "description": "Apply styling, coloring and formatting to text",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "gum",
+        "baseArgs": ["style"],
+        "missingDependencyHelp": "Install gum: brew install gum",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "text",
+          "type": "string",
+          "required": true,
+          "description": "Text to style"
+        },
+        {
+          "name": "foreground",
+          "type": "string",
+          "required": false,
+          "description": "Foreground color"
+        },
+        {
+          "name": "background",
+          "type": "string",
+          "required": false,
+          "description": "Background color"
+        },
+        {
+          "name": "bold",
+          "type": "boolean",
+          "required": false,
+          "description": "Bold text"
+        },
+        {
+          "name": "italic",
+          "type": "boolean",
+          "required": false,
+          "description": "Italic text"
+        },
+        {
+          "name": "underline",
+          "type": "boolean",
+          "required": false,
+          "description": "Underline text"
+        },
+        {
+          "name": "padding",
+          "type": "string",
+          "required": false,
+          "description": "Padding (e.g. 1 2)"
+        },
+        {
+          "name": "margin",
+          "type": "string",
+          "required": false,
+          "description": "Margin (e.g. 1 2)"
+        },
+        {
+          "name": "border",
+          "type": "string",
+          "required": false,
+          "description": "Border style (none, normal, rounded, thick, double, hidden)"
+        },
+        {
+          "name": "align",
+          "type": "string",
+          "required": false,
+          "description": "Text alignment (left, center, right)"
+        },
+        {
+          "name": "width",
+          "type": "number",
+          "required": false,
+          "description": "Text width"
+        },
+        {
+          "name": "height",
+          "type": "number",
+          "required": false,
+          "description": "Text height"
+        }
+      ]
+    },
+    {
+      "namespace": "gum",
+      "resource": "format",
+      "action": "render",
+      "description": "Format text using one of the available formatters",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "gum",
+        "baseArgs": ["format"],
+        "missingDependencyHelp": "Install gum: brew install gum",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "input",
+          "type": "string",
+          "required": false,
+          "description": "Text to format (reads from stdin if omitted)"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "required": false,
+          "description": "Format type (markdown, template, code, emoji)"
+        },
+        {
+          "name": "theme",
+          "type": "string",
+          "required": false,
+          "description": "Theme name for markdown rendering"
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "required": false,
+          "description": "Language for syntax highlighting"
+        }
+      ]
+    },
+    {
+      "namespace": "gum",
+      "resource": "table",
+      "action": "render",
+      "description": "Render a table from CSV/TSV or stdin",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "gum",
+        "baseArgs": ["table"],
+        "missingDependencyHelp": "Install gum: brew install gum",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "input",
+          "type": "string",
+          "required": false,
+          "description": "Table data (or pipe from stdin)"
+        },
+        {
+          "name": "columns",
+          "type": "number",
+          "required": false,
+          "description": "Number of columns"
+        },
+        {
+          "name": "widths",
+          "type": "string",
+          "required": false,
+          "description": "Column widths"
+        },
+        {
+          "name": "separator",
+          "type": "string",
+          "required": false,
+          "description": "Column separator regex"
+        },
+        {
+          "name": "border",
+          "type": "string",
+          "required": false,
+          "description": "Border style (none, normal, rounded, thick, double, hidden)"
+        }
+      ]
+    },
+    {
+      "namespace": "gum",
+      "resource": "join",
+      "action": "text",
+      "description": "Join text vertically or horizontally",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "gum",
+        "baseArgs": ["join"],
+        "missingDependencyHelp": "Install gum: brew install gum",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "text",
+          "type": "string",
+          "required": true,
+          "description": "Text lines to join"
+        },
+        {
+          "name": "horizontal",
+          "type": "boolean",
+          "required": false,
+          "description": "Join horizontally (default: vertical)"
+        },
+        {
+          "name": "align",
+          "type": "string",
+          "required": false,
+          "description": "Alignment when joining vertically (left, center, right)"
+        }
+      ]
+    },
+    {
+      "namespace": "gum",
+      "resource": "write",
+      "action": "text",
+      "description": "Write text from stdin to a file",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "gum",
+        "baseArgs": ["write"],
+        "missingDependencyHelp": "Install gum: brew install gum",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "content",
+          "type": "string",
+          "required": false,
+          "description": "Content to write (reads from stdin if omitted)"
+        },
+        {
+          "name": "width",
+          "type": "number",
+          "required": false,
+          "description": "Text area width"
+        },
+        {
+          "name": "height",
+          "type": "number",
+          "required": false,
+          "description": "Text area height"
+        },
+        {
+          "name": "char-limit",
+          "type": "number",
+          "required": false,
+          "description": "Maximum character limit"
+        },
+        {
+          "name": "show-line-numbers",
+          "type": "boolean",
+          "required": false,
+          "description": "Show line numbers"
+        }
+      ]
+    },
+    {
+      "namespace": "gum",
+      "resource": "file",
+      "action": "pick",
+      "description": "Pick a file from the filesystem",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "gum",
+        "baseArgs": ["file"],
+        "missingDependencyHelp": "Install gum: brew install gum",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "Starting directory"
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Cursor symbol"
+        },
+        {
+          "name": "all",
+          "type": "boolean",
+          "required": false,
+          "description": "Show hidden files"
+        },
+        {
+          "name": "file",
+          "type": "boolean",
+          "required": false,
+          "description": "Allow files selection"
+        },
+        {
+          "name": "directory",
+          "type": "boolean",
+          "required": false,
+          "description": "Allow directory selection"
+        }
+      ]
+    },
+    {
+      "namespace": "gum",
+      "resource": "_",
+      "action": "_",
+      "description": "_ _ via gum",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "gum",
+        "missingDependencyHelp": "Install gum: brew install gum",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "Additional gum arguments"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/gum/skills/quickstart/SKILL.md
+++ b/plugins/gum/skills/quickstart/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: gum
+description: Use this skill when the user wants to style shell output, format text, render tables, or create glamorous terminal scripts using gum.
+---
+
+# Gum Plugin
+
+A tool for glamorous shell scripts — style, format, and interact like a charm. Part of the Charmbracelet ecosystem.
+
+## Commands
+
+### Styling
+- `gum style apply` — Apply styling, coloring and formatting to text
+- `gum format render` — Format text using markdown, template, code, or emoji formatters
+- `gum table render` — Render a table from CSV/TSV or stdin data
+- `gum join text` — Join text vertically or horizontally
+- `gum write text` — Write text from stdin to a file with a text area
+- `gum file pick` — Pick a file from the filesystem
+
+## Usage Examples
+- "gum style --foreground 212 --bold --border rounded 'Hello World'"
+- "gum format --type markdown '# Heading\n\nSome text'"
+- "gum table --columns 3 --border rounded < data.csv"
+
+## Installation
+
+```bash
+brew install gum
+```
+
+## Examples
+
+```bash
+gum style --foreground 212 --bold --border rounded "Hello, World!"
+gum format --type markdown "# Hello\nWorld"
+gum table --columns 2 --border rounded < file.csv
+gum join --horizontal "hello" "world"
+```
+
+## Key Features
+- Text styling with colors, borders, padding, margin
+- Markdown rendering with themes
+- Table rendering from CSV/TSV/data
+- File picker dialog
+- Text input area
+- Interactive prompts (confirm, choose, input, spinner)


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** search for and add new CLI tools as bundled plugins to supercli. For each plugin: search GitHub for non-interactive CLI tools (stars>100, rust/go/python), create plugin files (plugin.json, meta.json, install-guidance.json, skills/quickstart/SKILL.md), validate JSON, commit with conventional commit message. Target 2 plugins per session.

**Branch:** `am/am-0e131c-tfuaus`

```
plugins/dotbot/install-guidance.json      |  13 ++
 plugins/dotbot/meta.json                  |   5 +
 plugins/dotbot/plugin.json                | 218 ++++++++++++++++++
 plugins/dotbot/skills/quickstart/SKILL.md |  47 ++++
 plugins/gum/install-guidance.json         |  13 ++
 plugins/gum/meta.json                     |   5 +
 plugins/gum/plugin.json                   | 357 ++++++++++++++++++++++++++++++
 plugins/gum/skills/quickstart/SKILL.md    |  46 ++++
 8 files changed, 704 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dotbot plugin with installation guidance (pip, brew, uv options), metadata, and quickstart documentation for dotfile management.
  * Added Gum plugin with installation guidance (Homebrew, Go, downloads), metadata, and quickstart documentation for terminal styling and content rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/javimosch/supercli/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->