### PR TITLE
automaintainer: Search and add new CLI tools as bundled plugins to supercli…

### DIFF
--- a/plugins/argc/install-guidance.json
+++ b/plugins/argc/install-guidance.json
@@ -5,8 +5,8 @@
   "install_steps": [
     "cargo install argc",
     "brew install argc",
-    "npm install -g @sigoden/argc",
     "Verify: argc --version",
     "supercli plugins install ./plugins/argc --on-conflict replace --json"
-  ]
+  ],
+  "note": "Source: https://github.com/sigoden/argc (1143 stars). Written in Rust."
 }

--- a/plugins/argc/install-guidance.json
+++ b/plugins/argc/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "argc",
+  "binary": "argc",
+  "check": "which argc",
+  "install_steps": [
+    "cargo install argc",
+    "brew install argc",
+    "npm install -g @sigoden/argc",
+    "Verify: argc --version",
+    "supercli plugins install ./plugins/argc --on-conflict replace --json"
+  ]
+}

--- a/plugins/argc/meta.json
+++ b/plugins/argc/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "argc — Bash CLI framework and command runner",
+  "tags": ["argc", "bash", "shell", "cli", "rust", "development", "task-runner"],
+  "has_learn": true
+}

--- a/plugins/argc/plugin.json
+++ b/plugins/argc/plugin.json
@@ -49,14 +49,7 @@
         "missingDependencyHelp": "Install argc: cargo install argc",
         "cwd": "invoke_cwd"
       },
-      "args": [
-        {
-          "name": "args",
-          "type": "string",
-          "required": false,
-          "description": "Script path and arguments"
-        }
-      ]
+      "args": []
     },
     {
       "namespace": "argc",
@@ -104,14 +97,7 @@
         "missingDependencyHelp": "Install argc: cargo install argc",
         "cwd": "invoke_cwd"
       },
-      "args": [
-        {
-          "name": "args",
-          "type": "string",
-          "required": false,
-          "description": "Additional arguments"
-        }
-      ]
+      "args": []
     }
   ]
 }

--- a/plugins/argc/plugin.json
+++ b/plugins/argc/plugin.json
@@ -1,0 +1,117 @@
+{
+  "name": "argc",
+  "version": "0.1.0",
+  "description": "argc — Bash CLI framework and command runner",
+  "source": "https://github.com/sigoden/argc",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "argc"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "argc",
+    "binary": "argc",
+    "check": "which argc",
+    "install_steps": [
+      "cargo install argc",
+      "brew install argc",
+      "Verify: argc --version",
+      "supercli plugins install ./plugins/argc --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "argc",
+      "resource": "self",
+      "action": "version",
+      "description": "Print argc version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "argc",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install argc: cargo install argc"
+      },
+      "args": []
+    },
+    {
+      "namespace": "argc",
+      "resource": "script",
+      "action": "run",
+      "description": "Run a bash script with argc annotations",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "argc",
+        "passthrough": true,
+        "missingDependencyHelp": "Install argc: cargo install argc",
+        "cwd": "invoke_cwd"
+      },
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "Script path and arguments"
+        }
+      ]
+    },
+    {
+      "namespace": "argc",
+      "resource": "completions",
+      "action": "generate",
+      "description": "Generate shell completions for argc",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "argc",
+        "baseArgs": ["--completions"],
+        "passthrough": true,
+        "missingDependencyHelp": "Install argc: cargo install argc"
+      },
+      "args": [
+        {
+          "name": "shell",
+          "type": "string",
+          "required": false,
+          "description": "Shell type (bash, zsh, fish, powershell, elvish)"
+        }
+      ]
+    },
+    {
+      "namespace": "argc",
+      "resource": "help",
+      "action": "show",
+      "description": "Show argc help",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "argc",
+        "baseArgs": ["--help"],
+        "missingDependencyHelp": "Install argc: cargo install argc"
+      },
+      "args": []
+    },
+    {
+      "namespace": "argc",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to argc",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "argc",
+        "passthrough": true,
+        "missingDependencyHelp": "Install argc: cargo install argc",
+        "cwd": "invoke_cwd"
+      },
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "Additional arguments"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/argc/skills/quickstart/SKILL.md
+++ b/plugins/argc/skills/quickstart/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: argc
+description: Use this skill when the user wants to create or run Bash CLIs with argc annotations.
+---
+
+# argc Plugin
+
+argc is a Bash CLI framework that turns bash scripts into full-featured command-line tools with help messages, argument validation, and shell completions.
+
+## Commands
+
+### Basic
+- `argc self version` — Print argc version
+- `argc help show` — Show argc help
+
+### Script Execution
+- `argc script run` — Run a bash script with argc annotations
+
+### Shell Integration
+- `argc completions generate` — Generate shell completions (bash/zsh/fish/powershell/elvish)
+
+### Passthrough
+- `argc _ _` — Pass raw arguments to argc binary
+
+## Usage Examples
+
+```bash
+# Show argc help
+sc argc help show --json
+
+# Run a script with argc annotations
+sc argc script run myscript.sh -- --help
+
+# Generate bash completions
+sc argc completions generate bash
+```

