### PR TITLE
feat: add 19 bundled plugins (batch 001/31)

### DIFF
--- a/plugins/advcp/install-guidance.json
+++ b/plugins/advcp/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "advcp",
+  "binary": "advcp",
+  "check": "which advcp",
+  "install_steps": [
+    "# Install advcp",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/advcp-linux-amd64 -o /usr/local/bin/advcp",
+    "chmod +x /usr/local/bin/advcp",
+    "# Or via package manager, see github.com/jarun/advcpmv"
+  ]
+}

--- a/plugins/advcp/meta.json
+++ b/plugins/advcp/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "advcp \u2014 File copy with progress bar",
+  "tags": [
+    "utility",
+    "file"
+  ],
+  "has_learn": false
+}

--- a/plugins/advcp/plugin.json
+++ b/plugins/advcp/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "advcp",
+  "version": "1.0.0",
+  "description": "advcp \u2014 File copy with progress bar",
+  "source": "github.com/jarun/advcpmv",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "advcp"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "advcp",
+    "binary": "advcp",
+    "check": "which advcp",
+    "install_steps": [
+      "# Install advcp:",
+      "# apt: sudo apt-get install advcp",
+      "# brew: brew install advcp",
+      "# cargo: cargo install advcp",
+      "# npm: npm install -g advcp",
+      "# pip: pip install advcp",
+      "# or download from github.com/jarun/advcpmv"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "advcp",
+      "resource": "advcp",
+      "action": "run",
+      "description": "Run advcp",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "advcp",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install advcp from github.com/jarun/advcpmv"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/aha/install-guidance.json
+++ b/plugins/aha/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "aha",
+  "binary": "aha",
+  "check": "which aha",
+  "install_steps": [
+    "# Install aha",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/aha-linux-amd64 -o /usr/local/bin/aha",
+    "chmod +x /usr/local/bin/aha",
+    "# Or via package manager, see github.com/theZiz/aha"
+  ]
+}

--- a/plugins/aha/meta.json
+++ b/plugins/aha/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "aha \u2014 ANSI to HTML converter",
+  "tags": [
+    "utility",
+    "terminal",
+    "html"
+  ],
+  "has_learn": false
+}

--- a/plugins/aha/plugin.json
+++ b/plugins/aha/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "aha",
+  "version": "1.0.0",
+  "description": "aha \u2014 ANSI to HTML converter",
+  "source": "github.com/theZiz/aha",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "aha"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "aha",
+    "binary": "aha",
+    "check": "which aha",
+    "install_steps": [
+      "# Install aha:",
+      "# apt: sudo apt-get install aha",
+      "# brew: brew install aha",
+      "# cargo: cargo install aha",
+      "# npm: npm install -g aha",
+      "# pip: pip install aha",
+      "# or download from github.com/theZiz/aha"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "aha",
+      "resource": "aha",
+      "action": "run",
+      "description": "Run aha",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "aha",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install aha from github.com/theZiz/aha"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ansiweather/install-guidance.json
+++ b/plugins/ansiweather/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ansiweather",
+  "binary": "ansiweather",
+  "check": "which ansiweather",
+  "install_steps": [
+    "# Install ansiweather",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ansiweather-linux-amd64 -o /usr/local/bin/ansiweather",
+    "chmod +x /usr/local/bin/ansiweather",
+    "# Or via package manager, see github.com/fcambus/ansiweather"
+  ]
+}

--- a/plugins/ansiweather/meta.json
+++ b/plugins/ansiweather/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ansiweather \u2014 Weather report in terminal",
+  "tags": [
+    "utility",
+    "weather"
+  ],
+  "has_learn": false
+}

