### PR TITLE
automaintainer: Consume from /root/candidates.json to create bundled plugin…

### DIFF
--- a/plugins/autojump/install-guidance.json
+++ b/plugins/autojump/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "autojump",
+  "binary": "autojump",
+  "check": "which autojump",
+  "install_steps": [
+    "apt-get install autojump",
+    "or: brew install autojump",
+    "or: git clone https://github.com/wting/autojump.git && cd autojump && ./install.py",
+    "Verify: autojump --help"
+  ],
+  "note": "For full functionality, add 'source /usr/share/autojump/autojump.sh' to your .bashrc or .zshrc."
+}

--- a/plugins/autojump/meta.json
+++ b/plugins/autojump/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "A faster way to navigate your filesystem. Learns directory usage patterns using frecency and provides quick jump shortcuts.",
+  "tags": ["autojump", "navigation", "filesystem", "python", "productivity", "utility"],
+  "has_learn": false
+}

--- a/plugins/autojump/plugin.json
+++ b/plugins/autojump/plugin.json
@@ -1,0 +1,78 @@
+{
+  "name": "autojump",
+  "version": "0.1.0",
+  "description": "A cd command that learns - easily navigate directories from the command line using frecency",
+  "source": "https://github.com/wting/autojump",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "autojump"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "autojump",
+    "binary": "autojump",
+    "check": "which autojump",
+    "install_steps": [
+      "apt-get install autojump",
+      "or: brew install autojump",
+      "or: git clone https://github.com/wting/autojump.git && cd autojump && ./install.py",
+      "Verify: autojump --help"
+    ],
+    "note": "Requires shell integration (source /usr/share/autojump/autojump.sh in bashrc/zshrc)."
+  },
+  "commands": [
+    {
+      "namespace": "autojump",
+      "resource": "self",
+      "action": "help",
+      "description": "Show autojump help",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "autojump",
+        "baseArgs": ["--help"],
+        "missingDependencyHelp": "Install: apt install autojump"
+      },
+      "args": []
+    },
+    {
+      "namespace": "autojump",
+      "resource": "stats",
+      "action": "show",
+      "description": "Show database statistics and directory weights",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "autojump",
+        "baseArgs": ["--stat"],
+        "missingDependencyHelp": "Install: apt install autojump"
+      },
+      "args": []
+    },
+    {
+      "namespace": "autojump",
+      "resource": "db",
+      "action": "purge",
+      "description": "Remove nonexistent directories from the database",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "autojump",
+        "baseArgs": ["--purge"],
+        "missingDependencyHelp": "Install: apt install autojump"
+      },
+      "args": []
+    },
+    {
+      "namespace": "autojump",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to autojump CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "autojump",
+        "passthrough": true,
+        "missingDependencyHelp": "Install: apt install autojump"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bcal/install-guidance.json
+++ b/plugins/bcal/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "bcal",
+  "binary": "bcal",
+  "check": "which bcal",
+  "install_steps": [
+    "apt-get install bcal",
+    "or: brew install bcal",
+    "or: sudo make strip install (from source at https://github.com/jarun/bcal)",
+    "Verify: bcal --help"
+  ],
+  "note": "Storage calculator written in C. Also available as a snap package: snap install bcal."
+}

--- a/plugins/bcal/meta.json
+++ b/plugins/bcal/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Byte CALculator for storage conversions, SI/IEC unit calculation, hex/dec/bin conversion, and CHS/LBA address computation. Non-interactive CLI with expression evaluation.",
+  "tags": ["bcal", "calculator", "storage", "conversion", "c", "math", "utility"],
+  "has_learn": false
+}