--- a/plugins/sccache/install-guidance.json
+++ b/plugins/sccache/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "sccache",
+  "binary": "sccache",
+  "check": "which sccache",
+  "install_steps": [
+    "cargo install sccache",
+    "brew install sccache",
+    "Verify: sccache --version",
+    "supercli plugins install ./plugins/sccache --on-conflict replace --json"
+  ]
+}

--- a/plugins/sccache/install-guidance.json
+++ b/plugins/sccache/install-guidance.json
@@ -7,5 +7,6 @@
     "brew install sccache",
     "Verify: sccache --version",
     "supercli plugins install ./plugins/sccache --on-conflict replace --json"
-  ]
+  ],
+  "note": "Source: https://github.com/mozilla/sccache (7323 stars). Written in Rust."
 }

--- a/plugins/sccache/meta.json
+++ b/plugins/sccache/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "sccache — shared compiler cache with cloud storage support",
+  "tags": ["sccache", "rust", "build", "cache", "compiler", "development"],
+  "has_learn": true
+}

--- a/plugins/sccache/plugin.json
+++ b/plugins/sccache/plugin.json
@@ -1,0 +1,112 @@
+{
+  "name": "sccache",
+  "version": "0.1.0",
+  "description": "sccache — shared compiler cache with cloud storage support",
+  "source": "https://github.com/mozilla/sccache",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "sccache"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "sccache",
+    "binary": "sccache",
+    "check": "which sccache",
+    "install_steps": [
+      "cargo install sccache",
+      "Verify: sccache --version",
+      "supercli plugins install ./plugins/sccache --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "sccache",
+      "resource": "self",
+      "action": "version",
+      "description": "Print sccache version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sccache",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install sccache: cargo install sccache"
+      },
+      "args": []
+    },
+    {
+      "namespace": "sccache",
+      "resource": "stats",
+      "action": "show",
+      "description": "Show sccache cache statistics",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sccache",
+        "baseArgs": ["--show-stats"],
+        "missingDependencyHelp": "Install sccache: cargo install sccache"
+      },
+      "args": []
+    },
+    {
+      "namespace": "sccache",
+      "resource": "cache",
+      "action": "clear",
+      "description": "Clear sccache cache",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sccache",
+        "baseArgs": ["--clear"],
+        "missingDependencyHelp": "Install sccache: cargo install sccache"
+      },
+      "args": []
+    },
+    {
+      "namespace": "sccache",
+      "resource": "server",
+      "action": "start",
+      "description": "Start sccache server",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sccache",
+        "baseArgs": ["--start-server"],
+        "missingDependencyHelp": "Install sccache: cargo install sccache"
+      },
+      "args": []
+    },
+    {
+      "namespace": "sccache",
+      "resource": "server",
+      "action": "stop",
+      "description": "Stop sccache server",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sccache",
+        "baseArgs": ["--stop-server"],
+        "missingDependencyHelp": "Install sccache: cargo install sccache"
+      },
+      "args": []
+    },
+    {
+      "namespace": "sccache",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to sccache",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sccache",
+        "passthrough": true,
+        "missingDependencyHelp": "Install sccache: cargo install sccache"
+      },
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "Additional arguments"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/sccache/plugin.json
+++ b/plugins/sccache/plugin.json
@@ -15,9 +15,11 @@
     "check": "which sccache",
     "install_steps": [
       "cargo install sccache",
+      "brew install sccache",
       "Verify: sccache --version",
       "supercli plugins install ./plugins/sccache --on-conflict replace --json"
-    ]
+    ],
+    "note": "Source: https://github.com/mozilla/sccache (7323 stars). Written in Rust."
   },
   "learn": {
     "file": "skills/quickstart/SKILL.md"
@@ -97,16 +99,10 @@
       "adapterConfig": {
         "command": "sccache",
         "passthrough": true,
-        "missingDependencyHelp": "Install sccache: cargo install sccache"
+        "missingDependencyHelp": "Install sccache: cargo install sccache",
+        "cwd": "invoke_cwd"
       },
-      "args": [
-        {
-          "name": "args",
-          "type": "string",
-          "required": false,
-          "description": "Additional arguments"
-        }
-      ]
+      "args": []
     }
   ]
 }