--- a/plugins/ansiweather/plugin.json
+++ b/plugins/ansiweather/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ansiweather",
+  "version": "1.0.0",
+  "description": "ansiweather \u2014 Weather report in terminal",
+  "source": "github.com/fcambus/ansiweather",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ansiweather"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ansiweather",
+    "binary": "ansiweather",
+    "check": "which ansiweather",
+    "install_steps": [
+      "# Install ansiweather:",
+      "# apt: sudo apt-get install ansiweather",
+      "# brew: brew install ansiweather",
+      "# cargo: cargo install ansiweather",
+      "# npm: npm install -g ansiweather",
+      "# pip: pip install ansiweather",
+      "# or download from github.com/fcambus/ansiweather"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ansiweather",
+      "resource": "ansiweather",
+      "action": "run",
+      "description": "Run ansiweather",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ansiweather",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ansiweather from github.com/fcambus/ansiweather"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/archey4/install-guidance.json
+++ b/plugins/archey4/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "archey4",
+  "binary": "archey4",
+  "check": "which archey4",
+  "install_steps": [
+    "# Install archey4",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/archey4-linux-amd64 -o /usr/local/bin/archey4",
+    "chmod +x /usr/local/bin/archey4",
+    "# Or via package manager, see github.com/HorlogeSkynet/archey4"
+  ]
+}

--- a/plugins/archey4/meta.json
+++ b/plugins/archey4/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "archey4 \u2014 System information display",
+  "tags": [
+    "utility",
+    "system",
+    "info"
+  ],
+  "has_learn": false
+}

--- a/plugins/archey4/plugin.json
+++ b/plugins/archey4/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "archey4",
+  "version": "1.0.0",
+  "description": "archey4 \u2014 System information display",
+  "source": "github.com/HorlogeSkynet/archey4",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "archey4"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "archey4",
+    "binary": "archey4",
+    "check": "which archey4",
+    "install_steps": [
+      "# Install archey4:",
+      "# apt: sudo apt-get install archey4",
+      "# brew: brew install archey4",
+      "# cargo: cargo install archey4",
+      "# npm: npm install -g archey4",
+      "# pip: pip install archey4",
+      "# or download from github.com/HorlogeSkynet/archey4"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "archey4",
+      "resource": "archey4",
+      "action": "run",
+      "description": "Run archey4",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "archey4",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install archey4 from github.com/HorlogeSkynet/archey4"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/as-tree/install-guidance.json
+++ b/plugins/as-tree/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "as-tree",
+  "binary": "as-tree",
+  "check": "which as-tree",
+  "install_steps": [
+    "# Install as-tree",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/as-tree-linux-amd64 -o /usr/local/bin/as-tree",
+    "chmod +x /usr/local/bin/as-tree",
+    "# Or via package manager, see crates.io/crates/as-tree"
+  ]
+}

--- a/plugins/as-tree/meta.json
+++ b/plugins/as-tree/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "as-tree \u2014 Indented text to tree view",
+  "tags": [
+    "utility",
+    "text"
+  ],
+  "has_learn": false
+}

--- a/plugins/as-tree/plugin.json
+++ b/plugins/as-tree/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "as-tree",
+  "version": "1.0.0",
+  "description": "as-tree \u2014 Indented text to tree view",
+  "source": "crates.io/crates/as-tree",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "as-tree"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "as-tree",
+    "binary": "as-tree",
+    "check": "which as-tree",
+    "install_steps": [
+      "# Install as-tree:",
+      "# apt: sudo apt-get install as-tree",
+      "# brew: brew install as-tree",
+      "# cargo: cargo install as-tree",
+      "# npm: npm install -g as-tree",
+      "# pip: pip install as-tree",
+      "# or download from crates.io/crates/as-tree"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "as",
+      "resource": "tree",
+      "action": "run",
+      "description": "Run as-tree",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "as-tree",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install as-tree from crates.io/crates/as-tree"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ask/install-guidance.json
+++ b/plugins/ask/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "ask",
+  "binary": "ask",
+  "check": "which ask",
+  "install_steps": [
+    "# Install ask",
+    "# See github.com/knqyf263/ask",
+    "# apt: sudo apt-get install ask",
+    "# brew: brew install ask",
+    "# cargo: cargo install ask",
+    "# npm: npm install -g ask"
+  ]
+}

--- a/plugins/ask/meta.json
+++ b/plugins/ask/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ask \u2014 Interactive question prompting",
+  "tags": [
+    "utility",
+    "prompt"
+  ],
+  "has_learn": false
+}