--- a/plugins/bcal/plugin.json
+++ b/plugins/bcal/plugin.json
@@ -1,0 +1,94 @@
+{
+  "name": "bcal",
+  "version": "0.1.0",
+  "description": "Byte CALculator for storage conversions, calculations, and HDD/SSD capacity planning",
+  "source": "https://github.com/jarun/bcal",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bcal"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bcal",
+    "binary": "bcal",
+    "check": "which bcal",
+    "install_steps": [
+      "apt-get install bcal",
+      "or: brew install bcal",
+      "or: sudo make strip install (from source)",
+      "Verify: bcal --help"
+    ],
+    "note": "Storage and general-purpose calculator. Minimal dependencies (libc + readline)."
+  },
+  "commands": [
+    {
+      "namespace": "bcal",
+      "resource": "self",
+      "action": "version",
+      "description": "Print bcal version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bcal",
+        "baseArgs": ["--help"],
+        "missingDependencyHelp": "Install: apt install bcal"
+      },
+      "args": []
+    },
+    {
+      "namespace": "bcal",
+      "resource": "calc",
+      "action": "evaluate",
+      "description": "Evaluate a storage expression (e.g. '(5kb+2mb)/3')",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bcal",
+        "baseArgs": [],
+        "missingDependencyHelp": "Install: apt install bcal"
+      },
+      "args": [
+        {
+          "name": "expression",
+          "type": "string",
+          "description": "Storage expression to evaluate (e.g. '5kb+2mb/3' or N unit)",
+          "positional": true,
+          "required": true
+        }
+      ]
+    },
+    {
+      "namespace": "bcal",
+      "resource": "convert",
+      "action": "show",
+      "description": "Show a number in binary, decimal, and hex representations",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bcal",
+        "baseArgs": ["-c"],
+        "missingDependencyHelp": "Install: apt install bcal"
+      },
+      "args": [
+        {
+          "name": "number",
+          "type": "number",
+          "description": "Positive integer to show in binary, decimal, hex",
+          "positional": true,
+          "required": true
+        }
+      ]
+    },
+    {
+      "namespace": "bcal",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to bcal CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bcal",
+        "passthrough": true,
+        "missingDependencyHelp": "Install: apt install bcal"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/doctoc/install-guidance.json
+++ b/plugins/doctoc/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "doctoc",
+  "binary": "doctoc",
+  "check": "which doctoc",
+  "install_steps": [
+    "npm install -g doctoc",
+    "Verify: doctoc --version"
+  ],
+  "note": "Generates and updates table of contents in markdown files. Supports GitHub, GitLab, Bitbucket modes. Has dry-run mode for CI use."
+}

--- a/plugins/doctoc/meta.json
+++ b/plugins/doctoc/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Generates table of contents for markdown files. Supports GitHub, GitLab, Bitbucket, and custom heading levels. Non-interactive with dry-run mode for CI integration.",
+  "tags": ["doctoc", "markdown", "toc", "table-of-contents", "node", "documentation", "utility"],
+  "has_learn": false
+}

--- a/plugins/doctoc/plugin.json
+++ b/plugins/doctoc/plugin.json
@@ -1,0 +1,106 @@
+{
+  "name": "doctoc",
+  "version": "0.1.0",
+  "description": "Generates table of contents for markdown files with heading support",
+  "source": "https://github.com/thlorenz/doctoc",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "doctoc"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "doctoc",
+    "binary": "doctoc",
+    "check": "which doctoc",
+    "install_steps": [
+      "npm install -g doctoc",
+      "Verify: doctoc --help"
+    ],
+    "note": "Generates and updates table of contents in markdown files. Supports GitHub, GitLab, Bitbucket, and other platforms."
+  },
+  "commands": [
+    {
+      "namespace": "doctoc",
+      "resource": "self",
+      "action": "version",
+      "description": "Print doctoc version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "doctoc",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install: npm install -g doctoc"
+      },
+      "args": []
+    },
+    {
+      "namespace": "doctoc",
+      "resource": "toc",
+      "action": "generate",
+      "description": "Generate table of contents for markdown files",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "doctoc",
+        "baseArgs": [],
+        "missingDependencyHelp": "Install: npm install -g doctoc"
+      },
+      "args": [
+        {
+          "name": "target",
+          "type": "string",
+          "description": "File or directory to generate TOC for",
+          "positional": true,
+          "required": true
+        },
+        {
+          "name": "gitlab",
+          "flag": "--gitlab",
+          "type": "boolean",
+          "description": "Use GitLab-compatible TOC links",
+          "required": false
+        },
+        {
+          "name": "bitbucket",
+          "flag": "--bitbucket",
+          "type": "boolean",
+          "description": "Use Bitbucket-compatible TOC links",
+          "required": false
+        },
+        {
+          "name": "maxlevel",
+          "flag": "--maxlevel",
+          "type": "number",
+          "description": "Maximum heading level to include in TOC",
+          "required": false
+        },
+        {
+          "name": "notitle",
+          "flag": "--notitle",
+          "type": "boolean",
+          "description": "Do not include the TOC title",
+          "required": false
+        },
+        {
+          "name": "dryrun",
+          "flag": "--dryrun",
+          "type": "boolean",
+          "description": "Dry run without writing changes (exit 1 if files would change)",
+          "required": false
+        }
+      ]
+    },
+    {
+      "namespace": "doctoc",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to doctoc CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "doctoc",
+        "passthrough": true,
+        "missingDependencyHelp": "Install: npm install -g doctoc"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/is-up-cli/install-guidance.json
+++ b/plugins/is-up-cli/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "is-up-cli",
+  "binary": "is-up",
+  "check": "which is-up",
+  "install_steps": [
+    "npm install -g is-up-cli",
+    "Verify: is-up --help"
+  ],
+  "note": "Exits with code 0 if up and 2 if down."
+}

