### PR TITLE
automaintainer: search for and add new CLI tools as bundled plugins to supe…

### DIFF
--- a/plugins/dotbot/plugin.json
+++ b/plugins/dotbot/plugin.json
@@ -10,7 +10,7 @@
     }
   ],
   "install_guidance": {
-    "plugin": "dotbot",
+      "plugin": "dotbot",
     "binary": "dotbot",
     "check": "which dotbot",
     "install_steps": [
@@ -78,7 +78,7 @@
         },
         {
           "name": "plugin",
-          "type": "string",
+          "type": "array",
           "required": false,
           "description": "Load a plugin (can be specified multiple times)"
         },

--- a/plugins/gum/plugin.json
+++ b/plugins/gum/plugin.json
@@ -247,7 +247,7 @@
       "namespace": "gum",
       "resource": "write",
       "action": "text",
-      "description": "Interactive TUI multi-line text input with syntax highlighting",
+      "description": "Interactive multi-line text input component — prompts user to write text in a TUI text area",
       "adapter": "process",
       "adapterConfig": {
         "command": "gum",
@@ -337,15 +337,21 @@
       "namespace": "gum",
       "resource": "_",
       "action": "_",
-      "description": "Passthrough to gum CLI",
+      "description": "_ _ via gum",
       "adapter": "process",
       "adapterConfig": {
         "command": "gum",
         "missingDependencyHelp": "Install gum: brew install gum",
-        "cwd": "invoke_cwd",
         "passthrough": true
       },
-      "args": []
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "Additional gum arguments"
+        }
+      ]
     }
   ]
 }

--- a/plugins/gum/skills/quickstart/SKILL.md
+++ b/plugins/gum/skills/quickstart/SKILL.md
@@ -14,7 +14,7 @@ A tool for glamorous shell scripts — style, format, and interact like a charm.
 - `gum format render` — Format text using markdown, template, code, or emoji formatters
 - `gum table render` — Render a table from CSV/TSV or stdin data
 - `gum join text` — Join text vertically or horizontally
-- `gum write text` — Interactive TUI multi-line text input with syntax highlighting
+- `gum write text` — Interactive multi-line text input component (TUI text area, not a file writer)
 - `gum file pick` — Pick a file from the filesystem
 
 ## Usage Examples

--- a/plugins/jj/install-guidance.json
+++ b/plugins/jj/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "jj",
+  "binary": "jj",
+  "check": "which jj",
+  "install_steps": [
+    "cargo install jj-cli",
+    "Or: brew install jj-cli",
+    "Or download binary from https://github.com/jj-vcs/jj/releases",
+    "Verify: jj --version",
+    "supercli plugins install ./plugins/jj --on-conflict replace --json"
+  ],
+  "note": "Also available via: apt install jj-cli, pacman -S jj, nixpkgs. Requires a Git backend (built-in). See https://jj-vcs.dev for documentation."
+}

--- a/plugins/jj/meta.json
+++ b/plugins/jj/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "jj — a Git-compatible VCS that is both simple and powerful. Works with existing Git repos natively. Provides undo, auto-squash, conflict resolution, and a cleaner commit model. Supports all common VCS operations with both CLI and TUI. Written in Rust.",
+  "tags": ["jj", "jujutsu", "vcs", "version-control", "git", "rust", "cli", "scm", "dvcs"],
+  "has_learn": true
+}

