### PR TITLE
fix: preflightBinary was no-op, now actually checks binary exists in PATH

### DIFF
--- a/cli/adapters/process.js
+++ b/cli/adapters/process.js
@@ -19,6 +19,11 @@ function toCliFlags(flags) {
 }
 
 function preflightBinary(binary) {
+  const { spawnSync } = require("child_process");
+  const r = spawnSync("which", [binary], { encoding: "utf-8", timeout: 5000 });
+  if (r.error || r.status !== 0) {
+    return { ok: false, reason: `Binary '${binary}' not found in PATH` };
+  }
   return { ok: true, reason: "" };
 }
 


### PR DESCRIPTION
Quick fix during gap hunt. AM teams please review.