--- a/plugins/is-up-cli/meta.json
+++ b/plugins/is-up-cli/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Check whether a website is up or down using the isitup.org API",
+  "tags": ["is-up-cli", "domain", "uptime", "monitoring", "network", "node", "health-check"],
+  "has_learn": false
+}

--- a/plugins/is-up-cli/plugin.json
+++ b/plugins/is-up-cli/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "is-up-cli",
+  "version": "0.1.0",
+  "description": "Check whether a website is up or down via the isitup.org API",
+  "source": "https://github.com/sindresorhus/is-up-cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "is-up"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "is-up-cli",
+    "binary": "is-up",
+    "check": "which is-up",
+    "install_steps": [
+      "npm install -g is-up-cli",
+      "Verify: is-up --help"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "is-up",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to is-up",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "is-up",
+        "passthrough": true,
+        "missingDependencyHelp": "Install is-up-cli: npm install -g is-up-cli"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/oh-my-posh/install-guidance.json
+++ b/plugins/oh-my-posh/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "oh-my-posh",
+  "binary": "oh-my-posh",
+  "check": "which oh-my-posh",
+  "install_steps": [
+    "curl -s https://ohmyposh.dev/install.sh | bash -s",
+    "Verify: oh-my-posh version",
+    "Install a Nerd Font for full icon support: https://www.nerdfonts.com/"
+  ],
+  "note": "Prompt theme engine. Requires a Nerd Font for full icon support. Supports zsh, bash, fish, and other shells."
+}

--- a/plugins/oh-my-posh/meta.json
+++ b/plugins/oh-my-posh/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Prompt theme engine for any shell with customizable segments and theming. Renders rich prompts with Git status, language versions, and system info.",
+  "tags": ["oh-my-posh", "prompt", "shell", "terminal", "go", "theme", "customization"],
+  "has_learn": false
+}

