### PR TITLE
feat: add 19 bundled plugins (batch 012/31)

### DIFF
--- a/plugins/jobber/install-guidance.json
+++ b/plugins/jobber/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "jobber",
+  "binary": "jobber",
+  "check": "which jobber",
+  "install_steps": [
+    "# Install jobber",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/jobber-linux-amd64 -o /usr/local/bin/jobber",
+    "chmod +x /usr/local/bin/jobber",
+    "# Or via package manager, see github.com/dshearer/jobber"
+  ]
+}

--- a/plugins/jobber/meta.json
+++ b/plugins/jobber/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "jobber \u2014 Job scheduler replacement for cron",
+  "tags": [
+    "utility",
+    "scheduling"
+  ],
+  "has_learn": false
+}

--- a/plugins/jobber/plugin.json
+++ b/plugins/jobber/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "jobber",
+  "version": "1.0.0",
+  "description": "jobber \u2014 Job scheduler replacement for cron",
+  "source": "github.com/dshearer/jobber",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "jobber"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "jobber",
+    "binary": "jobber",
+    "check": "which jobber",
+    "install_steps": [
+      "# Install jobber:",
+      "# apt: sudo apt-get install jobber",
+      "# brew: brew install jobber",
+      "# cargo: cargo install jobber",
+      "# npm: npm install -g jobber",
+      "# pip: pip install jobber",
+      "# or download from github.com/dshearer/jobber"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "jobber",
+      "resource": "jobber",
+      "action": "run",
+      "description": "Run jobber",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jobber",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install jobber from github.com/dshearer/jobber"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/johntheripper/install-guidance.json
+++ b/plugins/johntheripper/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "johntheripper",
+  "binary": "john",
+  "check": "which john",
+  "install_steps": [
+    "# Install johntheripper",
+    "# See openwall.com/john",
+    "# apt: sudo apt-get install johntheripper",
+    "# brew: brew install johntheripper",
+    "# cargo: cargo install johntheripper",
+    "# npm: npm install -g johntheripper"
+  ]
+}

--- a/plugins/johntheripper/meta.json
+++ b/plugins/johntheripper/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "johntheripper \u2014 Password cracker",
+  "tags": [
+    "security",
+    "password"
+  ],
+  "has_learn": false
+}

--- a/plugins/johntheripper/plugin.json
+++ b/plugins/johntheripper/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "johntheripper",
+  "version": "1.0.0",
+  "description": "johntheripper \u2014 Password cracker",
+  "source": "openwall.com/john",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "john"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "johntheripper",
+    "binary": "john",
+    "check": "which john",
+    "install_steps": [
+      "# Install johntheripper",
+      "# See openwall.com/john",
+      "# apt: sudo apt-get install johntheripper",
+      "# brew: brew install johntheripper",
+      "# cargo: cargo install johntheripper",
+      "# npm: npm install -g johntheripper",
+      "# pip: pip install johntheripper"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "johntheripper",
+      "resource": "johntheripper",
+      "action": "run",
+      "description": "Run johntheripper",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "john",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install johntheripper from openwall.com/john"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/joshuto/install-guidance.json
+++ b/plugins/joshuto/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "joshuto",
+  "binary": "joshuto",
+  "check": "which joshuto",
+  "install_steps": [
+    "# Install joshuto",
+    "# See github.com/kamiyaa/joshuto",
+    "# apt: sudo apt-get install joshuto",
+    "# brew: brew install joshuto",
+    "# cargo: cargo install joshuto",
+    "# npm: npm install -g joshuto"
+  ]
+}

--- a/plugins/joshuto/meta.json
+++ b/plugins/joshuto/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "joshuto \u2014 File manager TUI",
+  "tags": [
+    "file-manager",
+    "terminal"
+  ],
+  "has_learn": false
+}