--- a/plugins/ask/plugin.json
+++ b/plugins/ask/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ask",
+  "version": "1.0.0",
+  "description": "ask \u2014 Interactive question prompting",
+  "source": "github.com/knqyf263/ask",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ask"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ask",
+    "binary": "ask",
+    "check": "which ask",
+    "install_steps": [
+      "# Install ask",
+      "# See github.com/knqyf263/ask",
+      "# apt: sudo apt-get install ask",
+      "# brew: brew install ask",
+      "# cargo: cargo install ask",
+      "# npm: npm install -g ask",
+      "# pip: pip install ask"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ask",
+      "resource": "ask",
+      "action": "run",
+      "description": "Run ask",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ask",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ask from github.com/knqyf263/ask"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/assetfinder/install-guidance.json
+++ b/plugins/assetfinder/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "assetfinder",
+  "binary": "assetfinder",
+  "check": "which assetfinder",
+  "install_steps": [
+    "# Install assetfinder",
+    "# See github.com/tomnomnom/assetfinder",
+    "# apt: sudo apt-get install assetfinder",
+    "# brew: brew install assetfinder",
+    "# cargo: cargo install assetfinder",
+    "# npm: npm install -g assetfinder"
+  ]
+}

--- a/plugins/assetfinder/meta.json
+++ b/plugins/assetfinder/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "assetfinder \u2014 Find subdomains for a domain",
+  "tags": [
+    "security",
+    "recon"
+  ],
+  "has_learn": false
+}

--- a/plugins/assetfinder/plugin.json
+++ b/plugins/assetfinder/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "assetfinder",
+  "version": "1.0.0",
+  "description": "assetfinder \u2014 Find subdomains for a domain",
+  "source": "github.com/tomnomnom/assetfinder",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "assetfinder"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "assetfinder",
+    "binary": "assetfinder",
+    "check": "which assetfinder",
+    "install_steps": [
+      "# Install assetfinder",
+      "# See github.com/tomnomnom/assetfinder",
+      "# apt: sudo apt-get install assetfinder",
+      "# brew: brew install assetfinder",
+      "# cargo: cargo install assetfinder",
+      "# npm: npm install -g assetfinder",
+      "# pip: pip install assetfinder"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "assetfinder",
+      "resource": "assetfinder",
+      "action": "run",
+      "description": "Run assetfinder",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "assetfinder",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install assetfinder from github.com/tomnomnom/assetfinder"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/b2sum/install-guidance.json
+++ b/plugins/b2sum/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "b2sum",
+  "binary": "b2sum",
+  "check": "which b2sum",
+  "install_steps": [
+    "# Install b2sum",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/b2sum-linux-amd64 -o /usr/local/bin/b2sum",
+    "chmod +x /usr/local/bin/b2sum",
+    "# Or via package manager, see /usr/bin/b2sum"
+  ]
+}

--- a/plugins/b2sum/meta.json
+++ b/plugins/b2sum/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "b2sum \u2014 b2sum \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/b2sum/plugin.json
+++ b/plugins/b2sum/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "b2sum",
+  "version": "1.0.0",
+  "description": "b2sum \u2014 b2sum \u2014 CLI utility",
+  "source": "/usr/bin/b2sum",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "b2sum"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "b2sum",
+    "binary": "b2sum",
+    "check": "which b2sum",
+    "install_steps": [
+      "# Install b2sum:",
+      "# apt: sudo apt-get install b2sum",
+      "# brew: brew install b2sum",
+      "# cargo: cargo install b2sum",
+      "# npm: npm install -g b2sum",
+      "# pip: pip install b2sum",
+      "# or download from /usr/bin/b2sum"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "b2sum",
+      "resource": "b2sum",
+      "action": "run",
+      "description": "Run b2sum",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "b2sum",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install b2sum from /usr/bin/b2sum"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bats/install-guidance.json
+++ b/plugins/bats/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "bats",
+  "binary": "bats",
+  "check": "which bats",
+  "install_steps": [
+    "# Install bats",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/bats-linux-amd64 -o /usr/local/bin/bats",
+    "chmod +x /usr/local/bin/bats",
+    "# Or via package manager, see github.com/bats-core/bats-core"
+  ]
+}

--- a/plugins/bats/meta.json
+++ b/plugins/bats/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "bats \u2014 Bash testing framework",
+  "tags": [
+    "testing",
+    "bash"
+  ],
+  "has_learn": false
+}