--- a/plugins/oh-my-posh/plugin.json
+++ b/plugins/oh-my-posh/plugin.json
@@ -1,0 +1,132 @@
+{
+  "name": "oh-my-posh",
+  "version": "0.1.0",
+  "description": "Prompt theme engine for any shell with customizable segments and theming",
+  "source": "https://github.com/JanDeDobbeleer/oh-my-posh",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "oh-my-posh"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "oh-my-posh",
+    "binary": "oh-my-posh",
+    "check": "which oh-my-posh",
+    "install_steps": [
+      "curl -s https://ohmyposh.dev/install.sh | bash -s",
+      "Verify: oh-my-posh version"
+    ],
+    "note": "Prompt theme engine. Requires a Nerd Font for full icon support."
+  },
+  "commands": [
+    {
+      "namespace": "oh-my-posh",
+      "resource": "self",
+      "action": "version",
+      "description": "Print oh-my-posh version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "oh-my-posh",
+        "baseArgs": ["version"],
+        "missingDependencyHelp": "Install: curl -s https://ohmyposh.dev/install.sh | bash -s"
+      },
+      "args": []
+    },
+    {
+      "namespace": "oh-my-posh",
+      "resource": "prompt",
+      "action": "print",
+      "description": "Print the prompt to stdout (evaluate prompt rendering)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "oh-my-posh",
+        "baseArgs": ["print"],
+        "missingDependencyHelp": "Install: curl -s https://ohmyposh.dev/install.sh | bash -s"
+      },
+      "args": [
+        {
+          "name": "config",
+          "flag": "--config",
+          "type": "string",
+          "description": "Path to the config file to use",
+          "required": true
+        },
+        {
+          "name": "shell",
+          "flag": "--shell",
+          "type": "string",
+          "description": "Shell to use (e.g. zsh, bash, fish)",
+          "required": false
+        }
+      ]
+    },
+    {
+      "namespace": "oh-my-posh",
+      "resource": "init",
+      "action": "generate",
+      "description": "Generate shell init script for prompt rendering",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "oh-my-posh",
+        "baseArgs": ["init"],
+        "missingDependencyHelp": "Install: curl -s https://ohmyposh.dev/install.sh | bash -s"
+      },
+      "args": [
+        {
+          "name": "shell",
+          "flag": "--shell",
+          "type": "string",
+          "description": "Shell to initialize (e.g. zsh, bash, fish)",
+          "positional": true
+        },
+        {
+          "name": "config",
+          "flag": "--config",
+          "type": "string",
+          "description": "Path to the config file",
+          "required": false
+        }
+      ]
+    },
+    {
+      "namespace": "oh-my-posh",
+      "resource": "config",
+      "action": "export",
+      "description": "Export the current configuration as JSON",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "oh-my-posh",
+        "baseArgs": ["config", "export"],
+        "missingDependencyHelp": "Install: curl -s https://ohmyposh.dev/install.sh | bash -s"
+      },
+      "args": []
+    },
+    {
+      "namespace": "oh-my-posh",
+      "resource": "get",
+      "action": "shell",
+      "description": "Get the current shell name",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "oh-my-posh",
+        "baseArgs": ["get", "shell"],
+        "missingDependencyHelp": "Install: curl -s https://ohmyposh.dev/install.sh | bash -s"
+      },
+      "args": []
+    },
+    {
+      "namespace": "oh-my-posh",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to oh-my-posh CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "oh-my-posh",
+        "passthrough": true,
+        "missingDependencyHelp": "Install: curl -s https://ohmyposh.dev/install.sh | bash -s"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/snyk/install-guidance.json
+++ b/plugins/snyk/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "snyk",
+  "binary": "snyk",
+  "check": "which snyk",
+  "install_steps": [
+    "npm install -g snyk",
+    "or: curl -sL https://static.snyk.io/cli/latest/snyk-linux -o /usr/local/bin/snyk && chmod +x /usr/local/bin/snyk",
+    "or: brew install snyk",
+    "Authenticate: snyk auth",
+    "Verify: snyk --version"
+  ],
+  "note": "Requires authentication with a Snyk account. Run 'snyk auth' to get started. Supports --json flag for structured output."
+}

--- a/plugins/snyk/meta.json
+++ b/plugins/snyk/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Snyk CLI scans and monitors your projects for security vulnerabilities in dependencies, containers, and infrastructure as code. Supports JSON output for agent-driven security auditing.",
+  "tags": ["snyk", "security", "vulnerability", "scanning", "go", "devsecops", "audit"],
+  "has_learn": false
+}