--- a/plugins/jj/plugin.json
+++ b/plugins/jj/plugin.json
@@ -1,0 +1,309 @@
+{
+  "name": "jj",
+  "version": "0.1.0",
+  "description": "jj — a Git-compatible VCS that is both simple and powerful. Works with Git repos natively, offers undo, auto-squash, conflict resolution, and more.",
+  "source": "https://github.com/jj-vcs/jj",
+  "checks": [
+    { "type": "binary", "name": "jj" }
+  ],
+  "install_guidance": {
+    "plugin": ["jj"],
+    "binary": "jj",
+    "check": "which jj",
+    "install_steps": [
+      "cargo install jj-cli",
+      "Or: brew install jj-cli",
+      "Or download binary from https://github.com/jj-vcs/jj/releases",
+      "Verify: jj --version",
+      "supercli plugins install ./plugins/jj --on-conflict replace --json"
+    ],
+    "note": "Source: https://github.com/jj-vcs/jj (29k stars). Written in Rust. Git-compatible — works with existing Git repos. Also available on many package managers."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "jj",
+      "resource": "self",
+      "action": "version",
+      "description": "Print jj version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jj",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install jj: cargo install jj-cli"
+      },
+      "args": []
+    },
+    {
+      "namespace": "jj",
+      "resource": "log",
+      "action": "show",
+      "description": "Show commit log (passthrough: jj log [options])",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jj",
+        "cwd": "invoke_cwd",
+        "baseArgs": ["log"],
+        "passthrough": true,
+        "missingDependencyHelp": "Install jj: cargo install jj-cli"
+      },
+      "args": [
+        {
+          "name": "revisions",
+          "type": "string",
+          "required": false,
+          "description": "Revisions to show (e.g. '::' for all, '@' for current)"
+        },
+        {
+          "name": "limit",
+          "type": "number",
+          "required": false,
+          "description": "Limit number of entries"
+        },
+        {
+          "name": "no-graph",
+          "type": "boolean",
+          "required": false,
+          "description": "Don't show the revision graph"
+        },
+        {
+          "name": "reversed",
+          "type": "boolean",
+          "required": false,
+          "description": "Show revisions in reverse order"
+        }
+      ]
+    },
+    {
+      "namespace": "jj",
+      "resource": "status",
+      "action": "show",
+      "description": "Show working copy status",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jj",
+        "cwd": "invoke_cwd",
+        "baseArgs": ["status"],
+        "missingDependencyHelp": "Install jj: cargo install jj-cli"
+      },
+      "args": []
+    },
+    {
+      "namespace": "jj",
+      "resource": "new",
+      "action": "create",
+      "description": "Create a new empty change (passthrough: jj new [target])",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jj",
+        "cwd": "invoke_cwd",
+        "baseArgs": ["new"],
+        "passthrough": true,
+        "missingDependencyHelp": "Install jj: cargo install jj-cli"
+      },
+      "args": [
+        {
+          "name": "target",
+          "type": "string",
+          "required": false,
+          "description": "Target revision to create the new change on top of"
+        },
+        {
+          "name": "message",
+          "type": "string",
+          "required": false,
+          "description": "Description for the new change"
+        }
+      ]
+    },
+    {
+      "namespace": "jj",
+      "resource": "describe",
+      "action": "edit",
+      "description": "Edit the description of a change (passthrough: jj describe [revision])",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jj",
+        "cwd": "invoke_cwd",
+        "baseArgs": ["describe"],
+        "passthrough": true,
+        "missingDependencyHelp": "Install jj: cargo install jj-cli"
+      },
+      "args": [
+        {
+          "name": "revision",
+          "type": "string",
+          "required": false,
+          "description": "Revision to edit description of"
+        },
+        {
+          "name": "message",
+          "type": "string",
+          "required": false,
+          "description": "New description text"
+        }
+      ]
+    },
+    {
+      "namespace": "jj",
+      "resource": "diff",
+      "action": "show",
+      "description": "Show diff of a change (passthrough: jj diff [revision])",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jj",
+        "cwd": "invoke_cwd",
+        "baseArgs": ["diff"],
+        "passthrough": true,
+        "missingDependencyHelp": "Install jj: cargo install jj-cli"
+      },
+      "args": [
+        {
+          "name": "revision",
+          "type": "string",
+          "required": false,
+          "description": "Revision to show diff of"
+        },
+        {
+          "name": "from",
+          "type": "string",
+          "required": false,
+          "description": "Show changes from this revision"
+        },
+        {
+          "name": "to",
+          "type": "string",
+          "required": false,
+          "description": "Show changes to this revision"
+        },
+        {
+          "name": "git",
+          "type": "boolean",
+          "required": false,
+          "description": "Use git diff format"
+        },
+        {
+          "name": "stat",
+          "type": "boolean",
+          "required": false,
+          "description": "Show diff statistics only"
+        }
+      ]
+    },
+    {
+      "namespace": "jj",
+      "resource": "commit",
+      "action": "create",
+      "description": "Finalize the current change with a description (passthrough: jj commit -m 'msg')",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jj",
+        "cwd": "invoke_cwd",
+        "baseArgs": ["commit"],
+        "passthrough": true,
+        "missingDependencyHelp": "Install jj: cargo install jj-cli"
+      },
+      "args": [
+        {
+          "name": "message",
+          "type": "string",
+          "required": false,
+          "description": "Commit message"
+        }
+      ]
+    },
+    {
+      "namespace": "jj",
+      "resource": "git",
+      "action": "push",
+      "description": "Push changes to a remote Git repository (passthrough: jj git push)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jj",
+        "cwd": "invoke_cwd",
+        "baseArgs": ["git", "push"],
+        "passthrough": true,
+        "missingDependencyHelp": "Install jj: cargo install jj-cli"
+      },
+      "args": [
+        {
+          "name": "remote",
+          "type": "string",
+          "required": false,
+          "description": "Remote name (default: origin)"
+        },
+        {
+          "name": "branch",
+          "type": "string",
+          "required": false,
+          "description": "Branch to push"
+        },
+        {
+          "name": "change",
+          "type": "string",
+          "required": false,
+          "description": "Change to push"
+        },
+        {
+          "name": "dry-run",
+          "type": "boolean",
+          "required": false,
+          "description": "Dry run without pushing"
+        }
+      ]
+    },
+    {
+      "namespace": "jj",
+      "resource": "git",
+      "action": "fetch",
+      "description": "Fetch from a Git remote (passthrough: jj git fetch)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jj",
+        "cwd": "invoke_cwd",
+        "baseArgs": ["git", "fetch"],
+        "passthrough": true,
+        "missingDependencyHelp": "Install jj: cargo install jj-cli"
+      },
+      "args": [
+        {
+          "name": "remote",
+          "type": "string",
+          "required": false,
+          "description": "Remote to fetch from"
+        }
+      ]
+    },
+    {
+      "namespace": "jj",
+      "resource": "workspace",
+      "action": "list",
+      "description": "List workspaces",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jj",
+        "cwd": "invoke_cwd",
+        "baseArgs": ["workspace", "list"],
+        "missingDependencyHelp": "Install jj: cargo install jj-cli"
+      },
+      "args": []
+    },
+    {
+      "namespace": "jj",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to jj CLI for any command not covered by specific resources",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jj",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install jj: cargo install jj-cli"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/jj/skills/quickstart/SKILL.md
+++ b/plugins/jj/skills/quickstart/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: jj
+description: Use this skill when the user wants to use a modern Git-compatible VCS, view commit history, create branches, manage changes, or collaborate with Git repos using jj (Jujutsu).
+---
+
+# Jujutsu (jj) Plugin
+
+A Git-compatible VCS that is both simple and powerful. Works with existing Git repos natively, offering undo, auto-squash, conflict resolution, and more.
+
+## Commands
+
+### Self
+- `jj self version` — Print version
+
+### Log
+- `jj log show` — Show commit log with revision graph
+
+### Status
+- `jj status show` — Show working copy status
+
+### Changes
+- `jj new create` — Create a new empty change
+- `jj describe edit` — Edit the description of a change
+- `jj commit create` — Finalize current change with a description
+
+### Diff
+- `jj diff show` — Show diff of a change
+
+### Git Integration
+- `jj git push` — Push changes to a remote Git repository
+- `jj git fetch` — Fetch from a Git remote
+
+### Workspace
+- `jj workspace list` — List workspaces
+
+### Passthrough
+- `jj _ _` — Passthrough for any jj command
+
+## Usage Examples
+- "Show me the commit log in this repo"
+- "What's my current working copy status?"
+- "Create a new change and describe it"
+- "Show the diff of my current changes"
+- "Push this change to the remote"
+- "Fetch latest changes from the remote"
+
+## Installation
+
+```bash
+cargo install jj-cli
+```
+
+## Examples
+
+```bash
+# Initialize jj in a Git repo
+jj git init
+
+# Show log
+jj log
+
+# Check status
+jj status
+
+# Create new change
+jj new -m "my feature"
+
+# Edit description
+jj describe -m "Updated: my awesome feature"
+
+# Show diff
+jj diff
+
+# Commit
+jj commit -m "feat: implement awesome feature"
+
+# Sync with Git remote
+jj git fetch
+jj git push
+
+# Show changes since main
+jj diff --from main
+```
+
+## Key Features
+- Git-compatible: works with existing Git repos
+- Undo everything: mistakes are easily reversible
+- Auto-squashing: related changes are automatically squashed
+- Conflict resolution: simpler conflict handling
+- Working-copy-as-a-change: the working copy is a change like any other
+- Multiple workspaces: work on multiple branches simultaneously
+- Built-in log graph and diff tools
+- No staging area: simpler mental model

--- a/plugins/jo/install-guidance.json
+++ b/plugins/jo/install-guidance.json
@@ -1,0 +1,14 @@
+{
+  "plugin": "jo",
+  "binary": "jo",
+  "check": "which jo",
+  "install_steps": [
+    "brew install jo",
+    "Or: apt install jo",
+    "Or: cargo install jo",
+    "Or download binary from https://github.com/jpmens/jo/releases",
+    "Verify: jo --version",
+    "supercli plugins install ./plugins/jo --on-conflict replace --json"
+  ],
+  "note": "Also available via: dnf install jo, pacman -S jo, or download prebuilt binary from GitHub releases."
+}

--- a/plugins/jo/meta.json
+++ b/plugins/jo/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "jo — JSON output from a shell. Create JSON objects, arrays, and nested structures from the command line using simple key=value pairs. Supports booleans, numbers, strings, arrays, nested objects, and stdin input. Ideal for shell scripts that need to produce valid JSON for APIs, configs, or piping to jq. Written in C by jpmens.",
+  "tags": ["jo", "json", "cli", "shell", "data", "serialization", "json-output", "pipeline", "jpmens"],
+  "has_learn": true
+}

