### PR TITLE
automaintainer: Consume from /root/candidates.json to create bundled plugin…

### DIFF
--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generated_at": "2026-05-31T03:22:36.407Z",
-  "count": 3313,
+  "generated_at": "2026-05-31T06:36:13.436Z",
+  "count": 3317,
   "plugins": [
     {
       "name": "[",
@@ -2888,6 +2888,10 @@
       "checksum": "475ce6699b9c792e"
     },
     {
+      "name": "doit",
+      "checksum": "20982727f38271bc"
+    },
+    {
       "name": "dokka",
       "checksum": "42503196af76726d"
     },
@@ -5286,6 +5290,10 @@
     {
       "name": "httpretty",
       "checksum": "7eb64b921334714c"
+    },
+    {
+      "name": "httpstat",
+      "checksum": "a57955383cbad06b"
     },
     {
       "name": "httpu",
@@ -10396,6 +10404,10 @@
       "checksum": "fa3bccc2d75524ba"
     },
     {
+      "name": "shiori",
+      "checksum": "3df1fd49522af49b"
+    },
+    {
       "name": "ship-safe",
       "checksum": "80e599e18f60fb60"
     },
@@ -11482,6 +11494,10 @@
     {
       "name": "tfk8s",
       "checksum": "5c388d14034f5462"
+    },
+    {
+      "name": "tflint",
+      "checksum": "c9b821ab52b09f84"
     },
     {
       "name": "tfmv",

--- a/plugins/doit/install-guidance.json
+++ b/plugins/doit/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "doit",
+  "binary": "doit",
+  "check": "which doit",
+  "install_steps": [
+    "pip install doit",
+    "Verify: doit --version",
+    "supercli plugins install ./plugins/doit --on-conflict replace --json"
+  ],
+  "note": "doit is a task automation tool like make, but in Python. Tasks are defined in dodo.py files. Source: https://github.com/pydoit/doit (2k+ stars)."
+}

--- a/plugins/doit/meta.json
+++ b/plugins/doit/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "CLI task management and automation tool with dependency tracking, parallel execution, and JSON output reporter. Define tasks in Python (dodo.py), run with dependency resolution, and automate complex multi-step workflows.",
+  "tags": ["doit", "task", "automation", "python", "build", "workflow", "make", "pipeline"],
+  "has_learn": false
+}