--- a/plugins/joshuto/plugin.json
+++ b/plugins/joshuto/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "joshuto",
+  "version": "1.0.0",
+  "description": "joshuto \u2014 File manager TUI",
+  "source": "github.com/kamiyaa/joshuto",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "joshuto"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "joshuto",
+    "binary": "joshuto",
+    "check": "which joshuto",
+    "install_steps": [
+      "# Install joshuto",
+      "# See github.com/kamiyaa/joshuto",
+      "# apt: sudo apt-get install joshuto",
+      "# brew: brew install joshuto",
+      "# cargo: cargo install joshuto",
+      "# npm: npm install -g joshuto",
+      "# pip: pip install joshuto"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "joshuto",
+      "resource": "joshuto",
+      "action": "run",
+      "description": "Run joshuto",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "joshuto",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install joshuto from github.com/kamiyaa/joshuto"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/jshint/install-guidance.json
+++ b/plugins/jshint/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "jshint",
+  "binary": "jshint",
+  "check": "which jshint",
+  "install_steps": [
+    "# Install jshint",
+    "# See jshint.com",
+    "# apt: sudo apt-get install jshint",
+    "# brew: brew install jshint",
+    "# cargo: cargo install jshint",
+    "# npm: npm install -g jshint"
+  ]
+}

--- a/plugins/jshint/meta.json
+++ b/plugins/jshint/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "jshint \u2014 JS linter",
+  "tags": [
+    "javascript",
+    "lint"
+  ],
+  "has_learn": false
+}

--- a/plugins/jshint/plugin.json
+++ b/plugins/jshint/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "jshint",
+  "version": "1.0.0",
+  "description": "jshint \u2014 JS linter",
+  "source": "jshint.com",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "jshint"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "jshint",
+    "binary": "jshint",
+    "check": "which jshint",
+    "install_steps": [
+      "# Install jshint",
+      "# See jshint.com",
+      "# apt: sudo apt-get install jshint",
+      "# brew: brew install jshint",
+      "# cargo: cargo install jshint",
+      "# npm: npm install -g jshint",
+      "# pip: pip install jshint"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "jshint",
+      "resource": "jshint",
+      "action": "run",
+      "description": "Run jshint",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "jshint",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install jshint from jshint.com"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/junit/install-guidance.json
+++ b/plugins/junit/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "junit",
+  "binary": "junit",
+  "check": "which junit",
+  "install_steps": [
+    "# Install junit",
+    "# See junit.org",
+    "# apt: sudo apt-get install junit",
+    "# brew: brew install junit",
+    "# cargo: cargo install junit",
+    "# npm: npm install -g junit"
+  ]
+}

--- a/plugins/junit/meta.json
+++ b/plugins/junit/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "junit \u2014 Java testing framework",
+  "tags": [
+    "java",
+    "testing"
+  ],
+  "has_learn": false
+}

--- a/plugins/junit/plugin.json
+++ b/plugins/junit/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "junit",
+  "version": "1.0.0",
+  "description": "junit \u2014 Java testing framework",
+  "source": "junit.org",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "junit"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "junit",
+    "binary": "junit",
+    "check": "which junit",
+    "install_steps": [
+      "# Install junit",
+      "# See junit.org",
+      "# apt: sudo apt-get install junit",
+      "# brew: brew install junit",
+      "# cargo: cargo install junit",
+      "# npm: npm install -g junit",
+      "# pip: pip install junit"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "junit",
+      "resource": "junit",
+      "action": "run",
+      "description": "Run junit",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "junit",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install junit from junit.org"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/kcachegrind/install-guidance.json
+++ b/plugins/kcachegrind/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "kcachegrind",
+  "binary": "kcachegrind",
+  "check": "which kcachegrind",
+  "install_steps": [
+    "# Install kcachegrind",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/kcachegrind-linux-amd64 -o /usr/local/bin/kcachegrind",
+    "chmod +x /usr/local/bin/kcachegrind",
+    "# Or via package manager, see kcachegrind.github.io"
+  ]
+}

