### PR TITLE
automaintainer: Search and add new CLI tools as bundled plugins to supercli…

### DIFF
--- a/plugins/dotbot/plugin.json
+++ b/plugins/dotbot/plugin.json
@@ -10,7 +10,7 @@
     }
   ],
   "install_guidance": {
-    "plugin": ["dotbot"],
+    "plugin": "dotbot",
     "binary": "dotbot",
     "check": "which dotbot",
     "install_steps": [
@@ -198,21 +198,15 @@
       "namespace": "dotbot",
       "resource": "_",
       "action": "_",
-      "description": "_ _ via dotbot",
+      "description": "Passthrough to dotbot CLI",
       "adapter": "process",
       "adapterConfig": {
         "command": "dotbot",
         "missingDependencyHelp": "Install dotbot: pip install dotbot",
+        "cwd": "invoke_cwd",
         "passthrough": true
       },
-      "args": [
-        {
-          "name": "args",
-          "type": "string",
-          "required": false,
-          "description": "Additional dotbot arguments"
-        }
-      ]
+      "args": []
     }
   ]
 }

--- a/plugins/gum/plugin.json
+++ b/plugins/gum/plugin.json
@@ -10,7 +10,7 @@
     }
   ],
   "install_guidance": {
-    "plugin": ["gum"],
+    "plugin": "gum",
     "binary": "gum",
     "check": "which gum",
     "install_steps": [
@@ -337,21 +337,15 @@
       "namespace": "gum",
       "resource": "_",
       "action": "_",
-      "description": "_ _ via gum",
+      "description": "Passthrough to gum CLI",
       "adapter": "process",
       "adapterConfig": {
         "command": "gum",
         "missingDependencyHelp": "Install gum: brew install gum",
+        "cwd": "invoke_cwd",
         "passthrough": true
       },
-      "args": [
-        {
-          "name": "args",
-          "type": "string",
-          "required": false,
-          "description": "Additional gum arguments"
-        }
-      ]
+      "args": []
     }
   ]
 }


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Search and add new CLI tools as bundled plugins to supercli. For each plugin: search GitHub for non-interactive CLI tools (stars>100, rust/go/python), create files ONLY inside plugins/<name>/ (NEVER edit plugins/plugins.json or cli/plugin-install-guidance.js — that's legacy and causes merge conflicts). Required files: plugin.json (manifest), meta.json (description+tags+has_learn). Optional: install-guidance.json, skills/quickstart/SKILL.md (if has_learn:true), README.md. Target 2 plugins per session. Validate JSON, commit with conventional commit message.

**Branch:** `am/am-0e131c-tfumo0`

```
plugins/dotbot/plugin.json | 14 ++++----------
 plugins/gum/plugin.json    | 14 ++++----------
 2 files changed, 8 insertions(+), 20 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin configuration for dotbot and gum with improved command execution handling and simplified installation guidance metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/javimosch/supercli/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->