### PR TITLE
feat: add 20 bundled plugins (batch 002/31)

### DIFF
--- a/plugins/busybox/install-guidance.json
+++ b/plugins/busybox/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "busybox",
+  "binary": "busybox",
+  "check": "which busybox",
+  "install_steps": [
+    "# Install busybox",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/busybox-linux-amd64 -o /usr/local/bin/busybox",
+    "chmod +x /usr/local/bin/busybox",
+    "# Or via package manager, see /usr/bin/busybox"
+  ]
+}

--- a/plugins/busybox/meta.json
+++ b/plugins/busybox/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "busybox \u2014 busybox \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/busybox/plugin.json
+++ b/plugins/busybox/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "busybox",
+  "version": "1.0.0",
+  "description": "busybox \u2014 busybox \u2014 CLI utility",
+  "source": "/usr/bin/busybox",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "busybox"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "busybox",
+    "binary": "busybox",
+    "check": "which busybox",
+    "install_steps": [
+      "# Install busybox:",
+      "# apt: sudo apt-get install busybox",
+      "# brew: brew install busybox",
+      "# cargo: cargo install busybox",
+      "# npm: npm install -g busybox",
+      "# pip: pip install busybox",
+      "# or download from /usr/bin/busybox"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "busybox",
+      "resource": "busybox",
+      "action": "run",
+      "description": "Run busybox",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "busybox",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install busybox from /usr/bin/busybox"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/c_rehash/install-guidance.json
+++ b/plugins/c_rehash/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "c_rehash",
+  "binary": "c_rehash",
+  "check": "which c_rehash",
+  "install_steps": [
+    "# Install c_rehash",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/c_rehash-linux-amd64 -o /usr/local/bin/c_rehash",
+    "chmod +x /usr/local/bin/c_rehash",
+    "# Or via package manager, see /usr/bin/c_rehash"
+  ]
+}

--- a/plugins/c_rehash/meta.json
+++ b/plugins/c_rehash/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "c_rehash \u2014 c_rehash \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/c_rehash/plugin.json
+++ b/plugins/c_rehash/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "c-rehash",
+  "version": "1.0.0",
+  "description": "c-rehash \u2014 c_rehash \u2014 CLI utility",
+  "source": "/usr/bin/c_rehash",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "c_rehash"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "c-rehash",
+    "binary": "c_rehash",
+    "check": "which c_rehash",
+    "install_steps": [
+      "# Install c-rehash:",
+      "# apt: sudo apt-get install c-rehash",
+      "# brew: brew install c-rehash",
+      "# cargo: cargo install c-rehash",
+      "# npm: npm install -g c-rehash",
+      "# pip: pip install c-rehash",
+      "# or download from /usr/bin/c_rehash"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "c",
+      "resource": "rehash",
+      "action": "run",
+      "description": "Run c-rehash",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "c_rehash",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install c-rehash from /usr/bin/c_rehash"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cadaver/install-guidance.json
+++ b/plugins/cadaver/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cadaver",
+  "binary": "cadaver",
+  "check": "which cadaver",
+  "install_steps": [
+    "# Install cadaver",
+    "# See github.com/nmayor/cadaver",
+    "# apt: sudo apt-get install cadaver",
+    "# brew: brew install cadaver",
+    "# cargo: cargo install cadaver",
+    "# npm: npm install -g cadaver"
+  ]
+}

--- a/plugins/cadaver/meta.json
+++ b/plugins/cadaver/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cadaver \u2014 WebDAV client",
+  "tags": [
+    "network",
+    "webdav"
+  ],
+  "has_learn": false
+}

--- a/plugins/cadaver/plugin.json
+++ b/plugins/cadaver/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cadaver",
+  "version": "1.0.0",
+  "description": "cadaver \u2014 WebDAV client",
+  "source": "github.com/nmayor/cadaver",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cadaver"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cadaver",
+    "binary": "cadaver",
+    "check": "which cadaver",
+    "install_steps": [
+      "# Install cadaver",
+      "# See github.com/nmayor/cadaver",
+      "# apt: sudo apt-get install cadaver",
+      "# brew: brew install cadaver",
+      "# cargo: cargo install cadaver",
+      "# npm: npm install -g cadaver",
+      "# pip: pip install cadaver"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cadaver",
+      "resource": "cadaver",
+      "action": "run",
+      "description": "Run cadaver",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cadaver",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cadaver from github.com/nmayor/cadaver"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cargo-cache/install-guidance.json
+++ b/plugins/cargo-cache/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cargo-cache",
+  "binary": "cargo-cache",
+  "check": "which cargo-cache",
+  "install_steps": [
+    "# Install cargo-cache",
+    "# See github.com/matthiaskrgr/cargo-cache",
+    "# apt: sudo apt-get install cargo-cache",
+    "# brew: brew install cargo-cache",
+    "# cargo: cargo install cargo-cache",
+    "# npm: npm install -g cargo-cache"
+  ]
+}