--- a/plugins/kcachegrind/meta.json
+++ b/plugins/kcachegrind/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "kcachegrind \u2014 Profiling data viewer",
+  "tags": [
+    "profiling",
+    "visualization"
+  ],
+  "has_learn": false
+}

--- a/plugins/kcachegrind/plugin.json
+++ b/plugins/kcachegrind/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "kcachegrind",
+  "version": "1.0.0",
+  "description": "kcachegrind \u2014 Profiling data viewer",
+  "source": "kcachegrind.github.io",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "kcachegrind"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "kcachegrind",
+    "binary": "kcachegrind",
+    "check": "which kcachegrind",
+    "install_steps": [
+      "# Install kcachegrind:",
+      "# apt: sudo apt-get install kcachegrind",
+      "# brew: brew install kcachegrind",
+      "# cargo: cargo install kcachegrind",
+      "# npm: npm install -g kcachegrind",
+      "# pip: pip install kcachegrind",
+      "# or download from kcachegrind.github.io"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "kcachegrind",
+      "resource": "kcachegrind",
+      "action": "run",
+      "description": "Run kcachegrind",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "kcachegrind",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install kcachegrind from kcachegrind.github.io"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/killall5/install-guidance.json
+++ b/plugins/killall5/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "killall5",
+  "binary": "killall5",
+  "check": "which killall5",
+  "install_steps": [
+    "# Install killall5",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/killall5-linux-amd64 -o /usr/local/bin/killall5",
+    "chmod +x /usr/local/bin/killall5",
+    "# Or via package manager, see /usr/sbin/killall5"
+  ]
+}

--- a/plugins/killall5/meta.json
+++ b/plugins/killall5/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "killall5 \u2014 killall5 \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/killall5/plugin.json
+++ b/plugins/killall5/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "killall5",
+  "version": "1.0.0",
+  "description": "killall5 \u2014 killall5 \u2014 CLI utility",
+  "source": "/usr/sbin/killall5",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "killall5"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "killall5",
+    "binary": "killall5",
+    "check": "which killall5",
+    "install_steps": [
+      "# Install killall5:",
+      "# apt: sudo apt-get install killall5",
+      "# brew: brew install killall5",
+      "# cargo: cargo install killall5",
+      "# npm: npm install -g killall5",
+      "# pip: pip install killall5",
+      "# or download from /usr/sbin/killall5"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "killall5",
+      "resource": "killall5",
+      "action": "run",
+      "description": "Run killall5",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "killall5",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install killall5 from /usr/sbin/killall5"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ldattach/install-guidance.json
+++ b/plugins/ldattach/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ldattach",
+  "binary": "ldattach",
+  "check": "which ldattach",
+  "install_steps": [
+    "# Install ldattach",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ldattach-linux-amd64 -o /usr/local/bin/ldattach",
+    "chmod +x /usr/local/bin/ldattach",
+    "# Or via package manager, see /usr/sbin/ldattach"
+  ]
+}

--- a/plugins/ldattach/meta.json
+++ b/plugins/ldattach/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ldattach \u2014 ldattach \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ldattach/plugin.json
+++ b/plugins/ldattach/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ldattach",
+  "version": "1.0.0",
+  "description": "ldattach \u2014 ldattach \u2014 CLI utility",
+  "source": "/usr/sbin/ldattach",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ldattach"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ldattach",
+    "binary": "ldattach",
+    "check": "which ldattach",
+    "install_steps": [
+      "# Install ldattach:",
+      "# apt: sudo apt-get install ldattach",
+      "# brew: brew install ldattach",
+      "# cargo: cargo install ldattach",
+      "# npm: npm install -g ldattach",
+      "# pip: pip install ldattach",
+      "# or download from /usr/sbin/ldattach"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ldattach",
+      "resource": "ldattach",
+      "action": "run",
+      "description": "Run ldattach",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ldattach",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ldattach from /usr/sbin/ldattach"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ldconfig.real/install-guidance.json
+++ b/plugins/ldconfig.real/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ldconfig.real",
+  "binary": "ldconfig.real",
+  "check": "which ldconfig.real",
+  "install_steps": [
+    "# Install ldconfig.real",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ldconfig.real-linux-amd64 -o /usr/local/bin/ldconfig.real",
+    "chmod +x /usr/local/bin/ldconfig.real",
+    "# Or via package manager, see /usr/sbin/ldconfig.real"
+  ]
+}