--- a/plugins/doit/plugin.json
+++ b/plugins/doit/plugin.json
@@ -1,0 +1,297 @@
+{
+  "name": "doit",
+  "version": "0.1.0",
+  "description": "CLI task management and automation tool with dependency tracking, parallel execution, and JSON reporter",
+  "source": "https://github.com/pydoit/doit",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "doit"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "doit",
+    "binary": "doit",
+    "check": "which doit",
+    "install_steps": [
+      "pip install doit",
+      "Verify: doit --version",
+      "supercli plugins install ./plugins/doit --on-conflict replace --json"
+    ],
+    "note": "Available via pip. Source: https://github.com/pydoit/doit (2k+ stars). Written in Python."
+  },
+  "commands": [
+    {
+      "namespace": "doit",
+      "resource": "task",
+      "action": "run",
+      "description": "Run tasks (default command)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "doit",
+        "missingDependencyHelp": "Install doit: pip install doit",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "task",
+          "type": "string",
+          "required": false,
+          "description": "Task names to run (space-separated)"
+        },
+        {
+          "name": "file",
+          "type": "string",
+          "required": false,
+          "description": "Dodo file to use (default: dodo.py)"
+        },
+        {
+          "name": "dir",
+          "type": "string",
+          "required": false,
+          "description": "Working directory"
+        },
+        {
+          "name": "verbosity",
+          "type": "number",
+          "required": false,
+          "description": "0=capture all, 1=capture stdout, 2=capture nothing"
+        },
+        {
+          "name": "always-execute",
+          "type": "boolean",
+          "required": false,
+          "description": "Execute even if up-to-date"
+        },
+        {
+          "name": "continue",
+          "type": "boolean",
+          "required": false,
+          "description": "Continue after failure"
+        },
+        {
+          "name": "single",
+          "type": "boolean",
+          "required": false,
+          "description": "Execute without task dependencies"
+        },
+        {
+          "name": "process",
+          "type": "number",
+          "required": false,
+          "description": "Number of parallel processes (0=sequential)"
+        },
+        {
+          "name": "reporter",
+          "type": "string",
+          "required": false,
+          "description": "console, executed-only, json, zero, error-only"
+        },
+        {
+          "name": "output-file",
+          "type": "string",
+          "required": false,
+          "description": "Write output to file"
+        }
+      ]
+    },
+    {
+      "namespace": "doit",
+      "resource": "task",
+      "action": "list",
+      "description": "List tasks from dodo file",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "doit",
+        "baseArgs": ["list"],
+        "missingDependencyHelp": "Install doit: pip install doit",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "task",
+          "type": "string",
+          "required": false,
+          "description": "Filter by task name"
+        },
+        {
+          "name": "all",
+          "type": "boolean",
+          "required": false,
+          "description": "Include subtasks"
+        },
+        {
+          "name": "status",
+          "type": "boolean",
+          "required": false,
+          "description": "Show task status (R=run, U=up-to-date, I=ignored)"
+        },
+        {
+          "name": "quiet",
+          "type": "boolean",
+          "required": false,
+          "description": "Print just task name"
+        },
+        {
+          "name": "private",
+          "type": "boolean",
+          "required": false,
+          "description": "Show private tasks (start with _)"
+        },
+        {
+          "name": "file",
+          "type": "string",
+          "required": false,
+          "description": "Dodo file to use"
+        }
+      ]
+    },
+    {
+      "namespace": "doit",
+      "resource": "task",
+      "action": "info",
+      "description": "Show info about a task",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "doit",
+        "baseArgs": ["info"],
+        "missingDependencyHelp": "Install doit: pip install doit",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "task",
+          "type": "string",
+          "required": true,
+          "description": "Task name"
+        },
+        {
+          "name": "no-status",
+          "type": "boolean",
+          "required": false,
+          "description": "Hide reasons why task would execute"
+        }
+      ]
+    },
+    {
+      "namespace": "doit",
+      "resource": "task",
+      "action": "clean",
+      "description": "Clean actions / remove targets",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "doit",
+        "baseArgs": ["clean"],
+        "missingDependencyHelp": "Install doit: pip install doit",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "task",
+          "type": "string",
+          "required": false,
+          "description": "Tasks to clean"
+        },
+        {
+          "name": "dry-run",
+          "type": "boolean",
+          "required": false,
+          "description": "Print actions without executing"
+        },
+        {
+          "name": "clean-dep",
+          "type": "boolean",
+          "required": false,
+          "description": "Clean dependencies too"
+        },
+        {
+          "name": "clean-all",
+          "type": "boolean",
+          "required": false,
+          "description": "Clean all tasks"
+        },
+        {
+          "name": "file",
+          "type": "string",
+          "required": false,
+          "description": "Dodo file to use"
+        }
+      ]
+    },
+    {
+      "namespace": "doit",
+      "resource": "task",
+      "action": "forget",
+      "description": "Clear successful run status from internal DB",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "doit",
+        "baseArgs": ["forget"],
+        "missingDependencyHelp": "Install doit: pip install doit",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "task",
+          "type": "string",
+          "required": false,
+          "description": "Tasks to forget"
+        },
+        {
+          "name": "all",
+          "type": "boolean",
+          "required": false,
+          "description": "Forget all tasks"
+        }
+      ]
+    },
+    {
+      "namespace": "doit",
+      "resource": "db",
+      "action": "dump",
+      "description": "Dump dependency DB content",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "doit",
+        "baseArgs": ["dumpdb"],
+        "missingDependencyHelp": "Install doit: pip install doit",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "db-file",
+          "type": "string",
+          "required": false,
+          "description": "Dependency file name"
+        }
+      ]
+    },
+    {
+      "namespace": "doit",
+      "resource": "self",
+      "action": "version",
+      "description": "Print doit version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "doit",
+        "missingDependencyHelp": "Install doit: pip install doit",
+        "baseArgs": ["--version"]
+      },
+      "args": []
+    },
+    {
+      "namespace": "doit",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to doit CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "doit",
+        "missingDependencyHelp": "Install doit: pip install doit",
+        "cwd": "invoke_cwd",
+        "passthrough": true
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/httpstat/install-guidance.json
+++ b/plugins/httpstat/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "httpstat",
+  "binary": "httpstat",
+  "check": "which httpstat",
+  "install_steps": [
+    "pip install httpstat",
+    "Or: brew install httpstat",
+    "Verify: httpstat --version",
+    "supercli plugins install ./plugins/httpstat --on-conflict replace --json"
+  ],
+  "note": "httpstat wraps curl and provides detailed connection timing breakdown. Source: https://github.com/reorx/httpstat (6k+ stars). Written in Python."
+}