--- a/plugins/bats/plugin.json
+++ b/plugins/bats/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "bats",
+  "version": "1.0.0",
+  "description": "bats \u2014 Bash testing framework",
+  "source": "github.com/bats-core/bats-core",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bats"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bats",
+    "binary": "bats",
+    "check": "which bats",
+    "install_steps": [
+      "# Install bats:",
+      "# apt: sudo apt-get install bats",
+      "# brew: brew install bats",
+      "# cargo: cargo install bats",
+      "# npm: npm install -g bats",
+      "# pip: pip install bats",
+      "# or download from github.com/bats-core/bats-core"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bats",
+      "resource": "bats",
+      "action": "run",
+      "description": "Run bats",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bats",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bats from github.com/bats-core/bats-core"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bear/install-guidance.json
+++ b/plugins/bear/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "bear",
+  "binary": "bear",
+  "check": "which bear",
+  "install_steps": [
+    "# Install bear",
+    "# See github.com/rizsotto/Bear",
+    "# apt: sudo apt-get install bear",
+    "# brew: brew install bear",
+    "# cargo: cargo install bear",
+    "# npm: npm install -g bear"
+  ]
+}

--- a/plugins/bear/meta.json
+++ b/plugins/bear/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "bear \u2014 Generate compilation database",
+  "tags": [
+    "c",
+    "build"
+  ],
+  "has_learn": false
+}

--- a/plugins/bear/plugin.json
+++ b/plugins/bear/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "bear",
+  "version": "1.0.0",
+  "description": "bear \u2014 Generate compilation database",
+  "source": "github.com/rizsotto/Bear",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bear"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bear",
+    "binary": "bear",
+    "check": "which bear",
+    "install_steps": [
+      "# Install bear",
+      "# See github.com/rizsotto/Bear",
+      "# apt: sudo apt-get install bear",
+      "# brew: brew install bear",
+      "# cargo: cargo install bear",
+      "# npm: npm install -g bear",
+      "# pip: pip install bear"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bear",
+      "resource": "bear",
+      "action": "run",
+      "description": "Run bear",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bear",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bear from github.com/rizsotto/Bear"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bfs/install-guidance.json
+++ b/plugins/bfs/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "bfs",
+  "binary": "bfs",
+  "check": "which bfs",
+  "install_steps": [
+    "# Install bfs",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/bfs-linux-amd64 -o /usr/local/bin/bfs",
+    "chmod +x /usr/local/bin/bfs",
+    "# Or via package manager, see github.com/tavianator/bfs"
+  ]
+}

--- a/plugins/bfs/meta.json
+++ b/plugins/bfs/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "bfs \u2014 Breadth-first search find",
+  "tags": [
+    "utility",
+    "search"
+  ],
+  "has_learn": false
+}

--- a/plugins/bfs/plugin.json
+++ b/plugins/bfs/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "bfs",
+  "version": "1.0.0",
+  "description": "bfs \u2014 Breadth-first search find",
+  "source": "github.com/tavianator/bfs",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bfs"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bfs",
+    "binary": "bfs",
+    "check": "which bfs",
+    "install_steps": [
+      "# Install bfs:",
+      "# apt: sudo apt-get install bfs",
+      "# brew: brew install bfs",
+      "# cargo: cargo install bfs",
+      "# npm: npm install -g bfs",
+      "# pip: pip install bfs",
+      "# or download from github.com/tavianator/bfs"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bfs",
+      "resource": "bfs",
+      "action": "run",
+      "description": "Run bfs",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bfs",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bfs from github.com/tavianator/bfs"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/binocle/install-guidance.json
+++ b/plugins/binocle/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "binocle",
+  "binary": "binocle",
+  "check": "which binocle",
+  "install_steps": [
+    "# Install binocle",
+    "# See github.com/sharkdp/binocle",
+    "# apt: sudo apt-get install binocle",
+    "# brew: brew install binocle",
+    "# cargo: cargo install binocle",
+    "# npm: npm install -g binocle"
+  ]
+}

--- a/plugins/binocle/meta.json
+++ b/plugins/binocle/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "binocle \u2014 Binary data visualization",
+  "tags": [
+    "utility",
+    "binary"
+  ],
+  "has_learn": false
+}