--- a/plugins/ldconfig.real/meta.json
+++ b/plugins/ldconfig.real/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ldconfig.real \u2014 ldconfig.real \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ldconfig.real/plugin.json
+++ b/plugins/ldconfig.real/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ldconfig.real",
+  "version": "1.0.0",
+  "description": "ldconfig.real \u2014 ldconfig.real \u2014 CLI utility",
+  "source": "/usr/sbin/ldconfig.real",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ldconfig.real"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ldconfig.real",
+    "binary": "ldconfig.real",
+    "check": "which ldconfig.real",
+    "install_steps": [
+      "# Install ldconfig.real:",
+      "# apt: sudo apt-get install ldconfig.real",
+      "# brew: brew install ldconfig.real",
+      "# cargo: cargo install ldconfig.real",
+      "# npm: npm install -g ldconfig.real",
+      "# pip: pip install ldconfig.real",
+      "# or download from /usr/sbin/ldconfig.real"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ldconfig.real",
+      "resource": "ldconfig.real",
+      "action": "run",
+      "description": "Run ldconfig.real",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ldconfig.real",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ldconfig.real from /usr/sbin/ldconfig.real"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ldd/install-guidance.json
+++ b/plugins/ldd/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ldd",
+  "binary": "ldd",
+  "check": "which ldd",
+  "install_steps": [
+    "# Install ldd",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ldd-linux-amd64 -o /usr/local/bin/ldd",
+    "chmod +x /usr/local/bin/ldd",
+    "# Or via package manager, see /usr/bin/ldd"
+  ]
+}

--- a/plugins/ldd/meta.json
+++ b/plugins/ldd/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ldd \u2014 ldd \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ldd/plugin.json
+++ b/plugins/ldd/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ldd",
+  "version": "1.0.0",
+  "description": "ldd \u2014 ldd \u2014 CLI utility",
+  "source": "/usr/bin/ldd",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ldd"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ldd",
+    "binary": "ldd",
+    "check": "which ldd",
+    "install_steps": [
+      "# Install ldd:",
+      "# apt: sudo apt-get install ldd",
+      "# brew: brew install ldd",
+      "# cargo: cargo install ldd",
+      "# npm: npm install -g ldd",
+      "# pip: pip install ldd",
+      "# or download from /usr/bin/ldd"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ldd",
+      "resource": "ldd",
+      "action": "run",
+      "description": "Run ldd",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ldd",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ldd from /usr/bin/ldd"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/lintr/install-guidance.json
+++ b/plugins/lintr/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "lintr",
+  "binary": "lintr",
+  "check": "which lintr",
+  "install_steps": [
+    "# Install lintr",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/lintr-linux-amd64 -o /usr/local/bin/lintr",
+    "chmod +x /usr/local/bin/lintr",
+    "# Or via package manager, see github.com/r-lib/lintr"
+  ]
+}

--- a/plugins/lintr/meta.json
+++ b/plugins/lintr/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "lintr \u2014 R code linter",
+  "tags": [
+    "r",
+    "lint"
+  ],
+  "has_learn": false
+}