--- a/plugins/snyk/plugin.json
+++ b/plugins/snyk/plugin.json
@@ -1,0 +1,149 @@
+{
+  "name": "snyk",
+  "version": "0.1.0",
+  "description": "Snyk CLI scans and monitors projects for security vulnerabilities in dependencies",
+  "source": "https://github.com/snyk/cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "snyk"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "snyk",
+    "binary": "snyk",
+    "check": "which snyk",
+    "install_steps": [
+      "npm install -g snyk",
+      "or: curl -sL https://static.snyk.io/cli/latest/snyk-linux -o /usr/local/bin/snyk && chmod +x /usr/local/bin/snyk",
+      "Authenticate: snyk auth"
+    ],
+    "note": "Requires authentication. Run 'snyk auth' to authenticate with your Snyk account."
+  },
+  "commands": [
+    {
+      "namespace": "snyk",
+      "resource": "self",
+      "action": "version",
+      "description": "Print snyk version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "snyk",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install: npm install -g snyk"
+      },
+      "args": []
+    },
+    {
+      "namespace": "snyk",
+      "resource": "project",
+      "action": "test",
+      "description": "Test a project for open-source vulnerabilities and license issues",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "snyk",
+        "baseArgs": ["test"],
+        "missingDependencyHelp": "Install: npm install -g snyk"
+      },
+      "args": [
+        {
+          "name": "json",
+          "flag": "--json",
+          "type": "boolean",
+          "description": "Output results as JSON",
+          "required": false
+        },
+        {
+          "name": "all-projects",
+          "flag": "--all-projects",
+          "type": "boolean",
+          "description": "Auto-detect all projects in the working directory",
+          "required": false
+        },
+        {
+          "name": "severity-threshold",
+          "flag": "--severity-threshold",
+          "type": "string",
+          "description": "Report only vulnerabilities at the specified level or higher (low|medium|high|critical)",
+          "required": false
+        },
+        {
+          "name": "file",
+          "flag": "--file",
+          "type": "string",
+          "description": "Specify a package file",
+          "required": false
+        },
+        {
+          "name": "org",
+          "flag": "--org",
+          "type": "string",
+          "description": "Specify the Snyk organization ID",
+          "required": false
+        }
+      ]
+    },
+    {
+      "namespace": "snyk",
+      "resource": "project",
+      "action": "monitor",
+      "description": "Snapshot and continuously monitor a project for vulnerabilities",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "snyk",
+        "baseArgs": ["monitor"],
+        "missingDependencyHelp": "Install: npm install -g snyk"
+      },
+      "args": [
+        {
+          "name": "all-projects",
+          "flag": "--all-projects",
+          "type": "boolean",
+          "description": "Auto-detect all projects",
+          "required": false
+        },
+        {
+          "name": "org",
+          "flag": "--org",
+          "type": "string",
+          "description": "Specify the Snyk organization ID",
+          "required": false
+        }
+      ]
+    },
+    {
+      "namespace": "snyk",
+      "resource": "auth",
+      "action": "authenticate",
+      "description": "Authenticate with Snyk account",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "snyk",
+        "baseArgs": ["auth"],
+        "missingDependencyHelp": "Install: npm install -g snyk"
+      },
+      "args": [
+        {
+          "name": "token",
+          "flag": "--auth-type",
+          "type": "string",
+          "description": "Authentication type (token, oauth)",
+          "required": false
+        }
+      ]
+    },
+    {
+      "namespace": "snyk",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to snyk CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "snyk",
+        "passthrough": true,
+        "missingDependencyHelp": "Install: npm install -g snyk"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/tfenv/install-guidance.json
+++ b/plugins/tfenv/install-guidance.json
@@ -1,0 +1,14 @@
+{
+  "plugin": "tfenv",
+  "binary": "tfenv",
+  "check": "which tfenv",
+  "install_steps": [
+    "brew install tfenv",
+    "# Or manually:",
+    "# git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv",
+    "# echo 'export PATH=\"$HOME/.tfenv/bin:$PATH\"' >> ~/.bashrc",
+    "# source ~/.bashrc",
+    "Verify: tfenv --version"
+  ],
+  "note": "After manual install, ensure ~/.tfenv/bin is in your PATH. Use 'tfenv list-remote' to see available versions."
+}

--- a/plugins/tfenv/meta.json
+++ b/plugins/tfenv/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Terraform version manager — install, switch, and manage multiple Terraform versions via shell-based CLI",
+  "tags": ["tfenv", "terraform", "version-manager", "infrastructure", "devops", "iac", "shell"],
+  "has_learn": false
+}