--- a/plugins/cargo-cache/meta.json
+++ b/plugins/cargo-cache/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cargo-cache \u2014 Cargo cache management",
+  "tags": [
+    "rust",
+    "cache"
+  ],
+  "has_learn": false
+}

--- a/plugins/cargo-cache/plugin.json
+++ b/plugins/cargo-cache/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-cache",
+  "version": "1.0.0",
+  "description": "cargo-cache \u2014 Cargo cache management",
+  "source": "github.com/matthiaskrgr/cargo-cache",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cargo-cache"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cargo-cache",
+    "binary": "cargo-cache",
+    "check": "which cargo-cache",
+    "install_steps": [
+      "# Install cargo-cache",
+      "# See github.com/matthiaskrgr/cargo-cache",
+      "# apt: sudo apt-get install cargo-cache",
+      "# brew: brew install cargo-cache",
+      "# cargo: cargo install cargo-cache",
+      "# npm: npm install -g cargo-cache",
+      "# pip: pip install cargo-cache"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cargo",
+      "resource": "cache",
+      "action": "run",
+      "description": "Run cargo-cache",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cargo-cache",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cargo-cache from github.com/matthiaskrgr/cargo-cache"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cargo-deb/install-guidance.json
+++ b/plugins/cargo-deb/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cargo-deb",
+  "binary": "cargo-deb",
+  "check": "which cargo-deb",
+  "install_steps": [
+    "# Install cargo-deb",
+    "# See github.com/kornelski/cargo-deb",
+    "# apt: sudo apt-get install cargo-deb",
+    "# brew: brew install cargo-deb",
+    "# cargo: cargo install cargo-deb",
+    "# npm: npm install -g cargo-deb"
+  ]
+}

--- a/plugins/cargo-deb/meta.json
+++ b/plugins/cargo-deb/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cargo-deb \u2014 Debian packages from Cargo",
+  "tags": [
+    "rust",
+    "packaging"
+  ],
+  "has_learn": false
+}

--- a/plugins/cargo-deb/plugin.json
+++ b/plugins/cargo-deb/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-deb",
+  "version": "1.0.0",
+  "description": "cargo-deb \u2014 Debian packages from Cargo",
+  "source": "github.com/kornelski/cargo-deb",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cargo-deb"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cargo-deb",
+    "binary": "cargo-deb",
+    "check": "which cargo-deb",
+    "install_steps": [
+      "# Install cargo-deb",
+      "# See github.com/kornelski/cargo-deb",
+      "# apt: sudo apt-get install cargo-deb",
+      "# brew: brew install cargo-deb",
+      "# cargo: cargo install cargo-deb",
+      "# npm: npm install -g cargo-deb",
+      "# pip: pip install cargo-deb"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cargo",
+      "resource": "deb",
+      "action": "run",
+      "description": "Run cargo-deb",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cargo-deb",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cargo-deb from github.com/kornelski/cargo-deb"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cargo-flamegraph/install-guidance.json
+++ b/plugins/cargo-flamegraph/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cargo-flamegraph",
+  "binary": "cargo-flamegraph",
+  "check": "which cargo-flamegraph",
+  "install_steps": [
+    "# Install cargo-flamegraph",
+    "# See github.com/flamegraph-rs/flamegraph",
+    "# apt: sudo apt-get install cargo-flamegraph",
+    "# brew: brew install cargo-flamegraph",
+    "# cargo: cargo install cargo-flamegraph",
+    "# npm: npm install -g cargo-flamegraph"
+  ]
+}

--- a/plugins/cargo-flamegraph/meta.json
+++ b/plugins/cargo-flamegraph/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cargo-flamegraph \u2014 Flame graphs for Rust",
+  "tags": [
+    "rust",
+    "profiling"
+  ],
+  "has_learn": false
+}