--- a/plugins/httpstat/meta.json
+++ b/plugins/httpstat/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "curl statistics made simple — visualize HTTP request timing breakdown with DNS lookup, TCP connection, TLS handshake, server processing, and content transfer phases. Supports pretty, JSON, and JSONL output formats with SLO threshold checking.",
+  "tags": ["httpstat", "http", "curl", "network", "timing", "performance", "python", "debugging", "monitoring"],
+  "has_learn": false
+}

--- a/plugins/httpstat/plugin.json
+++ b/plugins/httpstat/plugin.json
@@ -1,0 +1,90 @@
+{
+  "name": "httpstat",
+  "version": "0.1.0",
+  "description": "curl statistics made simple — visualize HTTP request timing breakdown (DNS, TCP, TLS, server, transfer)",
+  "source": "https://github.com/reorx/httpstat",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "httpstat"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "httpstat",
+    "binary": "httpstat",
+    "check": "which httpstat",
+    "install_steps": [
+      "pip install httpstat",
+      "Verify: httpstat --version",
+      "supercli plugins install ./plugins/httpstat --on-conflict replace --json"
+    ],
+    "note": "Also available via brew: brew install httpstat. Source: https://github.com/reorx/httpstat (6k+ stars). Written in Python."
+  },
+  "commands": [
+    {
+      "namespace": "httpstat",
+      "resource": "request",
+      "action": "run",
+      "description": "Visualize HTTP request timing statistics for a URL",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "httpstat",
+        "missingDependencyHelp": "Install httpstat: pip install httpstat",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "url",
+          "type": "string",
+          "required": true,
+          "description": "URL to request (with or without http(s):// prefix)"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "required": false,
+          "description": "Output format: pretty, json, or jsonl"
+        },
+        {
+          "name": "slo",
+          "type": "string",
+          "required": false,
+          "description": "SLO thresholds as key=value pairs (total, connect, ttfb, dns, tls)"
+        },
+        {
+          "name": "save",
+          "type": "string",
+          "required": false,
+          "description": "Save structured output to a file path"
+        }
+      ]
+    },
+    {
+      "namespace": "httpstat",
+      "resource": "self",
+      "action": "version",
+      "description": "Print httpstat version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "httpstat",
+        "missingDependencyHelp": "Install httpstat: pip install httpstat",
+        "baseArgs": ["--version"]
+      },
+      "args": []
+    },
+    {
+      "namespace": "httpstat",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to httpstat CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "httpstat",
+        "missingDependencyHelp": "Install httpstat: pip install httpstat",
+        "cwd": "invoke_cwd",
+        "passthrough": true
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/shiori/install-guidance.json
+++ b/plugins/shiori/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "shiori",
+  "binary": "shiori",
+  "check": "which shiori",
+  "install_steps": [
+    "go install github.com/go-shiori/shiori/cmd/shiori@latest",
+    "Or download from https://github.com/go-shiori/shiori/releases",
+    "Verify: shiori version",
+    "supercli plugins install ./plugins/shiori --on-conflict replace --json"
+  ],
+  "note": "Shiori requires a database (SQLite by default). First run creates it automatically. Source: https://github.com/go-shiori/shiori (11k+ stars). Written in Go."
+}