--- a/plugins/binocle/plugin.json
+++ b/plugins/binocle/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "binocle",
+  "version": "1.0.0",
+  "description": "binocle \u2014 Binary data visualization",
+  "source": "github.com/sharkdp/binocle",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "binocle"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "binocle",
+    "binary": "binocle",
+    "check": "which binocle",
+    "install_steps": [
+      "# Install binocle",
+      "# See github.com/sharkdp/binocle",
+      "# apt: sudo apt-get install binocle",
+      "# brew: brew install binocle",
+      "# cargo: cargo install binocle",
+      "# npm: npm install -g binocle",
+      "# pip: pip install binocle"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "binocle",
+      "resource": "binocle",
+      "action": "run",
+      "description": "Run binocle",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "binocle",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install binocle from github.com/sharkdp/binocle"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bitwise/install-guidance.json
+++ b/plugins/bitwise/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "bitwise",
+  "binary": "bitwise",
+  "check": "which bitwise",
+  "install_steps": [
+    "# Install bitwise",
+    "# See github.com/mellowcandle/bitwise",
+    "# apt: sudo apt-get install bitwise",
+    "# brew: brew install bitwise",
+    "# cargo: cargo install bitwise",
+    "# npm: npm install -g bitwise"
+  ]
+}

--- a/plugins/bitwise/meta.json
+++ b/plugins/bitwise/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "bitwise \u2014 Bitwise operation calculator",
+  "tags": [
+    "utility",
+    "calculator"
+  ],
+  "has_learn": false
+}

--- a/plugins/bitwise/plugin.json
+++ b/plugins/bitwise/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "bitwise",
+  "version": "1.0.0",
+  "description": "bitwise \u2014 Bitwise operation calculator",
+  "source": "github.com/mellowcandle/bitwise",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bitwise"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bitwise",
+    "binary": "bitwise",
+    "check": "which bitwise",
+    "install_steps": [
+      "# Install bitwise",
+      "# See github.com/mellowcandle/bitwise",
+      "# apt: sudo apt-get install bitwise",
+      "# brew: brew install bitwise",
+      "# cargo: cargo install bitwise",
+      "# npm: npm install -g bitwise",
+      "# pip: pip install bitwise"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bitwise",
+      "resource": "bitwise",
+      "action": "run",
+      "description": "Run bitwise",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bitwise",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bitwise from github.com/mellowcandle/bitwise"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bkt/install-guidance.json
+++ b/plugins/bkt/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "bkt",
+  "binary": "bkt",
+  "check": "which bkt",
+  "install_steps": [
+    "# Install bkt",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/bkt-linux-amd64 -o /usr/local/bin/bkt",
+    "chmod +x /usr/local/bin/bkt",
+    "# Or via package manager, see crates.io/crates/bkt"
+  ]
+}

--- a/plugins/bkt/meta.json
+++ b/plugins/bkt/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "bkt \u2014 Subprocess caching utility",
+  "tags": [
+    "utility",
+    "caching"
+  ],
+  "has_learn": false
+}

--- a/plugins/bkt/plugin.json
+++ b/plugins/bkt/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "bkt",
+  "version": "1.0.0",
+  "description": "bkt \u2014 Subprocess caching utility",
+  "source": "crates.io/crates/bkt",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bkt"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bkt",
+    "binary": "bkt",
+    "check": "which bkt",
+    "install_steps": [
+      "# Install bkt:",
+      "# apt: sudo apt-get install bkt",
+      "# brew: brew install bkt",
+      "# cargo: cargo install bkt",
+      "# npm: npm install -g bkt",
+      "# pip: pip install bkt",
+      "# or download from crates.io/crates/bkt"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bkt",
+      "resource": "bkt",
+      "action": "run",
+      "description": "Run bkt",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bkt",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bkt from crates.io/crates/bkt"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bleachbit/install-guidance.json
+++ b/plugins/bleachbit/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "bleachbit",
+  "binary": "bleachbit",
+  "check": "which bleachbit",
+  "install_steps": [
+    "# Install bleachbit",
+    "# See bleachbit.org",
+    "# apt: sudo apt-get install bleachbit",
+    "# brew: brew install bleachbit",
+    "# cargo: cargo install bleachbit",
+    "# npm: npm install -g bleachbit"
+  ]
+}