--- a/plugins/cargo-flamegraph/plugin.json
+++ b/plugins/cargo-flamegraph/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-flamegraph",
+  "version": "1.0.0",
+  "description": "cargo-flamegraph \u2014 Flame graphs for Rust",
+  "source": "github.com/flamegraph-rs/flamegraph",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cargo-flamegraph"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cargo-flamegraph",
+    "binary": "cargo-flamegraph",
+    "check": "which cargo-flamegraph",
+    "install_steps": [
+      "# Install cargo-flamegraph",
+      "# See github.com/flamegraph-rs/flamegraph",
+      "# apt: sudo apt-get install cargo-flamegraph",
+      "# brew: brew install cargo-flamegraph",
+      "# cargo: cargo install cargo-flamegraph",
+      "# npm: npm install -g cargo-flamegraph",
+      "# pip: pip install cargo-flamegraph"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cargo",
+      "resource": "flamegraph",
+      "action": "run",
+      "description": "Run cargo-flamegraph",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cargo-flamegraph",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cargo-flamegraph from github.com/flamegraph-rs/flamegraph"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cargo-fuzz/install-guidance.json
+++ b/plugins/cargo-fuzz/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cargo-fuzz",
+  "binary": "cargo-fuzz",
+  "check": "which cargo-fuzz",
+  "install_steps": [
+    "# Install cargo-fuzz",
+    "# See github.com/rust-fuzz/cargo-fuzz",
+    "# apt: sudo apt-get install cargo-fuzz",
+    "# brew: brew install cargo-fuzz",
+    "# cargo: cargo install cargo-fuzz",
+    "# npm: npm install -g cargo-fuzz"
+  ]
+}

--- a/plugins/cargo-fuzz/meta.json
+++ b/plugins/cargo-fuzz/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cargo-fuzz \u2014 Fuzz testing for Rust",
+  "tags": [
+    "rust",
+    "testing"
+  ],
+  "has_learn": false
+}

--- a/plugins/cargo-fuzz/plugin.json
+++ b/plugins/cargo-fuzz/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-fuzz",
+  "version": "1.0.0",
+  "description": "cargo-fuzz \u2014 Fuzz testing for Rust",
+  "source": "github.com/rust-fuzz/cargo-fuzz",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cargo-fuzz"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cargo-fuzz",
+    "binary": "cargo-fuzz",
+    "check": "which cargo-fuzz",
+    "install_steps": [
+      "# Install cargo-fuzz",
+      "# See github.com/rust-fuzz/cargo-fuzz",
+      "# apt: sudo apt-get install cargo-fuzz",
+      "# brew: brew install cargo-fuzz",
+      "# cargo: cargo install cargo-fuzz",
+      "# npm: npm install -g cargo-fuzz",
+      "# pip: pip install cargo-fuzz"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cargo",
+      "resource": "fuzz",
+      "action": "run",
+      "description": "Run cargo-fuzz",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cargo-fuzz",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cargo-fuzz from github.com/rust-fuzz/cargo-fuzz"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cargo-geiger/install-guidance.json
+++ b/plugins/cargo-geiger/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cargo-geiger",
+  "binary": "cargo-geiger",
+  "check": "which cargo-geiger",
+  "install_steps": [
+    "# Install cargo-geiger",
+    "# See github.com/rust-secure-code/cargo-geiger",
+    "# apt: sudo apt-get install cargo-geiger",
+    "# brew: brew install cargo-geiger",
+    "# cargo: cargo install cargo-geiger",
+    "# npm: npm install -g cargo-geiger"
+  ]
+}

--- a/plugins/cargo-geiger/meta.json
+++ b/plugins/cargo-geiger/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cargo-geiger \u2014 Unsafe Rust detection",
+  "tags": [
+    "rust",
+    "security"
+  ],
+  "has_learn": false
+}

--- a/plugins/cargo-geiger/plugin.json
+++ b/plugins/cargo-geiger/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-geiger",
+  "version": "1.0.0",
+  "description": "cargo-geiger \u2014 Unsafe Rust detection",
+  "source": "github.com/rust-secure-code/cargo-geiger",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cargo-geiger"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cargo-geiger",
+    "binary": "cargo-geiger",
+    "check": "which cargo-geiger",
+    "install_steps": [
+      "# Install cargo-geiger",
+      "# See github.com/rust-secure-code/cargo-geiger",
+      "# apt: sudo apt-get install cargo-geiger",
+      "# brew: brew install cargo-geiger",
+      "# cargo: cargo install cargo-geiger",
+      "# npm: npm install -g cargo-geiger",
+      "# pip: pip install cargo-geiger"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cargo",
+      "resource": "geiger",
+      "action": "run",
+      "description": "Run cargo-geiger",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cargo-geiger",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cargo-geiger from github.com/rust-secure-code/cargo-geiger"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cargo-license/install-guidance.json
+++ b/plugins/cargo-license/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "cargo-license",
+  "binary": "cargo-license",
+  "check": "which cargo-license",
+  "install_steps": [
+    "# Install cargo-license",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/cargo-license-linux-amd64 -o /usr/local/bin/cargo-license",
+    "chmod +x /usr/local/bin/cargo-license",
+    "# Or via package manager, see crates.io/crates/cargo-license"
+  ]
+}