--- a/plugins/shiori/meta.json
+++ b/plugins/shiori/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Simple command-line bookmark manager built with Go. Add, list (with JSON output), search, update, delete, open, import, export, and check bookmarks. Supports offline archival, tagging, and CalDAV sync.",
+  "tags": ["shiori", "bookmark", "bookmarks", "go", "utility", "archive", "productivity", "web"],
+  "has_learn": false
+}

--- a/plugins/shiori/plugin.json
+++ b/plugins/shiori/plugin.json
@@ -1,0 +1,335 @@
+{
+  "name": "shiori",
+  "version": "0.1.0",
+  "description": "Simple command-line bookmark manager built with Go — add, list, search, open, and archive bookmarks",
+  "source": "https://github.com/go-shiori/shiori",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "shiori"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "shiori",
+    "binary": "shiori",
+    "check": "which shiori",
+    "install_steps": [
+      "go install github.com/go-shiori/shiori/cmd/shiori@latest",
+      "Or download from https://github.com/go-shiori/shiori/releases",
+      "Verify: shiori version",
+      "supercli plugins install ./plugins/shiori --on-conflict replace --json"
+    ],
+    "note": "Available via Go install and direct binary download. Source: https://github.com/go-shiori/shiori (11k+ stars). Written in Go."
+  },
+  "commands": [
+    {
+      "namespace": "shiori",
+      "resource": "bookmark",
+      "action": "add",
+      "description": "Bookmark the specified URL",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "shiori",
+        "baseArgs": ["add"],
+        "missingDependencyHelp": "Install shiori: go install github.com/go-shiori/shiori/cmd/shiori@latest",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "url",
+          "type": "string",
+          "required": true,
+          "description": "URL to bookmark"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "description": "Custom title for this bookmark"
+        },
+        {
+          "name": "excerpt",
+          "type": "string",
+          "required": false,
+          "description": "Custom excerpt for this bookmark"
+        },
+        {
+          "name": "tags",
+          "type": "string",
+          "required": false,
+          "description": "Comma-separated tags"
+        },
+        {
+          "name": "offline",
+          "type": "boolean",
+          "required": false,
+          "description": "Save without fetching data from internet"
+        },
+        {
+          "name": "no-archival",
+          "type": "boolean",
+          "required": false,
+          "description": "Save without creating offline archive"
+        }
+      ]
+    },
+    {
+      "namespace": "shiori",
+      "resource": "bookmark",
+      "action": "list",
+      "description": "List saved bookmarks",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "shiori",
+        "baseArgs": ["print"],
+        "missingDependencyHelp": "Install shiori: go install github.com/go-shiori/shiori/cmd/shiori@latest",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "indices",
+          "type": "string",
+          "required": false,
+          "description": "Space-separated indices or hyphenated ranges (e.g. 1-3 7 9)"
+        },
+        {
+          "name": "json",
+          "type": "boolean",
+          "required": false,
+          "description": "Output data in JSON format"
+        },
+        {
+          "name": "search",
+          "type": "string",
+          "required": false,
+          "description": "Search with keyword"
+        },
+        {
+          "name": "tags",
+          "type": "string",
+          "required": false,
+          "description": "Filter by tags"
+        },
+        {
+          "name": "exclude-tags",
+          "type": "string",
+          "required": false,
+          "description": "Exclude by tags"
+        },
+        {
+          "name": "latest",
+          "type": "boolean",
+          "required": false,
+          "description": "Sort by latest"
+        }
+      ]
+    },
+    {
+      "namespace": "shiori",
+      "resource": "bookmark",
+      "action": "update",
+      "description": "Update saved bookmarks",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "shiori",
+        "baseArgs": ["update"],
+        "missingDependencyHelp": "Install shiori: go install github.com/go-shiori/shiori/cmd/shiori@latest",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "indices",
+          "type": "string",
+          "required": false,
+          "description": "Space-separated indices or ranges"
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "required": false,
+          "description": "New URL for this bookmark"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "description": "New title"
+        },
+        {
+          "name": "tags",
+          "type": "string",
+          "required": false,
+          "description": "Comma-separated tags (prefix with - to remove)"
+        },
+        {
+          "name": "yes",
+          "type": "boolean",
+          "required": false,
+          "description": "Skip confirmation prompt and update ALL"
+        }
+      ]
+    },
+    {
+      "namespace": "shiori",
+      "resource": "bookmark",
+      "action": "delete",
+      "description": "Delete saved bookmarks",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "shiori",
+        "baseArgs": ["delete"],
+        "missingDependencyHelp": "Install shiori: go install github.com/go-shiori/shiori/cmd/shiori@latest",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "indices",
+          "type": "string",
+          "required": false,
+          "description": "Space-separated indices or ranges"
+        },
+        {
+          "name": "yes",
+          "type": "boolean",
+          "required": false,
+          "description": "Skip confirmation and delete ALL"
+        }
+      ]
+    },
+    {
+      "namespace": "shiori",
+      "resource": "bookmark",
+      "action": "open",
+      "description": "Open saved bookmarks in browser",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "shiori",
+        "baseArgs": ["open"],
+        "missingDependencyHelp": "Install shiori: go install github.com/go-shiori/shiori/cmd/shiori@latest",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "indices",
+          "type": "string",
+          "required": false,
+          "description": "Space-separated indices or ranges"
+        },
+        {
+          "name": "archive",
+          "type": "boolean",
+          "required": false,
+          "description": "Open archived content"
+        },
+        {
+          "name": "text-cache",
+          "type": "boolean",
+          "required": false,
+          "description": "Open text cache in terminal"
+        },
+        {
+          "name": "yes",
+          "type": "boolean",
+          "required": false,
+          "description": "Skip confirmation and open ALL"
+        }
+      ]
+    },
+    {
+      "namespace": "shiori",
+      "resource": "bookmark",
+      "action": "check",
+      "description": "Find bookmarked sites that no longer exist",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "shiori",
+        "baseArgs": ["check"],
+        "missingDependencyHelp": "Install shiori: go install github.com/go-shiori/shiori/cmd/shiori@latest",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "yes",
+          "type": "boolean",
+          "required": false,
+          "description": "Skip confirmation and check ALL"
+        }
+      ]
+    },
+    {
+      "namespace": "shiori",
+      "resource": "bookmark",
+      "action": "import",
+      "description": "Import bookmarks from HTML file (Netscape format)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "shiori",
+        "baseArgs": ["import"],
+        "missingDependencyHelp": "Install shiori: go install github.com/go-shiori/shiori/cmd/shiori@latest",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "source-file",
+          "type": "string",
+          "required": true,
+          "description": "Path to HTML file"
+        },
+        {
+          "name": "generate-tag",
+          "type": "boolean",
+          "required": false,
+          "description": "Auto-generate tags from bookmark category"
+        }
+      ]
+    },
+    {
+      "namespace": "shiori",
+      "resource": "bookmark",
+      "action": "export",
+      "description": "Export bookmarks to HTML file (Netscape format)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "shiori",
+        "baseArgs": ["export"],
+        "missingDependencyHelp": "Install shiori: go install github.com/go-shiori/shiori/cmd/shiori@latest",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "target-file",
+          "type": "string",
+          "required": true,
+          "description": "Path to output HTML file"
+        }
+      ]
+    },
+    {
+      "namespace": "shiori",
+      "resource": "self",
+      "action": "version",
+      "description": "Print shiori version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "shiori",
+        "missingDependencyHelp": "Install shiori: go install github.com/go-shiori/shiori/cmd/shiori@latest",
+        "baseArgs": ["version"]
+      },
+      "args": []
+    },
+    {
+      "namespace": "shiori",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to shiori CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "shiori",
+        "missingDependencyHelp": "Install shiori: go install github.com/go-shiori/shiori/cmd/shiori@latest",
+        "cwd": "invoke_cwd",
+        "passthrough": true
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/tflint/install-guidance.json
+++ b/plugins/tflint/install-guidance.json
@@ -1,0 +1,14 @@
+{
+  "plugin": "tflint",
+  "binary": "tflint",
+  "check": "which tflint",
+  "install_steps": [
+    "brew install tflint",
+    "Or: curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash",
+    "Or download from https://github.com/terraform-linters/tflint/releases",
+    "Initialize plugins: tflint --init",
+    "Verify: tflint --version",
+    "supercli plugins install ./plugins/tflint --on-conflict replace --json"
+  ],
+  "note": "TFLint supports deep lint rules for major cloud providers via plugins. Run tflint --init to install configured plugins. Source: https://github.com/terraform-linters/tflint (5.7k+ stars). Written in Go."
+}

--- a/plugins/tflint/meta.json
+++ b/plugins/tflint/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "A pluggable Terraform linter for detecting errors, warnings, and enforcing best practices. Supports JSON, SARIF, JUnit, and Checkstyle output formats. Complements existing Terraform tooling with deep lint rules for AWS, Azure, and GCP providers.",
+  "tags": ["tflint", "terraform", "lint", "iac", "infrastructure", "go", "static-analysis", "devops", "hcl"],
+  "has_learn": false
+}