--- a/plugins/sccache/skills/quickstart/SKILL.md
+++ b/plugins/sccache/skills/quickstart/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: sccache
+description: Use this skill when the user wants to manage a shared compiler cache with cloud storage support.
+---
+
+# sccache Plugin
+
+sccache is a compiler caching tool (like ccache) with support for local and cloud storage backends (S3, GCS, Azure, Redis).
+
+## Commands
+
+### Version Info
+- `sccache self version` — Print sccache version
+
+### Cache Management
+- `sccache stats show` — Show cache statistics (hits, misses, size)
+- `sccache cache clear` — Clear the entire cache
+
+### Server Management
+- `sccache server start` — Start the sccache daemon
+- `sccache server stop` — Stop the sccache daemon
+
+### Passthrough
+- `sccache _ _` — Pass raw arguments to sccache binary
+
+## Usage Examples
+
+```bash
+# Check cache stats
+sc sccache stats show --json
+
+# Clear cache
+sc sccache cache clear
+
+# Use sccache as compiler wrapper
+export RUSTC_WRAPPER=sccache
+cargo build
+sc sccache stats show --json
+```


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Search and add new CLI tools as bundled plugins to supercli. For each plugin: search GitHub for non-interactive CLI tools (stars>100, rust/go/python), create files ONLY inside plugins/<name>/ (NEVER edit plugins/plugins.json or cli/plugin-install-guidance.js — that's legacy and causes merge conflicts). Required files: plugin.json (manifest), meta.json (description+tags+has_learn). Optional: install-guidance.json, skills/quickstart/SKILL.md (if has_learn:true), README.md. Target 2 plugins per session. Validate JSON, commit with conventional commit message.

**Branch:** `am/am-0e131c-tfupg0`

```
plugins/argc/install-guidance.json         |  12 ++++
 plugins/argc/meta.json                     |   5 ++
 plugins/argc/plugin.json                   | 103 +++++++++++++++++++++++++++
 plugins/argc/skills/quickstart/SKILL.md    |  36 ++++++++++
 plugins/sccache/install-guidance.json      |  12 ++++
 plugins/sccache/meta.json                  |   5 ++
 plugins/sccache/plugin.json                | 108 +++++++++++++++++++++++++++++
 plugins/sccache/skills/quickstart/SKILL.md |  39 +++++++++++
 8 files changed, 320 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `argc` plugin for running Bash command-line interfaces with support for script execution, shell completions, and help documentation.
  * Added `sccache` plugin for managing a shared compiler cache with commands for server control, cache statistics, and cache management.

* **Documentation**
  * Added quickstart guides for both plugins, including installation instructions, command references, and practical usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/javimosch/supercli/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->