--- a/plugins/cargo-license/meta.json
+++ b/plugins/cargo-license/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cargo-license \u2014 Display crate licenses",
+  "tags": [
+    "utility",
+    "rust"
+  ],
+  "has_learn": false
+}

--- a/plugins/cargo-license/plugin.json
+++ b/plugins/cargo-license/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-license",
+  "version": "1.0.0",
+  "description": "cargo-license \u2014 Display crate licenses",
+  "source": "crates.io/crates/cargo-license",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cargo-license"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cargo-license",
+    "binary": "cargo-license",
+    "check": "which cargo-license",
+    "install_steps": [
+      "# Install cargo-license:",
+      "# apt: sudo apt-get install cargo-license",
+      "# brew: brew install cargo-license",
+      "# cargo: cargo install cargo-license",
+      "# npm: npm install -g cargo-license",
+      "# pip: pip install cargo-license",
+      "# or download from crates.io/crates/cargo-license"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cargo",
+      "resource": "license",
+      "action": "run",
+      "description": "Run cargo-license",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cargo-license",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cargo-license from crates.io/crates/cargo-license"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cargo-limit/install-guidance.json
+++ b/plugins/cargo-limit/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cargo-limit",
+  "binary": "cargo-limit",
+  "check": "which cargo-limit",
+  "install_steps": [
+    "# Install cargo-limit",
+    "# See github.com/cargo-limit/cargo-limit",
+    "# apt: sudo apt-get install cargo-limit",
+    "# brew: brew install cargo-limit",
+    "# cargo: cargo install cargo-limit",
+    "# npm: npm install -g cargo-limit"
+  ]
+}

--- a/plugins/cargo-limit/meta.json
+++ b/plugins/cargo-limit/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cargo-limit \u2014 Faster cargo errors",
+  "tags": [
+    "rust",
+    "build"
+  ],
+  "has_learn": false
+}

--- a/plugins/cargo-limit/plugin.json
+++ b/plugins/cargo-limit/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-limit",
+  "version": "1.0.0",
+  "description": "cargo-limit \u2014 Faster cargo errors",
+  "source": "github.com/cargo-limit/cargo-limit",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cargo-limit"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cargo-limit",
+    "binary": "cargo-limit",
+    "check": "which cargo-limit",
+    "install_steps": [
+      "# Install cargo-limit",
+      "# See github.com/cargo-limit/cargo-limit",
+      "# apt: sudo apt-get install cargo-limit",
+      "# brew: brew install cargo-limit",
+      "# cargo: cargo install cargo-limit",
+      "# npm: npm install -g cargo-limit",
+      "# pip: pip install cargo-limit"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cargo",
+      "resource": "limit",
+      "action": "run",
+      "description": "Run cargo-limit",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cargo-limit",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cargo-limit from github.com/cargo-limit/cargo-limit"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cargo-profiler/install-guidance.json
+++ b/plugins/cargo-profiler/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cargo-profiler",
+  "binary": "cargo-profiler",
+  "check": "which cargo-profiler",
+  "install_steps": [
+    "# Install cargo-profiler",
+    "# See github.com/svenstaro/cargo-profiler",
+    "# apt: sudo apt-get install cargo-profiler",
+    "# brew: brew install cargo-profiler",
+    "# cargo: cargo install cargo-profiler",
+    "# npm: npm install -g cargo-profiler"
+  ]
+}

--- a/plugins/cargo-profiler/meta.json
+++ b/plugins/cargo-profiler/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cargo-profiler \u2014 Rust profiling",
+  "tags": [
+    "rust",
+    "profiling"
+  ],
+  "has_learn": false
+}

--- a/plugins/cargo-profiler/plugin.json
+++ b/plugins/cargo-profiler/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-profiler",
+  "version": "1.0.0",
+  "description": "cargo-profiler \u2014 Rust profiling",
+  "source": "github.com/svenstaro/cargo-profiler",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cargo-profiler"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cargo-profiler",
+    "binary": "cargo-profiler",
+    "check": "which cargo-profiler",
+    "install_steps": [
+      "# Install cargo-profiler",
+      "# See github.com/svenstaro/cargo-profiler",
+      "# apt: sudo apt-get install cargo-profiler",
+      "# brew: brew install cargo-profiler",
+      "# cargo: cargo install cargo-profiler",
+      "# npm: npm install -g cargo-profiler",
+      "# pip: pip install cargo-profiler"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cargo",
+      "resource": "profiler",
+      "action": "run",
+      "description": "Run cargo-profiler",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cargo-profiler",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cargo-profiler from github.com/svenstaro/cargo-profiler"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cargo-show/install-guidance.json
+++ b/plugins/cargo-show/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cargo-show",
+  "binary": "cargo-show",
+  "check": "which cargo-show",
+  "install_steps": [
+    "# Install cargo-show",
+    "# See github.com/ankane/cargo-show",
+    "# apt: sudo apt-get install cargo-show",
+    "# brew: brew install cargo-show",
+    "# cargo: cargo install cargo-show",
+    "# npm: npm install -g cargo-show"
+  ]
+}