--- a/plugins/tflint/plugin.json
+++ b/plugins/tflint/plugin.json
@@ -1,0 +1,170 @@
+{
+  "name": "tflint",
+  "version": "0.1.0",
+  "description": "A pluggable Terraform linter for detecting errors, warnings, and enforcing best practices with JSON output",
+  "source": "https://github.com/terraform-linters/tflint",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "tflint"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "tflint",
+    "binary": "tflint",
+    "check": "which tflint",
+    "install_steps": [
+      "brew install tflint",
+      "Or: curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash",
+      "Or download from https://github.com/terraform-linters/tflint/releases",
+      "Verify: tflint --version",
+      "supercli plugins install ./plugins/tflint --on-conflict replace --json"
+    ],
+    "note": "Available via Homebrew, direct binary download, and package managers. Source: https://github.com/terraform-linters/tflint (5.7k+ stars). Written in Go."
+  },
+  "commands": [
+    {
+      "namespace": "tflint",
+      "resource": "lint",
+      "action": "run",
+      "description": "Lint Terraform files in a directory",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "tflint",
+        "missingDependencyHelp": "Install tflint: brew install tflint",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "dir",
+          "type": "string",
+          "required": false,
+          "description": "Directory to lint (default: current directory)"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "required": false,
+          "description": "Output format: default, json, checkstyle, junit, sarif"
+        },
+        {
+          "name": "config",
+          "type": "string",
+          "required": false,
+          "description": "Config file path"
+        },
+        {
+          "name": "chdir",
+          "type": "string",
+          "required": false,
+          "description": "Switch to a different working directory"
+        },
+        {
+          "name": "recursive",
+          "type": "boolean",
+          "required": false,
+          "description": "Lint subdirectories recursively"
+        },
+        {
+          "name": "filter",
+          "type": "string",
+          "required": false,
+          "description": "File filter pattern"
+        },
+        {
+          "name": "ignore-module",
+          "type": "string",
+          "required": false,
+          "description": "Ignore module sources"
+        },
+        {
+          "name": "minimum-failure-severity",
+          "type": "string",
+          "required": false,
+          "description": "Minimum severity to fail: error, warning, notice"
+        },
+        {
+          "name": "action",
+          "type": "boolean",
+          "required": false,
+          "description": "Enable actions (automatic fixes)"
+        },
+        {
+          "name": "force",
+          "type": "boolean",
+          "required": false,
+          "description": "Return zero exit status even if issues found"
+        }
+      ]
+    },
+    {
+      "namespace": "tflint",
+      "resource": "plugin",
+      "action": "list",
+      "description": "List installed plugins",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "tflint",
+        "baseArgs": ["--plugin"],
+        "missingDependencyHelp": "Install tflint: brew install tflint",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "format",
+          "type": "string",
+          "required": false,
+          "description": "Output format: default, json"
+        }
+      ]
+    },
+    {
+      "namespace": "tflint",
+      "resource": "init",
+      "action": "run",
+      "description": "Initialize tflint and install plugins",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "tflint",
+        "baseArgs": ["--init"],
+        "missingDependencyHelp": "Install tflint: brew install tflint",
+        "passthrough": true
+      },
+      "args": [
+        {
+          "name": "config",
+          "type": "string",
+          "required": false,
+          "description": "Config file path"
+        }
+      ]
+    },
+    {
+      "namespace": "tflint",
+      "resource": "self",
+      "action": "version",
+      "description": "Print tflint version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "tflint",
+        "missingDependencyHelp": "Install tflint: brew install tflint",
+        "baseArgs": ["--version"]
+      },
+      "args": []
+    },
+    {
+      "namespace": "tflint",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to tflint CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "tflint",
+        "missingDependencyHelp": "Install tflint: brew install tflint",
+        "cwd": "invoke_cwd",
+        "passthrough": true
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Consume from /root/candidates.json to create bundled plugins for supercli.

SESSION TARGET: Create 4 new bundled plugins per session.

## How to consume candidates
1. Read /root/candidates.json (owned agent:agent, root can still read)
2. For each candidate, check if plugins/<name>/ already exists in the supercli repo
3. Pick 4 candidates whose plugin dirs do NOT exist yet
4. Create the plugins

## Plugin creation rules (CRITICAL)
- Create files ONLY inside plugins/<name>/ for each plugin
- NEVER edit plugins/plugins.json or cli/plugin-install-guidance.js — that is legacy, causes merge conflicts
- Required per plugin: plugin.json (manifest with commands), meta.json (description + tags + has_learn: false unless you create a skills/quickstart/SKILL.md)
- Optional: install-guidance.json (if the CLI tool needs specific install steps beyond "pip install" or "go install")
- Validate all JSON files are parseable
- Commit each plugin separately with conventional commit message: "feat(plugins): add <name> - <description>"
- Push. auto-merge is ON — your PR merges immediately, so make it correct.

## Quality gates per plugin
- plugin.json must have correct command definitions (check the upstream CLI with --help)
- meta.json tags should include language, category, and functionality keywords
- If the tool needs special setup (config files, API keys, extra deps), add install-guidance.json
- Skip candidates where the upstream CLI is interactive-only or requires a TTY

## Progress tracking (sc mem)
Use sc mem (agentmemory-cli) to save progress after each session:
  sc agentmemory-cli memory save --text "Created plugins: name1, name2, name3, name4" --project supercli-candidates --json
This allows future sessions to check what was done.

Do NOT exceed 4 plugins per session. Quality over speed.

**Branch:** `am/am-0e131c-tfw220`

```
plugins/catalog.json                   |  20 +-
 plugins/doit/install-guidance.json     |  11 ++
 plugins/doit/meta.json                 |   5 +
 plugins/doit/plugin.json               | 297 +++++++++++++++++++++++++++++
 plugins/httpstat/install-guidance.json |  12 ++
 plugins/httpstat/meta.json             |   5 +
 plugins/httpstat/plugin.json           |  90 +++++++++
 plugins/shiori/install-guidance.json   |  12 ++
 plugins/shiori/meta.json               |   5 +
 plugins/shiori/plugin.json             | 335 +++++++++++++++++++++++++++++++++
 plugins/tflint/install-guidance.json   |  14 ++
 plugins/tflint/meta.json               |   5 +
 plugins/tflint/plugin.json             | 170 +++++++++++++++++
 13 files changed, 979 insertions(+), 2 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new plugins: doit for task automation, httpstat for HTTP timing analysis, shiori for bookmark management, and tflint for Terraform linting. Each includes installation guidance and integrated command support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->