--- a/plugins/bleachbit/meta.json
+++ b/plugins/bleachbit/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "bleachbit \u2014 System cleaner",
+  "tags": [
+    "utility",
+    "cleaner"
+  ],
+  "has_learn": false
+}

--- a/plugins/bleachbit/plugin.json
+++ b/plugins/bleachbit/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "bleachbit",
+  "version": "1.0.0",
+  "description": "bleachbit \u2014 System cleaner",
+  "source": "bleachbit.org",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bleachbit"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bleachbit",
+    "binary": "bleachbit",
+    "check": "which bleachbit",
+    "install_steps": [
+      "# Install bleachbit",
+      "# See bleachbit.org",
+      "# apt: sudo apt-get install bleachbit",
+      "# brew: brew install bleachbit",
+      "# cargo: cargo install bleachbit",
+      "# npm: npm install -g bleachbit",
+      "# pip: pip install bleachbit"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bleachbit",
+      "resource": "bleachbit",
+      "action": "run",
+      "description": "Run bleachbit",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bleachbit",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bleachbit from bleachbit.org"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bpytop/install-guidance.json
+++ b/plugins/bpytop/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "bpytop",
+  "binary": "bpytop",
+  "check": "which bpytop",
+  "install_steps": [
+    "# Install bpytop",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/bpytop-linux-amd64 -o /usr/local/bin/bpytop",
+    "chmod +x /usr/local/bin/bpytop",
+    "# Or via package manager, see github.com/aristocratos/bpytop"
+  ]
+}

--- a/plugins/bpytop/meta.json
+++ b/plugins/bpytop/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "bpytop \u2014 Resource monitor (Python)",
+  "tags": [
+    "system",
+    "monitor"
+  ],
+  "has_learn": false
+}

--- a/plugins/bpytop/plugin.json
+++ b/plugins/bpytop/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "bpytop",
+  "version": "1.0.0",
+  "description": "bpytop \u2014 Resource monitor (Python)",
+  "source": "github.com/aristocratos/bpytop",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bpytop"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bpytop",
+    "binary": "bpytop",
+    "check": "which bpytop",
+    "install_steps": [
+      "# Install bpytop:",
+      "# apt: sudo apt-get install bpytop",
+      "# brew: brew install bpytop",
+      "# cargo: cargo install bpytop",
+      "# npm: npm install -g bpytop",
+      "# pip: pip install bpytop",
+      "# or download from github.com/aristocratos/bpytop"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bpytop",
+      "resource": "bpytop",
+      "action": "run",
+      "description": "Run bpytop",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bpytop",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bpytop from github.com/aristocratos/bpytop"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bubblewrap/install-guidance.json
+++ b/plugins/bubblewrap/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "bubblewrap",
+  "binary": "bubblewrap",
+  "check": "which bubblewrap",
+  "install_steps": [
+    "# Install bubblewrap",
+    "# See github.com/containers/bubblewrap",
+    "# apt: sudo apt-get install bubblewrap",
+    "# brew: brew install bubblewrap",
+    "# cargo: cargo install bubblewrap",
+    "# npm: npm install -g bubblewrap"
+  ]
+}

--- a/plugins/bubblewrap/meta.json
+++ b/plugins/bubblewrap/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "bubblewrap \u2014 Sandboxing tool",
+  "tags": [
+    "security",
+    "sandbox"
+  ],
+  "has_learn": false
+}

--- a/plugins/bubblewrap/plugin.json
+++ b/plugins/bubblewrap/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "bubblewrap",
+  "version": "1.0.0",
+  "description": "bubblewrap \u2014 Sandboxing tool",
+  "source": "github.com/containers/bubblewrap",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bubblewrap"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bubblewrap",
+    "binary": "bubblewrap",
+    "check": "which bubblewrap",
+    "install_steps": [
+      "# Install bubblewrap",
+      "# See github.com/containers/bubblewrap",
+      "# apt: sudo apt-get install bubblewrap",
+      "# brew: brew install bubblewrap",
+      "# cargo: cargo install bubblewrap",
+      "# npm: npm install -g bubblewrap",
+      "# pip: pip install bubblewrap"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bubblewrap",
+      "resource": "bubblewrap",
+      "action": "run",
+      "description": "Run bubblewrap",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bubblewrap",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bubblewrap from github.com/containers/bubblewrap"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bugwarrior/install-guidance.json
+++ b/plugins/bugwarrior/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "bugwarrior",
+  "binary": "bugwarrior",
+  "check": "which bugwarrior",
+  "install_steps": [
+    "# Install bugwarrior",
+    "# See github.com/ralphbean/bugwarrior",
+    "# apt: sudo apt-get install bugwarrior",
+    "# brew: brew install bugwarrior",
+    "# cargo: cargo install bugwarrior",
+    "# npm: npm install -g bugwarrior"
+  ]
+}