--- a/plugins/cargo-show/meta.json
+++ b/plugins/cargo-show/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cargo-show \u2014 Show crate details",
+  "tags": [
+    "rust",
+    "dependencies"
+  ],
+  "has_learn": false
+}

--- a/plugins/cargo-show/plugin.json
+++ b/plugins/cargo-show/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-show",
+  "version": "1.0.0",
+  "description": "cargo-show \u2014 Show crate details",
+  "source": "github.com/ankane/cargo-show",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cargo-show"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cargo-show",
+    "binary": "cargo-show",
+    "check": "which cargo-show",
+    "install_steps": [
+      "# Install cargo-show",
+      "# See github.com/ankane/cargo-show",
+      "# apt: sudo apt-get install cargo-show",
+      "# brew: brew install cargo-show",
+      "# cargo: cargo install cargo-show",
+      "# npm: npm install -g cargo-show",
+      "# pip: pip install cargo-show"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cargo",
+      "resource": "show",
+      "action": "run",
+      "description": "Run cargo-show",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cargo-show",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cargo-show from github.com/ankane/cargo-show"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cargo-sort/install-guidance.json
+++ b/plugins/cargo-sort/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cargo-sort",
+  "binary": "cargo-sort",
+  "check": "which cargo-sort",
+  "install_steps": [
+    "# Install cargo-sort",
+    "# See github.com/DevinR528/cargo-sort",
+    "# apt: sudo apt-get install cargo-sort",
+    "# brew: brew install cargo-sort",
+    "# cargo: cargo install cargo-sort",
+    "# npm: npm install -g cargo-sort"
+  ]
+}

--- a/plugins/cargo-sort/meta.json
+++ b/plugins/cargo-sort/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cargo-sort \u2014 Sort dependencies",
+  "tags": [
+    "rust",
+    "formatting"
+  ],
+  "has_learn": false
+}

--- a/plugins/cargo-sort/plugin.json
+++ b/plugins/cargo-sort/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-sort",
+  "version": "1.0.0",
+  "description": "cargo-sort \u2014 Sort dependencies",
+  "source": "github.com/DevinR528/cargo-sort",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cargo-sort"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cargo-sort",
+    "binary": "cargo-sort",
+    "check": "which cargo-sort",
+    "install_steps": [
+      "# Install cargo-sort",
+      "# See github.com/DevinR528/cargo-sort",
+      "# apt: sudo apt-get install cargo-sort",
+      "# brew: brew install cargo-sort",
+      "# cargo: cargo install cargo-sort",
+      "# npm: npm install -g cargo-sort",
+      "# pip: pip install cargo-sort"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cargo",
+      "resource": "sort",
+      "action": "run",
+      "description": "Run cargo-sort",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cargo-sort",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cargo-sort from github.com/DevinR528/cargo-sort"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cargo-update/install-guidance.json
+++ b/plugins/cargo-update/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "cargo-update",
+  "binary": "cargo-update",
+  "check": "which cargo-update",
+  "install_steps": [
+    "# Install cargo-update",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/cargo-update-linux-amd64 -o /usr/local/bin/cargo-update",
+    "chmod +x /usr/local/bin/cargo-update",
+    "# Or via package manager, see crates.io/crates/cargo-update"
+  ]
+}

--- a/plugins/cargo-update/meta.json
+++ b/plugins/cargo-update/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cargo-update \u2014 Update cargo-installed binaries",
+  "tags": [
+    "utility",
+    "rust"
+  ],
+  "has_learn": false
+}