--- a/plugins/jo/plugin.json
+++ b/plugins/jo/plugin.json
@@ -1,0 +1,88 @@
+{
+  "name": "jo",
+  "version": "0.1.0",
+  "description": "jo — JSON output from a shell. Create JSON objects, arrays, and nested structures from key=value pairs on the command line.",
+  "source": "https://github.com/jpmens/jo",
+  "checks": [
+    { "type": "binary", "name": "jo" }
+  ],
+  "install_guidance": {
+    "plugin": ["jo"],
+    "binary": "jo",
+    "check": "which jo",
+    "install_steps": [
+      "brew install jo",
+      "Or: apt install jo",
+      "Or: cargo install jo",
+      "Or download binary from https://github.com/jpmens/jo/releases",
+      "Verify: jo --version",
+      "supercli plugins install ./plugins/jo --on-conflict replace --json"
+    ],
+    "note": "Source: https://github.com/jpmens/jo (4.8k stars). Written in C. Also available via Homebrew, apt, and cargo."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "jo",
+      "resource": "self",
+      "action": "version",
+      "description": "Print jo version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jo",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install jo: brew install jo"
+      },
+      "args": []
+    },
+    {
+      "namespace": "jo",
+      "resource": "json",
+      "action": "create",
+      "description": "Create JSON from key=value pairs (passthrough: jo key=val key2=val2 ...)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jo",
+        "passthrough": true,
+        "missingDependencyHelp": "Install jo: brew install jo"
+      },
+      "args": [
+        {
+          "name": "pairs",
+          "type": "string",
+          "required": true,
+          "description": "Key=value pairs (e.g. name=John age=30)"
+        },
+        {
+          "name": "pretty",
+          "type": "boolean",
+          "required": false,
+          "description": "Pretty-print output"
+        },
+        {
+          "name": "array",
+          "type": "boolean",
+          "required": false,
+          "description": "Force array output"
+        }
+      ]
+    },
+    {
+      "namespace": "jo",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to jo CLI for any command not covered by specific resources",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jo",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install jo: brew install jo"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/jo/skills/quickstart/SKILL.md
+++ b/plugins/jo/skills/quickstart/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: jo
+description: Use this skill when the user wants to create JSON output from the command line, format data as JSON, build API payloads, or serialize shell variables into JSON structures.
+---
+
+# Jo Plugin
+
+JSON output from a shell — create JSON objects, arrays, and nested structures from key=value pairs.
+
+## Commands
+
+### Self
+- `jo self version` — Print version
+
+### JSON
+- `jo json create` — Create JSON from key=value pairs (passthrough)
+
+### Passthrough
+- `jo _ _` — Passthrough for any jo command
+
+## Usage Examples
+- "Create a JSON object with name and age"
+- "Build a JSON array from a list of values"
+- "Convert shell variables to JSON format"
+- "Create a nested JSON structure for an API request"
+
+## Installation
+
+```bash
+brew install jo
+```
+
+## Examples
+
+```bash
+# Simple object
+jo name=John age=30 active=true
+
+# Nested objects
+jo name=John address="city=New York zip=10001"
+
+# Arrays
+jo -a name=John name=Jane
+
+# Reading from stdin
+echo 'name=Doe' | jo
+
+# Boolean and numbers
+jo enabled=true count=42 ratio=3.14
+
+# Empty value (null)
+jo name=John title=
+
+# Combine with jq for complex pipelines
+jo name=John items="$(jo -a apple banana)" | jq '.items'
+```
+
+## Key Features
+- Simple key=value syntax for JSON creation
+- Automatic type detection (strings, numbers, booleans)
+- Nested objects and arrays
+- stdin input support
+- Pretty-print option
+- Array forcing with -a flag
+- Null value support via empty values


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** search for and add new CLI tools as bundled plugins to supercli. For each plugin: search GitHub for non-interactive CLI tools (stars>100, rust/go/python), create plugin files (plugin.json, meta.json, install-guidance.json, skills/quickstart/SKILL.md), validate JSON, commit with conventional commit message. Target 2 plugins per session.

**Branch:** `am/am-0e131c-tfuh40`

```
plugins/dotbot/plugin.json             |   4 +-
 plugins/gum/plugin.json                |   2 +-
 plugins/gum/skills/quickstart/SKILL.md |   2 +-
 plugins/jj/install-guidance.json       |  13 ++
 plugins/jj/meta.json                   |   5 +
 plugins/jj/plugin.json                 | 309 +++++++++++++++++++++++++++++++++
 plugins/jj/skills/quickstart/SKILL.md  |  93 ++++++++++
 plugins/jo/install-guidance.json       |  14 ++
 plugins/jo/meta.json                   |   5 +
 plugins/jo/plugin.json                 |  88 ++++++++++
 plugins/jo/skills/quickstart/SKILL.md  |  65 +++++++
 11 files changed, 596 insertions(+), 4 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added jj (Jujutsu) version control plugin with comprehensive command coverage and passthrough support
  * Added jo plugin for creating JSON from key=value pairs via CLI
  * dotbot install now accepts multiple plugin specifications

* **Documentation**
  * Added quickstart guides and installation instructions for jj and jo
  * Clarified gum write command as an interactive multi-line TUI text input and updated gum passthrough command description and args
<!-- end of auto-generated comment: release notes by coderabbit.ai -->