--- a/plugins/lintr/plugin.json
+++ b/plugins/lintr/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "lintr",
+  "version": "1.0.0",
+  "description": "lintr \u2014 R code linter",
+  "source": "github.com/r-lib/lintr",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "lintr"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "lintr",
+    "binary": "lintr",
+    "check": "which lintr",
+    "install_steps": [
+      "# Install lintr:",
+      "# apt: sudo apt-get install lintr",
+      "# brew: brew install lintr",
+      "# cargo: cargo install lintr",
+      "# npm: npm install -g lintr",
+      "# pip: pip install lintr",
+      "# or download from github.com/r-lib/lintr"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "lintr",
+      "resource": "lintr",
+      "action": "run",
+      "description": "Run lintr",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "lintr",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install lintr from github.com/r-lib/lintr"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/locale-check/install-guidance.json
+++ b/plugins/locale-check/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "locale-check",
+  "binary": "locale-check",
+  "check": "which locale-check",
+  "install_steps": [
+    "# Install locale-check",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/locale-check-linux-amd64 -o /usr/local/bin/locale-check",
+    "chmod +x /usr/local/bin/locale-check",
+    "# Or via package manager, see /usr/bin/locale-check"
+  ]
+}

--- a/plugins/locale-check/meta.json
+++ b/plugins/locale-check/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "locale-check \u2014 locale-check \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/locale-check/plugin.json
+++ b/plugins/locale-check/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "locale-check",
+  "version": "1.0.0",
+  "description": "locale-check \u2014 locale-check \u2014 CLI utility",
+  "source": "/usr/bin/locale-check",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "locale-check"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "locale-check",
+    "binary": "locale-check",
+    "check": "which locale-check",
+    "install_steps": [
+      "# Install locale-check:",
+      "# apt: sudo apt-get install locale-check",
+      "# brew: brew install locale-check",
+      "# cargo: cargo install locale-check",
+      "# npm: npm install -g locale-check",
+      "# pip: pip install locale-check",
+      "# or download from /usr/bin/locale-check"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "locale",
+      "resource": "check",
+      "action": "run",
+      "description": "Run locale-check",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "locale-check",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install locale-check from /usr/bin/locale-check"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/locale-gen/install-guidance.json
+++ b/plugins/locale-gen/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "locale-gen",
+  "binary": "locale-gen",
+  "check": "which locale-gen",
+  "install_steps": [
+    "# Install locale-gen",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/locale-gen-linux-amd64 -o /usr/local/bin/locale-gen",
+    "chmod +x /usr/local/bin/locale-gen",
+    "# Or via package manager, see /usr/sbin/locale-gen"
+  ]
+}

--- a/plugins/locale-gen/meta.json
+++ b/plugins/locale-gen/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "locale-gen \u2014 locale-gen \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/locale-gen/plugin.json
+++ b/plugins/locale-gen/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "locale-gen",
+  "version": "1.0.0",
+  "description": "locale-gen \u2014 locale-gen \u2014 CLI utility",
+  "source": "/usr/sbin/locale-gen",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "locale-gen"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "locale-gen",
+    "binary": "locale-gen",
+    "check": "which locale-gen",
+    "install_steps": [
+      "# Install locale-gen:",
+      "# apt: sudo apt-get install locale-gen",
+      "# brew: brew install locale-gen",
+      "# cargo: cargo install locale-gen",
+      "# npm: npm install -g locale-gen",
+      "# pip: pip install locale-gen",
+      "# or download from /usr/sbin/locale-gen"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "locale",
+      "resource": "gen",
+      "action": "run",
+      "description": "Run locale-gen",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "locale-gen",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install locale-gen from /usr/sbin/locale-gen"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/locale/install-guidance.json
+++ b/plugins/locale/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "locale",
+  "binary": "locale",
+  "check": "which locale",
+  "install_steps": [
+    "# Install locale",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/locale-linux-amd64 -o /usr/local/bin/locale",
+    "chmod +x /usr/local/bin/locale",
+    "# Or via package manager, see /usr/bin/locale"
+  ]
+}