--- a/plugins/cargo-update/plugin.json
+++ b/plugins/cargo-update/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-update",
+  "version": "1.0.0",
+  "description": "cargo-update \u2014 Update cargo-installed binaries",
+  "source": "crates.io/crates/cargo-update",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cargo-update"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cargo-update",
+    "binary": "cargo-update",
+    "check": "which cargo-update",
+    "install_steps": [
+      "# Install cargo-update:",
+      "# apt: sudo apt-get install cargo-update",
+      "# brew: brew install cargo-update",
+      "# cargo: cargo install cargo-update",
+      "# npm: npm install -g cargo-update",
+      "# pip: pip install cargo-update",
+      "# or download from crates.io/crates/cargo-update"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cargo",
+      "resource": "update",
+      "action": "run",
+      "description": "Run cargo-update",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cargo-update",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cargo-update from crates.io/crates/cargo-update"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cargo-wipe/install-guidance.json
+++ b/plugins/cargo-wipe/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cargo-wipe",
+  "binary": "cargo-wipe",
+  "check": "which cargo-wipe",
+  "install_steps": [
+    "# Install cargo-wipe",
+    "# See github.com/mihai-dinculescu/cargo-wipe",
+    "# apt: sudo apt-get install cargo-wipe",
+    "# brew: brew install cargo-wipe",
+    "# cargo: cargo install cargo-wipe",
+    "# npm: npm install -g cargo-wipe"
+  ]
+}

--- a/plugins/cargo-wipe/meta.json
+++ b/plugins/cargo-wipe/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cargo-wipe \u2014 Clean Rust projects",
+  "tags": [
+    "rust",
+    "cleanup"
+  ],
+  "has_learn": false
+}

--- a/plugins/cargo-wipe/plugin.json
+++ b/plugins/cargo-wipe/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-wipe",
+  "version": "1.0.0",
+  "description": "cargo-wipe \u2014 Clean Rust projects",
+  "source": "github.com/mihai-dinculescu/cargo-wipe",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cargo-wipe"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cargo-wipe",
+    "binary": "cargo-wipe",
+    "check": "which cargo-wipe",
+    "install_steps": [
+      "# Install cargo-wipe",
+      "# See github.com/mihai-dinculescu/cargo-wipe",
+      "# apt: sudo apt-get install cargo-wipe",
+      "# brew: brew install cargo-wipe",
+      "# cargo: cargo install cargo-wipe",
+      "# npm: npm install -g cargo-wipe",
+      "# pip: pip install cargo-wipe"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cargo",
+      "resource": "wipe",
+      "action": "run",
+      "description": "Run cargo-wipe",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cargo-wipe",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cargo-wipe from github.com/mihai-dinculescu/cargo-wipe"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cdiff/install-guidance.json
+++ b/plugins/cdiff/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cdiff",
+  "binary": "cdiff",
+  "check": "which cdiff",
+  "install_steps": [
+    "# Install cdiff",
+    "# See github.com/ymattw/cdiff",
+    "# apt: sudo apt-get install cdiff",
+    "# brew: brew install cdiff",
+    "# cargo: cargo install cdiff",
+    "# npm: npm install -g cdiff"
+  ]
+}

--- a/plugins/cdiff/meta.json
+++ b/plugins/cdiff/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cdiff \u2014 Colorized diff",
+  "tags": [
+    "utility",
+    "diff"
+  ],
+  "has_learn": false
+}

--- a/plugins/cdiff/plugin.json
+++ b/plugins/cdiff/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cdiff",
+  "version": "1.0.0",
+  "description": "cdiff \u2014 Colorized diff",
+  "source": "github.com/ymattw/cdiff",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cdiff"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cdiff",
+    "binary": "cdiff",
+    "check": "which cdiff",
+    "install_steps": [
+      "# Install cdiff",
+      "# See github.com/ymattw/cdiff",
+      "# apt: sudo apt-get install cdiff",
+      "# brew: brew install cdiff",
+      "# cargo: cargo install cdiff",
+      "# npm: npm install -g cdiff",
+      "# pip: pip install cdiff"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cdiff",
+      "resource": "cdiff",
+      "action": "run",
+      "description": "Run cdiff",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cdiff",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cdiff from github.com/ymattw/cdiff"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/changelog/install-guidance.json
+++ b/plugins/changelog/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "changelog",
+  "binary": "changelog",
+  "check": "which changelog",
+  "install_steps": [
+    "# Install changelog",
+    "# See github.com/github-changelog-generator/github-changelog-generator",
+    "# apt: sudo apt-get install changelog",
+    "# brew: brew install changelog",
+    "# cargo: cargo install changelog",
+    "# npm: npm install -g changelog"
+  ]
+}

--- a/plugins/changelog/meta.json
+++ b/plugins/changelog/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "changelog \u2014 Generate changelogs",
+  "tags": [
+    "utility",
+    "documentation"
+  ],
+  "has_learn": false
+}