--- a/plugins/tfenv/plugin.json
+++ b/plugins/tfenv/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "tfenv",
+  "version": "0.1.0",
+  "description": "Terraform version manager for installing, switching, and managing multiple Terraform versions",
+  "source": "https://github.com/tfutils/tfenv",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "tfenv"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "tfenv",
+    "binary": "tfenv",
+    "check": "which tfenv",
+    "install_steps": [
+      "brew install tfenv",
+      "# Or manually:",
+      "# git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv",
+      "# echo 'export PATH=\"$HOME/.tfenv/bin:$PATH\"' >> ~/.bashrc",
+      "Verify: tfenv --version"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "tfenv",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to tfenv",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "tfenv",
+        "passthrough": true,
+        "missingDependencyHelp": "Install tfenv: brew install tfenv"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/webhook/install-guidance.json
+++ b/plugins/webhook/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "webhook",
+  "binary": "webhook",
+  "check": "which webhook",
+  "install_steps": [
+    "snap install webhook",
+    "or: apt-get install webhook",
+    "or: go install github.com/adnanh/webhook@latest",
+    "or: download from https://github.com/adnanh/webhook/releases",
+    "Verify: webhook --help"
+  ],
+  "note": "Requires a hooks.json configuration file. See https://github.com/adnanh/webhook for examples."
+}

--- a/plugins/webhook/meta.json
+++ b/plugins/webhook/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "A lightweight configurable tool written in Go that creates HTTP endpoints (hooks) to execute configured shell commands. Supports CORS, HTTPS, hot-reload, and trigger rules.",
+  "tags": ["webhook", "hooks", "http", "server", "go", "automation", "ci-cd"],
+  "has_learn": false
+}