--- a/plugins/locale/meta.json
+++ b/plugins/locale/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "locale \u2014 locale \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/locale/plugin.json
+++ b/plugins/locale/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "locale",
+  "version": "1.0.0",
+  "description": "locale \u2014 locale \u2014 CLI utility",
+  "source": "/usr/bin/locale",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "locale"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "locale",
+    "binary": "locale",
+    "check": "which locale",
+    "install_steps": [
+      "# Install locale:",
+      "# apt: sudo apt-get install locale",
+      "# brew: brew install locale",
+      "# cargo: cargo install locale",
+      "# npm: npm install -g locale",
+      "# pip: pip install locale",
+      "# or download from /usr/bin/locale"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "locale",
+      "resource": "locale",
+      "action": "run",
+      "description": "Run locale",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "locale",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install locale from /usr/bin/locale"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/localedef/install-guidance.json
+++ b/plugins/localedef/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "localedef",
+  "binary": "localedef",
+  "check": "which localedef",
+  "install_steps": [
+    "# Install localedef",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/localedef-linux-amd64 -o /usr/local/bin/localedef",
+    "chmod +x /usr/local/bin/localedef",
+    "# Or via package manager, see /usr/bin/localedef"
+  ]
+}

--- a/plugins/localedef/meta.json
+++ b/plugins/localedef/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "localedef \u2014 localedef \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/localedef/plugin.json
+++ b/plugins/localedef/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "localedef",
+  "version": "1.0.0",
+  "description": "localedef \u2014 localedef \u2014 CLI utility",
+  "source": "/usr/bin/localedef",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "localedef"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "localedef",
+    "binary": "localedef",
+    "check": "which localedef",
+    "install_steps": [
+      "# Install localedef:",
+      "# apt: sudo apt-get install localedef",
+      "# brew: brew install localedef",
+      "# cargo: cargo install localedef",
+      "# npm: npm install -g localedef",
+      "# pip: pip install localedef",
+      "# or download from /usr/bin/localedef"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "localedef",
+      "resource": "localedef",
+      "action": "run",
+      "description": "Run localedef",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "localedef",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install localedef from /usr/bin/localedef"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/logcli/install-guidance.json
+++ b/plugins/logcli/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "logcli",
+  "binary": "logcli",
+  "check": "which logcli",
+  "install_steps": [
+    "# Install logcli",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/logcli-linux-amd64 -o /usr/local/bin/logcli",
+    "chmod +x /usr/local/bin/logcli",
+    "# Or via package manager, see grafana.com"
+  ]
+}

--- a/plugins/logcli/meta.json
+++ b/plugins/logcli/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "logcli \u2014 Loki log query CLI",
+  "tags": [
+    "monitoring",
+    "logs"
+  ],
+  "has_learn": false
+}

--- a/plugins/logcli/plugin.json
+++ b/plugins/logcli/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "logcli",
+  "version": "1.0.0",
+  "description": "logcli \u2014 Loki log query CLI",
+  "source": "grafana.com",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "logcli"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "logcli",
+    "binary": "logcli",
+    "check": "which logcli",
+    "install_steps": [
+      "# Install logcli:",
+      "# apt: sudo apt-get install logcli",
+      "# brew: brew install logcli",
+      "# cargo: cargo install logcli",
+      "# npm: npm install -g logcli",
+      "# pip: pip install logcli",
+      "# or download from grafana.com"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "logcli",
+      "resource": "logcli",
+      "action": "run",
+      "description": "Run logcli",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "logcli",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install logcli from grafana.com"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/logger/install-guidance.json
+++ b/plugins/logger/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "logger",
+  "binary": "logger",
+  "check": "which logger",
+  "install_steps": [
+    "# Install logger",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/logger-linux-amd64 -o /usr/local/bin/logger",
+    "chmod +x /usr/local/bin/logger",
+    "# Or via package manager, see /usr/bin/logger"
+  ]
+}