--- a/plugins/changelog/plugin.json
+++ b/plugins/changelog/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "changelog",
+  "version": "1.0.0",
+  "description": "changelog \u2014 Generate changelogs",
+  "source": "github.com/github-changelog-generator/github-changelog-generator",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "changelog"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "changelog",
+    "binary": "changelog",
+    "check": "which changelog",
+    "install_steps": [
+      "# Install changelog",
+      "# See github.com/github-changelog-generator/github-changelog-generator",
+      "# apt: sudo apt-get install changelog",
+      "# brew: brew install changelog",
+      "# cargo: cargo install changelog",
+      "# npm: npm install -g changelog",
+      "# pip: pip install changelog"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "changelog",
+      "resource": "changelog",
+      "action": "run",
+      "description": "Run changelog",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "changelog",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install changelog from github.com/github-changelog-generator/github-changelog-generator"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cider/install-guidance.json
+++ b/plugins/cider/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cider",
+  "binary": "cider",
+  "check": "which cider",
+  "install_steps": [
+    "# Install cider",
+    "# See github.com/ciderapp/cider",
+    "# apt: sudo apt-get install cider",
+    "# brew: brew install cider",
+    "# cargo: cargo install cider",
+    "# npm: npm install -g cider"
+  ]
+}

--- a/plugins/cider/meta.json
+++ b/plugins/cider/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cider \u2014 Apple Music CLI",
+  "tags": [
+    "music",
+    "apple"
+  ],
+  "has_learn": false
+}

--- a/plugins/cider/plugin.json
+++ b/plugins/cider/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cider",
+  "version": "1.0.0",
+  "description": "cider \u2014 Apple Music CLI",
+  "source": "github.com/ciderapp/cider",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cider"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cider",
+    "binary": "cider",
+    "check": "which cider",
+    "install_steps": [
+      "# Install cider",
+      "# See github.com/ciderapp/cider",
+      "# apt: sudo apt-get install cider",
+      "# brew: brew install cider",
+      "# cargo: cargo install cider",
+      "# npm: npm install -g cider",
+      "# pip: pip install cider"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cider",
+      "resource": "cider",
+      "action": "run",
+      "description": "Run cider",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cider",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cider from github.com/ciderapp/cider"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cinnamon/install-guidance.json
+++ b/plugins/cinnamon/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cinnamon",
+  "binary": "cinnamon",
+  "check": "which cinnamon",
+  "install_steps": [
+    "# Install cinnamon",
+    "# See github.com/linuxmint/cinnamon",
+    "# apt: sudo apt-get install cinnamon",
+    "# brew: brew install cinnamon",
+    "# cargo: cargo install cinnamon",
+    "# npm: npm install -g cinnamon"
+  ]
+}

--- a/plugins/cinnamon/meta.json
+++ b/plugins/cinnamon/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cinnamon \u2014 Cinnamon desktop tools",
+  "tags": [
+    "desktop",
+    "ui"
+  ],
+  "has_learn": false
+}

--- a/plugins/cinnamon/plugin.json
+++ b/plugins/cinnamon/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cinnamon",
+  "version": "1.0.0",
+  "description": "cinnamon \u2014 Cinnamon desktop tools",
+  "source": "github.com/linuxmint/cinnamon",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cinnamon"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cinnamon",
+    "binary": "cinnamon",
+    "check": "which cinnamon",
+    "install_steps": [
+      "# Install cinnamon",
+      "# See github.com/linuxmint/cinnamon",
+      "# apt: sudo apt-get install cinnamon",
+      "# brew: brew install cinnamon",
+      "# cargo: cargo install cinnamon",
+      "# npm: npm install -g cinnamon",
+      "# pip: pip install cinnamon"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cinnamon",
+      "resource": "cinnamon",
+      "action": "run",
+      "description": "Run cinnamon",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cinnamon",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cinnamon from github.com/linuxmint/cinnamon"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cizzo/install-guidance.json
+++ b/plugins/cizzo/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "cizzo",
+  "binary": "cizzo",
+  "check": "which cizzo",
+  "install_steps": [
+    "# Install cizzo",
+    "# See github.com/cizzo/cizzo",
+    "# apt: sudo apt-get install cizzo",
+    "# brew: brew install cizzo",
+    "# cargo: cargo install cizzo",
+    "# npm: npm install -g cizzo"
+  ]
+}

--- a/plugins/cizzo/meta.json
+++ b/plugins/cizzo/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "cizzo \u2014 Time tracking CLI",
+  "tags": [
+    "productivity",
+    "time"
+  ],
+  "has_learn": false
+}