--- a/plugins/webhook/plugin.json
+++ b/plugins/webhook/plugin.json
@@ -1,0 +1,122 @@
+{
+  "name": "webhook",
+  "version": "0.1.0",
+  "description": "A lightweight incoming webhook server to run shell commands based on HTTP requests",
+  "source": "https://github.com/adnanh/webhook",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "webhook"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "webhook",
+    "binary": "webhook",
+    "check": "which webhook",
+    "install_steps": [
+      "snap install webhook",
+      "or: apt-get install webhook",
+      "or: go install github.com/adnanh/webhook@latest",
+      "Verify: webhook --help"
+    ],
+    "note": "Lightweight webhook server. Configure hooks via hooks.json or hooks.yaml files."
+  },
+  "commands": [
+    {
+      "namespace": "webhook",
+      "resource": "self",
+      "action": "help",
+      "description": "Show webhook help",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "webhook",
+        "baseArgs": ["--help"],
+        "missingDependencyHelp": "Install: snap install webhook"
+      },
+      "args": []
+    },
+    {
+      "namespace": "webhook",
+      "resource": "server",
+      "action": "start",
+      "description": "Start the webhook server with hooks configuration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "webhook",
+        "baseArgs": [],
+        "missingDependencyHelp": "Install: snap install webhook"
+      },
+      "args": [
+        {
+          "name": "hooks",
+          "flag": "-hooks",
+          "type": "string",
+          "description": "Path to hooks configuration file (JSON or YAML)",
+          "required": true
+        },
+        {
+          "name": "port",
+          "flag": "-port",
+          "type": "number",
+          "description": "Port to listen on (default: 9000)",
+          "required": false
+        },
+        {
+          "name": "ip",
+          "flag": "-ip",
+          "type": "string",
+          "description": "IP address to listen on (default: 0.0.0.0)",
+          "required": false
+        },
+        {
+          "name": "verbose",
+          "flag": "-verbose",
+          "type": "boolean",
+          "description": "Enable verbose output",
+          "required": false
+        },
+        {
+          "name": "secure",
+          "flag": "-secure",
+          "type": "boolean",
+          "description": "Use HTTPS",
+          "required": false
+        },
+        {
+          "name": "cert",
+          "flag": "-cert",
+          "type": "string",
+          "description": "Path to SSL certificate file",
+          "required": false
+        },
+        {
+          "name": "key",
+          "flag": "-key",
+          "type": "string",
+          "description": "Path to SSL private key file",
+          "required": false
+        },
+        {
+          "name": "hotreload",
+          "flag": "-hotreload",
+          "type": "boolean",
+          "description": "Hot-reload hooks on file changes",
+          "required": false
+        }
+      ]
+    },
+    {
+      "namespace": "webhook",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to webhook CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "webhook",
+        "passthrough": true,
+        "missingDependencyHelp": "Install: snap install webhook"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Consume from /root/candidates.json to create bundled plugins for supercli.

SESSION TARGET: Create 4 new bundled plugins per session.

## How to consume candidates
1. Read /root/candidates.json (owned agent:agent, root can still read)
2. For each candidate, check if plugins/<name>/ already exists in the supercli repo
3. Pick 4 candidates whose plugin dirs do NOT exist yet
4. Create the plugins

## Plugin creation rules (CRITICAL)
- Create files ONLY inside plugins/<name>/ for each plugin
- NEVER edit plugins/plugins.json or cli/plugin-install-guidance.js — that is legacy, causes merge conflicts
- Required per plugin: plugin.json (manifest with commands), meta.json (description + tags + has_learn: false unless you create a skills/quickstart/SKILL.md)
- Optional: install-guidance.json (if the CLI tool needs specific install steps beyond "pip install" or "go install")
- Validate all JSON files are parseable
- Commit each plugin separately with conventional commit message: "feat(plugins): add <name> - <description>"
- Push. auto-merge is ON — your PR merges immediately, so make it correct.

## Quality gates per plugin
- plugin.json must have correct command definitions (check the upstream CLI with --help)
- meta.json tags should include language, category, and functionality keywords
- If the tool needs special setup (config files, API keys, extra deps), add install-guidance.json
- Skip candidates where the upstream CLI is interactive-only or requires a TTY

## Progress tracking (sc mem)
Use sc mem (agentmemory-cli) to save progress after each session:
  sc agentmemory-cli memory save --text "Created plugins: name1, name2, name3, name4" --project supercli-candidates --json
This allows future sessions to check what was done.

Do NOT exceed 4 plugins per session. Quality over speed.

**Branch:** `am/am-0e131c-tfw7e0`

```
plugins/autojump/install-guidance.json   |  12 +++
 plugins/autojump/meta.json               |   5 ++
 plugins/autojump/plugin.json             |  78 ++++++++++++++++
 plugins/bcal/install-guidance.json       |  12 +++
 plugins/bcal/meta.json                   |   5 ++
 plugins/bcal/plugin.json                 |  94 +++++++++++++++++++
 plugins/doctoc/install-guidance.json     |  10 +++
 plugins/doctoc/meta.json                 |   5 ++
 plugins/doctoc/plugin.json               | 106 ++++++++++++++++++++++
 plugins/is-up-cli/install-guidance.json  |  10 +++
 plugins/is-up-cli/meta.json              |   5 ++
 plugins/is-up-cli/plugin.json            |  36 ++++++++
 plugins/oh-my-posh/install-guidance.json |  11 +++
 plugins/oh-my-posh/meta.json             |   5 ++
 plugins/oh-my-posh/plugin.json           | 132 +++++++++++++++++++++++++++
 plugins/snyk/install-guidance.json       |  13 +++
 plugins/snyk/meta.json                   |   5 ++
 plugins/snyk/plugin.json                 | 149 +++++++++++++++++++++++++++++++
 plugins/tfenv/install-guidance.json      |  14 +++
 plugins/tfenv/meta.json                  |   5 ++
 plugins/tfenv/plugin.json                |  39 ++++++++
 plugins/webhook/install-guidance.json    |  13 +++
 plugins/webhook/meta.json                |   5 ++
 plugins/webhook/plugin.json              | 122 +++++++++++++++++++++++++
 24 files changed, 891 insertions(+)
```