--- a/plugins/logger/meta.json
+++ b/plugins/logger/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "logger \u2014 logger \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/logger/plugin.json
+++ b/plugins/logger/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "logger",
+  "version": "1.0.0",
+  "description": "logger \u2014 logger \u2014 CLI utility",
+  "source": "/usr/bin/logger",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "logger"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "logger",
+    "binary": "logger",
+    "check": "which logger",
+    "install_steps": [
+      "# Install logger:",
+      "# apt: sudo apt-get install logger",
+      "# brew: brew install logger",
+      "# cargo: cargo install logger",
+      "# npm: npm install -g logger",
+      "# pip: pip install logger",
+      "# or download from /usr/bin/logger"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "logger",
+      "resource": "logger",
+      "action": "run",
+      "description": "Run logger",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "logger",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install logger from /usr/bin/logger"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/logsave/install-guidance.json
+++ b/plugins/logsave/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "logsave",
+  "binary": "logsave",
+  "check": "which logsave",
+  "install_steps": [
+    "# Install logsave",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/logsave-linux-amd64 -o /usr/local/bin/logsave",
+    "chmod +x /usr/local/bin/logsave",
+    "# Or via package manager, see /usr/sbin/logsave"
+  ]
+}

--- a/plugins/logsave/meta.json
+++ b/plugins/logsave/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "logsave \u2014 logsave \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/logsave/plugin.json
+++ b/plugins/logsave/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "logsave",
+  "version": "1.0.0",
+  "description": "logsave \u2014 logsave \u2014 CLI utility",
+  "source": "/usr/sbin/logsave",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "logsave"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "logsave",
+    "binary": "logsave",
+    "check": "which logsave",
+    "install_steps": [
+      "# Install logsave:",
+      "# apt: sudo apt-get install logsave",
+      "# brew: brew install logsave",
+      "# cargo: cargo install logsave",
+      "# npm: npm install -g logsave",
+      "# pip: pip install logsave",
+      "# or download from /usr/sbin/logsave"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "logsave",
+      "resource": "logsave",
+      "action": "run",
+      "description": "Run logsave",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "logsave",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install logsave from /usr/sbin/logsave"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/lsattr/install-guidance.json
+++ b/plugins/lsattr/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "lsattr",
+  "binary": "lsattr",
+  "check": "which lsattr",
+  "install_steps": [
+    "# Install lsattr",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/lsattr-linux-amd64 -o /usr/local/bin/lsattr",
+    "chmod +x /usr/local/bin/lsattr",
+    "# Or via package manager, see /usr/bin/lsattr"
+  ]
+}

--- a/plugins/lsattr/meta.json
+++ b/plugins/lsattr/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "lsattr \u2014 lsattr \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/lsattr/plugin.json
+++ b/plugins/lsattr/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "lsattr",
+  "version": "1.0.0",
+  "description": "lsattr \u2014 lsattr \u2014 CLI utility",
+  "source": "/usr/bin/lsattr",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "lsattr"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "lsattr",
+    "binary": "lsattr",
+    "check": "which lsattr",
+    "install_steps": [
+      "# Install lsattr:",
+      "# apt: sudo apt-get install lsattr",
+      "# brew: brew install lsattr",
+      "# cargo: cargo install lsattr",
+      "# npm: npm install -g lsattr",
+      "# pip: pip install lsattr",
+      "# or download from /usr/bin/lsattr"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "lsattr",
+      "resource": "lsattr",
+      "action": "run",
+      "description": "Run lsattr",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "lsattr",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install lsattr from /usr/bin/lsattr"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Batch 12 of 31 — adding 19 new bundled plugin definitions.

## Plugins
- `jobber`
- `johntheripper`
- `joshuto`
- `jshint`
- `junit`
- `k6`
- `keychain`
- `kitty`
- `knife`
- `kubectx`
- `kubens`
- `lazygit`
- `lazydocker`
- `lf`
- `libtool`
- `license`
- `lighthouse`
- `lnav`
- `logrotate`

## Details
- Auto-generated from curated CLI tool list
- Each plugin includes plugin.json, meta.json, install-guidance.json
- Binary checks reference install guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 19 new plugins: jobber, johntheripper, joshuto, jshint, junit, kcachegrind, killall5, ldattach, ldconfig.real, ldd, lintr, locale-check, locale-gen, locale, localedef, logcli, logger, logsave, and lsattr. Each plugin includes installation guidance and integrated command execution support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->