--- a/plugins/bugwarrior/meta.json
+++ b/plugins/bugwarrior/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "bugwarrior \u2014 Sync issues to taskwarrior",
+  "tags": [
+    "productivity",
+    "task"
+  ],
+  "has_learn": false
+}

--- a/plugins/bugwarrior/plugin.json
+++ b/plugins/bugwarrior/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "bugwarrior",
+  "version": "1.0.0",
+  "description": "bugwarrior \u2014 Sync issues to taskwarrior",
+  "source": "github.com/ralphbean/bugwarrior",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bugwarrior"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bugwarrior",
+    "binary": "bugwarrior",
+    "check": "which bugwarrior",
+    "install_steps": [
+      "# Install bugwarrior",
+      "# See github.com/ralphbean/bugwarrior",
+      "# apt: sudo apt-get install bugwarrior",
+      "# brew: brew install bugwarrior",
+      "# cargo: cargo install bugwarrior",
+      "# npm: npm install -g bugwarrior",
+      "# pip: pip install bugwarrior"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bugwarrior",
+      "resource": "bugwarrior",
+      "action": "run",
+      "description": "Run bugwarrior",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bugwarrior",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bugwarrior from github.com/ralphbean/bugwarrior"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bumpversion/install-guidance.json
+++ b/plugins/bumpversion/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "bumpversion",
+  "binary": "bumpversion",
+  "check": "which bumpversion",
+  "install_steps": [
+    "# Install bumpversion",
+    "# See github.com/peritus/bumpversion",
+    "# apt: sudo apt-get install bumpversion",
+    "# brew: brew install bumpversion",
+    "# cargo: cargo install bumpversion",
+    "# npm: npm install -g bumpversion"
+  ]
+}

--- a/plugins/bumpversion/meta.json
+++ b/plugins/bumpversion/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "bumpversion \u2014 Version bump tool",
+  "tags": [
+    "utility",
+    "versioning"
+  ],
+  "has_learn": false
+}

--- a/plugins/bumpversion/plugin.json
+++ b/plugins/bumpversion/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "bumpversion",
+  "version": "1.0.0",
+  "description": "bumpversion \u2014 Version bump tool",
+  "source": "github.com/peritus/bumpversion",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bumpversion"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bumpversion",
+    "binary": "bumpversion",
+    "check": "which bumpversion",
+    "install_steps": [
+      "# Install bumpversion",
+      "# See github.com/peritus/bumpversion",
+      "# apt: sudo apt-get install bumpversion",
+      "# brew: brew install bumpversion",
+      "# cargo: cargo install bumpversion",
+      "# npm: npm install -g bumpversion",
+      "# pip: pip install bumpversion"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bumpversion",
+      "resource": "bumpversion",
+      "action": "run",
+      "description": "Run bumpversion",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bumpversion",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bumpversion from github.com/peritus/bumpversion"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Batch 001 of 31 — adding 19 new bundled plugin definitions.

## Plugins

- 
- 
- 
- 
- 
- 
- 
- 786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce  -
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 

## Details
- Auto-generated from curated CLI tool list
- Each plugin includes plugin.json, meta.json, install-guidance.json
- Binary checks reference install guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added 19 new plugins: advcp, aha, ansiweather, archey4, as-tree, ask, assetfinder, b2sum, bats, bear, bfs, binocle, bitwise, bkt, bleachbit, bpytop, bubblewrap, bugwarrior, and bumpversion.
* Each plugin includes metadata definitions, installation guidance for multiple package managers, and integrated command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->