--- a/plugins/cizzo/plugin.json
+++ b/plugins/cizzo/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "cizzo",
+  "version": "1.0.0",
+  "description": "cizzo \u2014 Time tracking CLI",
+  "source": "github.com/cizzo/cizzo",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cizzo"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cizzo",
+    "binary": "cizzo",
+    "check": "which cizzo",
+    "install_steps": [
+      "# Install cizzo",
+      "# See github.com/cizzo/cizzo",
+      "# apt: sudo apt-get install cizzo",
+      "# brew: brew install cizzo",
+      "# cargo: cargo install cizzo",
+      "# npm: npm install -g cizzo",
+      "# pip: pip install cizzo"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cizzo",
+      "resource": "cizzo",
+      "action": "run",
+      "description": "Run cizzo",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cizzo",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cizzo from github.com/cizzo/cizzo"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Batch 002 of 31 — adding 20 new bundled plugin definitions.

## Plugins

- BusyBox v1.36.1 (Ubuntu 1:1.36.1-6ubuntu3) multi-call binary.
BusyBox is copyrighted by many authors between 1998-2015.
Licensed under GPLv2. See source distribution for detailed
copyright notices.

Usage: busybox [function [arguments]...]
   or: busybox --list[-full]
   or: busybox --install [-s] [DIR]
   or: function [arguments]...

	BusyBox is a multi-call binary that combines many common Unix
	utilities into a single executable.  The shell in this build
	is configured to run built-in utilities without $PATH search.
	You don't need to install a link to busybox for each utility.
	To run external program, use full path (/sbin/ip instead of ip).

Currently defined functions:
	[, [[, acpid, adjtimex, ar, arch, arp, arping, ascii, ash, awk, base64,
	basename, bc, blkdiscard, blockdev, brctl, bunzip2, busybox, bzcat,
	bzip2, cal, cat, chgrp, chmod, chown, chpasswd, chroot, chvt, clear,
	cmp, cp, cpio, crc32, crond, crontab, cttyhack, cut, date, dc, dd,
	deallocvt, depmod, devmem, df, diff, dirname, dmesg, dnsdomainname,
	dos2unix, dpkg, dpkg-deb, du, dumpkmap, dumpleases, echo, ed, egrep,
	env, expand, expr, factor, fallocate, false, fatattr, fdisk, fgrep,
	find, findfs, fold, free, freeramdisk, fsfreeze, fstrim, ftpget,
	ftpput, getopt, getty, grep, groups, gunzip, gzip, halt, head, hexdump,
	hostid, hostname, httpd, hwclock, i2cdetect, i2cdump, i2cget, i2cset,
	i2ctransfer, id, ifconfig, ifdown, ifup, init, insmod, ionice, ip,
	ipcalc, kill, killall, klogd, last, less, link, linux32, linux64,
	linuxrc, ln, loadfont, loadkmap, logger, login, logname, logread,
	losetup, ls, lsmod, lsscsi, lzcat, lzma, lzop, md5sum, mdev, microcom,
	mim, mkdir, mkdosfs, mke2fs, mkfifo, mknod, mkpasswd, mkswap, mktemp,
	modinfo, modprobe, more, mount, mt, mv, nameif, nbd-client, nc,
	netstat, nl, nologin, nproc, nsenter, nslookup, nuke, od, openvt,
	partprobe, passwd, paste, patch, pidof, ping, ping6, pivot_root,
	poweroff, printf, ps, pwd, rdate, readlink, realpath, reboot, renice,
	reset, resume, rev, rm, rmdir, rmmod, route, rpm, rpm2cpio, run-init,
	run-parts, sed, seq, setkeycodes, setpriv, setsid, sh, sha1sum,
	sha256sum, sha3sum, sha512sum, shred, shuf, sleep, sort, ssl_client,
	start-stop-daemon, stat, static-sh, strings, stty, su, sulogin, svc,
	svok, swapoff, swapon, switch_root, sync, sysctl, syslogd, tac, tail,
	tar, taskset, tc, tee, telnet, telnetd, test, tftp, time, timeout, top,
	touch, tr, traceroute, traceroute6, true, truncate, ts, tty, tunctl,
	ubirename, udhcpc, udhcpc6, udhcpd, uevent, umount, uname, uncompress,
	unexpand, uniq, unix2dos, unlink, unlzma, unshare, unxz, unzip, uptime,
	usleep, uudecode, uuencode, vconfig, vi, w, watch, watchdog, wc, wget,
	which, who, whoami, xargs, xxd, xz, xzcat, yes, zcat
- Doing /usr/lib/ssl/certs
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 

## Details
- Auto-generated from curated CLI tool list
- Each plugin includes plugin.json, meta.json, install-guidance.json
- Binary checks reference install guidance