### PR TITLE
feat: add 20 bundled plugins (batch 013/31)

### DIFF
--- a/plugins/lsb_release/install-guidance.json
+++ b/plugins/lsb_release/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "lsb_release",
+  "binary": "lsb_release",
+  "check": "which lsb_release",
+  "install_steps": [
+    "# Install lsb_release",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/lsb_release-linux-amd64 -o /usr/local/bin/lsb_release",
+    "chmod +x /usr/local/bin/lsb_release",
+    "# Or via package manager, see /usr/bin/lsb_release"
+  ]
+}

--- a/plugins/lsb_release/meta.json
+++ b/plugins/lsb_release/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "lsb_release \u2014 lsb_release \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/lsb_release/plugin.json
+++ b/plugins/lsb_release/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "lsb-release",
+  "version": "1.0.0",
+  "description": "lsb-release \u2014 lsb_release \u2014 CLI utility",
+  "source": "/usr/bin/lsb_release",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "lsb_release"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "lsb-release",
+    "binary": "lsb_release",
+    "check": "which lsb_release",
+    "install_steps": [
+      "# Install lsb-release:",
+      "# apt: sudo apt-get install lsb-release",
+      "# brew: brew install lsb-release",
+      "# cargo: cargo install lsb-release",
+      "# npm: npm install -g lsb-release",
+      "# pip: pip install lsb-release",
+      "# or download from /usr/bin/lsb_release"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "lsb",
+      "resource": "release",
+      "action": "run",
+      "description": "Run lsb-release",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "lsb_release",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install lsb-release from /usr/bin/lsb_release"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/lslogins/install-guidance.json
+++ b/plugins/lslogins/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "lslogins",
+  "binary": "lslogins",
+  "check": "which lslogins",
+  "install_steps": [
+    "# Install lslogins",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/lslogins-linux-amd64 -o /usr/local/bin/lslogins",
+    "chmod +x /usr/local/bin/lslogins",
+    "# Or via package manager, see /usr/bin/lslogins"
+  ]
+}

--- a/plugins/lslogins/meta.json
+++ b/plugins/lslogins/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "lslogins \u2014 lslogins \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/lslogins/plugin.json
+++ b/plugins/lslogins/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "lslogins",
+  "version": "1.0.0",
+  "description": "lslogins \u2014 lslogins \u2014 CLI utility",
+  "source": "/usr/bin/lslogins",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "lslogins"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "lslogins",
+    "binary": "lslogins",
+    "check": "which lslogins",
+    "install_steps": [
+      "# Install lslogins:",
+      "# apt: sudo apt-get install lslogins",
+      "# brew: brew install lslogins",
+      "# cargo: cargo install lslogins",
+      "# npm: npm install -g lslogins",
+      "# pip: pip install lslogins",
+      "# or download from /usr/bin/lslogins"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "lslogins",
+      "resource": "lslogins",
+      "action": "run",
+      "description": "Run lslogins",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "lslogins",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install lslogins from /usr/bin/lslogins"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/m-cli/install-guidance.json
+++ b/plugins/m-cli/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "m-cli",
+  "binary": "m-cli",
+  "check": "which m-cli",
+  "install_steps": [
+    "# Install m-cli",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/m-cli-linux-amd64 -o /usr/local/bin/m-cli",
+    "chmod +x /usr/local/bin/m-cli",
+    "# Or via package manager, see github.com/rgcr/m-cli"
+  ]
+}

--- a/plugins/m-cli/meta.json
+++ b/plugins/m-cli/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "m-cli \u2014 macOS CLI tools",
+  "tags": [
+    "macos",
+    "utility"
+  ],
+  "has_learn": false
+}

--- a/plugins/m-cli/plugin.json
+++ b/plugins/m-cli/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "m-cli",
+  "version": "1.0.0",
+  "description": "m-cli \u2014 macOS CLI tools",
+  "source": "github.com/rgcr/m-cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "m-cli"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "m-cli",
+    "binary": "m-cli",
+    "check": "which m-cli",
+    "install_steps": [
+      "# Install m-cli:",
+      "# apt: sudo apt-get install m-cli",
+      "# brew: brew install m-cli",
+      "# cargo: cargo install m-cli",
+      "# npm: npm install -g m-cli",
+      "# pip: pip install m-cli",
+      "# or download from github.com/rgcr/m-cli"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "m",
+      "resource": "cli",
+      "action": "run",
+      "description": "Run m-cli",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "m-cli",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install m-cli from github.com/rgcr/m-cli"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/man/install-guidance.json
+++ b/plugins/man/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "man",
+  "binary": "man",
+  "check": "which man",
+  "install_steps": [
+    "# Install man",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/man-linux-amd64 -o /usr/local/bin/man",
+    "chmod +x /usr/local/bin/man",
+    "# Or via package manager, see /usr/bin/man"
+  ]
+}

--- a/plugins/man/meta.json
+++ b/plugins/man/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "man \u2014 man \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/man/plugin.json
+++ b/plugins/man/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "man",
+  "version": "1.0.0",
+  "description": "man \u2014 man \u2014 CLI utility",
+  "source": "/usr/bin/man",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "man"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "man",
+    "binary": "man",
+    "check": "which man",
+    "install_steps": [
+      "# Install man:",
+      "# apt: sudo apt-get install man",
+      "# brew: brew install man",
+      "# cargo: cargo install man",
+      "# npm: npm install -g man",
+      "# pip: pip install man",
+      "# or download from /usr/bin/man"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "man",
+      "resource": "man",
+      "action": "run",
+      "description": "Run man",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "man",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install man from /usr/bin/man"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mergerfs/install-guidance.json
+++ b/plugins/mergerfs/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mergerfs",
+  "binary": "mergerfs",
+  "check": "which mergerfs",
+  "install_steps": [
+    "# Install mergerfs",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mergerfs-linux-amd64 -o /usr/local/bin/mergerfs",
+    "chmod +x /usr/local/bin/mergerfs",
+    "# Or via package manager, see github.com/trapexit/mergerfs"
+  ]
+}

--- a/plugins/mergerfs/meta.json
+++ b/plugins/mergerfs/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mergerfs \u2014 Union filesystem",
+  "tags": [
+    "utility",
+    "filesystem"
+  ],
+  "has_learn": false
+}

--- a/plugins/mergerfs/plugin.json
+++ b/plugins/mergerfs/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mergerfs",
+  "version": "1.0.0",
+  "description": "mergerfs \u2014 Union filesystem",
+  "source": "github.com/trapexit/mergerfs",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mergerfs"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mergerfs",
+    "binary": "mergerfs",
+    "check": "which mergerfs",
+    "install_steps": [
+      "# Install mergerfs:",
+      "# apt: sudo apt-get install mergerfs",
+      "# brew: brew install mergerfs",
+      "# cargo: cargo install mergerfs",
+      "# npm: npm install -g mergerfs",
+      "# pip: pip install mergerfs",
+      "# or download from github.com/trapexit/mergerfs"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mergerfs",
+      "resource": "mergerfs",
+      "action": "run",
+      "description": "Run mergerfs",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mergerfs",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mergerfs from github.com/trapexit/mergerfs"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mk_modmap/install-guidance.json
+++ b/plugins/mk_modmap/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mk_modmap",
+  "binary": "mk_modmap",
+  "check": "which mk_modmap",
+  "install_steps": [
+    "# Install mk_modmap",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mk_modmap-linux-amd64 -o /usr/local/bin/mk_modmap",
+    "chmod +x /usr/local/bin/mk_modmap",
+    "# Or via package manager, see /usr/bin/mk_modmap"
+  ]
+}

--- a/plugins/mk_modmap/meta.json
+++ b/plugins/mk_modmap/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mk_modmap \u2014 mk_modmap \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/mk_modmap/plugin.json
+++ b/plugins/mk_modmap/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mk-modmap",
+  "version": "1.0.0",
+  "description": "mk-modmap \u2014 mk_modmap \u2014 CLI utility",
+  "source": "/usr/bin/mk_modmap",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mk_modmap"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mk-modmap",
+    "binary": "mk_modmap",
+    "check": "which mk_modmap",
+    "install_steps": [
+      "# Install mk-modmap:",
+      "# apt: sudo apt-get install mk-modmap",
+      "# brew: brew install mk-modmap",
+      "# cargo: cargo install mk-modmap",
+      "# npm: npm install -g mk-modmap",
+      "# pip: pip install mk-modmap",
+      "# or download from /usr/bin/mk_modmap"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mk",
+      "resource": "modmap",
+      "action": "run",
+      "description": "Run mk-modmap",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mk_modmap",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mk-modmap from /usr/bin/mk_modmap"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mkdosfs/install-guidance.json
+++ b/plugins/mkdosfs/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mkdosfs",
+  "binary": "mkdosfs",
+  "check": "which mkdosfs",
+  "install_steps": [
+    "# Install mkdosfs",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mkdosfs-linux-amd64 -o /usr/local/bin/mkdosfs",
+    "chmod +x /usr/local/bin/mkdosfs",
+    "# Or via package manager, see /usr/sbin/mkdosfs"
+  ]
+}

--- a/plugins/mkdosfs/meta.json
+++ b/plugins/mkdosfs/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mkdosfs \u2014 mkdosfs \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/mkdosfs/plugin.json
+++ b/plugins/mkdosfs/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mkdosfs",
+  "version": "1.0.0",
+  "description": "mkdosfs \u2014 mkdosfs \u2014 CLI utility",
+  "source": "/usr/sbin/mkdosfs",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mkdosfs"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mkdosfs",
+    "binary": "mkdosfs",
+    "check": "which mkdosfs",
+    "install_steps": [
+      "# Install mkdosfs:",
+      "# apt: sudo apt-get install mkdosfs",
+      "# brew: brew install mkdosfs",
+      "# cargo: cargo install mkdosfs",
+      "# npm: npm install -g mkdosfs",
+      "# pip: pip install mkdosfs",
+      "# or download from /usr/sbin/mkdosfs"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mkdosfs",
+      "resource": "mkdosfs",
+      "action": "run",
+      "description": "Run mkdosfs",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mkdosfs",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mkdosfs from /usr/sbin/mkdosfs"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mke2fs/install-guidance.json
+++ b/plugins/mke2fs/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mke2fs",
+  "binary": "mke2fs",
+  "check": "which mke2fs",
+  "install_steps": [
+    "# Install mke2fs",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mke2fs-linux-amd64 -o /usr/local/bin/mke2fs",
+    "chmod +x /usr/local/bin/mke2fs",
+    "# Or via package manager, see /usr/sbin/mke2fs"
+  ]
+}

--- a/plugins/mke2fs/meta.json
+++ b/plugins/mke2fs/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mke2fs \u2014 mke2fs \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/mke2fs/plugin.json
+++ b/plugins/mke2fs/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mke2fs",
+  "version": "1.0.0",
+  "description": "mke2fs \u2014 mke2fs \u2014 CLI utility",
+  "source": "/usr/sbin/mke2fs",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mke2fs"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mke2fs",
+    "binary": "mke2fs",
+    "check": "which mke2fs",
+    "install_steps": [
+      "# Install mke2fs:",
+      "# apt: sudo apt-get install mke2fs",
+      "# brew: brew install mke2fs",
+      "# cargo: cargo install mke2fs",
+      "# npm: npm install -g mke2fs",
+      "# pip: pip install mke2fs",
+      "# or download from /usr/sbin/mke2fs"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mke2fs",
+      "resource": "mke2fs",
+      "action": "run",
+      "description": "Run mke2fs",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mke2fs",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mke2fs from /usr/sbin/mke2fs"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mkfifo/install-guidance.json
+++ b/plugins/mkfifo/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mkfifo",
+  "binary": "mkfifo",
+  "check": "which mkfifo",
+  "install_steps": [
+    "# Install mkfifo",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mkfifo-linux-amd64 -o /usr/local/bin/mkfifo",
+    "chmod +x /usr/local/bin/mkfifo",
+    "# Or via package manager, see /usr/bin/mkfifo"
+  ]
+}

--- a/plugins/mkfifo/meta.json
+++ b/plugins/mkfifo/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mkfifo \u2014 mkfifo \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/mkfifo/plugin.json
+++ b/plugins/mkfifo/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mkfifo",
+  "version": "1.0.0",
+  "description": "mkfifo \u2014 mkfifo \u2014 CLI utility",
+  "source": "/usr/bin/mkfifo",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mkfifo"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mkfifo",
+    "binary": "mkfifo",
+    "check": "which mkfifo",
+    "install_steps": [
+      "# Install mkfifo:",
+      "# apt: sudo apt-get install mkfifo",
+      "# brew: brew install mkfifo",
+      "# cargo: cargo install mkfifo",
+      "# npm: npm install -g mkfifo",
+      "# pip: pip install mkfifo",
+      "# or download from /usr/bin/mkfifo"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mkfifo",
+      "resource": "mkfifo",
+      "action": "run",
+      "description": "Run mkfifo",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mkfifo",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mkfifo from /usr/bin/mkfifo"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mkfontscale/install-guidance.json
+++ b/plugins/mkfontscale/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mkfontscale",
+  "binary": "mkfontscale",
+  "check": "which mkfontscale",
+  "install_steps": [
+    "# Install mkfontscale",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mkfontscale-linux-amd64 -o /usr/local/bin/mkfontscale",
+    "chmod +x /usr/local/bin/mkfontscale",
+    "# Or via package manager, see /usr/bin/mkfontscale"
+  ]
+}

--- a/plugins/mkfontscale/meta.json
+++ b/plugins/mkfontscale/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mkfontscale \u2014 mkfontscale \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/mkfontscale/plugin.json
+++ b/plugins/mkfontscale/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mkfontscale",
+  "version": "1.0.0",
+  "description": "mkfontscale \u2014 mkfontscale \u2014 CLI utility",
+  "source": "/usr/bin/mkfontscale",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mkfontscale"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mkfontscale",
+    "binary": "mkfontscale",
+    "check": "which mkfontscale",
+    "install_steps": [
+      "# Install mkfontscale:",
+      "# apt: sudo apt-get install mkfontscale",
+      "# brew: brew install mkfontscale",
+      "# cargo: cargo install mkfontscale",
+      "# npm: npm install -g mkfontscale",
+      "# pip: pip install mkfontscale",
+      "# or download from /usr/bin/mkfontscale"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mkfontscale",
+      "resource": "mkfontscale",
+      "action": "run",
+      "description": "Run mkfontscale",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mkfontscale",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mkfontscale from /usr/bin/mkfontscale"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mkhomedir_helper/install-guidance.json
+++ b/plugins/mkhomedir_helper/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mkhomedir_helper",
+  "binary": "mkhomedir_helper",
+  "check": "which mkhomedir_helper",
+  "install_steps": [
+    "# Install mkhomedir_helper",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mkhomedir_helper-linux-amd64 -o /usr/local/bin/mkhomedir_helper",
+    "chmod +x /usr/local/bin/mkhomedir_helper",
+    "# Or via package manager, see /usr/sbin/mkhomedir_helper"
+  ]
+}

--- a/plugins/mkhomedir_helper/meta.json
+++ b/plugins/mkhomedir_helper/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mkhomedir_helper \u2014 mkhomedir_helper \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/mkhomedir_helper/plugin.json
+++ b/plugins/mkhomedir_helper/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mkhomedir-helper",
+  "version": "1.0.0",
+  "description": "mkhomedir-helper \u2014 mkhomedir_helper \u2014 CLI utility",
+  "source": "/usr/sbin/mkhomedir_helper",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mkhomedir_helper"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mkhomedir-helper",
+    "binary": "mkhomedir_helper",
+    "check": "which mkhomedir_helper",
+    "install_steps": [
+      "# Install mkhomedir-helper:",
+      "# apt: sudo apt-get install mkhomedir-helper",
+      "# brew: brew install mkhomedir-helper",
+      "# cargo: cargo install mkhomedir-helper",
+      "# npm: npm install -g mkhomedir-helper",
+      "# pip: pip install mkhomedir-helper",
+      "# or download from /usr/sbin/mkhomedir_helper"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mkhomedir",
+      "resource": "helper",
+      "action": "run",
+      "description": "Run mkhomedir-helper",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mkhomedir_helper",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mkhomedir-helper from /usr/sbin/mkhomedir_helper"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mklost+found/install-guidance.json
+++ b/plugins/mklost+found/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mklost+found",
+  "binary": "mklost+found",
+  "check": "which mklost+found",
+  "install_steps": [
+    "# Install mklost+found",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mklost+found-linux-amd64 -o /usr/local/bin/mklost+found",
+    "chmod +x /usr/local/bin/mklost+found",
+    "# Or via package manager, see /usr/sbin/mklost+found"
+  ]
+}

--- a/plugins/mklost+found/meta.json
+++ b/plugins/mklost+found/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mklost+found \u2014 mklost+found \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/mklost+found/plugin.json
+++ b/plugins/mklost+found/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mklost+found",
+  "version": "1.0.0",
+  "description": "mklost+found \u2014 mklost+found \u2014 CLI utility",
+  "source": "/usr/sbin/mklost+found",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mklost+found"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mklost+found",
+    "binary": "mklost+found",
+    "check": "which mklost+found",
+    "install_steps": [
+      "# Install mklost+found:",
+      "# apt: sudo apt-get install mklost+found",
+      "# brew: brew install mklost+found",
+      "# cargo: cargo install mklost+found",
+      "# npm: npm install -g mklost+found",
+      "# pip: pip install mklost+found",
+      "# or download from /usr/sbin/mklost+found"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mklost+found",
+      "resource": "mklost+found",
+      "action": "run",
+      "description": "Run mklost+found",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mklost+found",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mklost+found from /usr/sbin/mklost+found"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mknod/install-guidance.json
+++ b/plugins/mknod/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mknod",
+  "binary": "mknod",
+  "check": "which mknod",
+  "install_steps": [
+    "# Install mknod",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mknod-linux-amd64 -o /usr/local/bin/mknod",
+    "chmod +x /usr/local/bin/mknod",
+    "# Or via package manager, see /usr/bin/mknod"
+  ]
+}

--- a/plugins/mknod/meta.json
+++ b/plugins/mknod/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mknod \u2014 mknod \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/mknod/plugin.json
+++ b/plugins/mknod/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mknod",
+  "version": "1.0.0",
+  "description": "mknod \u2014 mknod \u2014 CLI utility",
+  "source": "/usr/bin/mknod",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mknod"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mknod",
+    "binary": "mknod",
+    "check": "which mknod",
+    "install_steps": [
+      "# Install mknod:",
+      "# apt: sudo apt-get install mknod",
+      "# brew: brew install mknod",
+      "# cargo: cargo install mknod",
+      "# npm: npm install -g mknod",
+      "# pip: pip install mknod",
+      "# or download from /usr/bin/mknod"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mknod",
+      "resource": "mknod",
+      "action": "run",
+      "description": "Run mknod",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mknod",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mknod from /usr/bin/mknod"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mkntfs/install-guidance.json
+++ b/plugins/mkntfs/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mkntfs",
+  "binary": "mkntfs",
+  "check": "which mkntfs",
+  "install_steps": [
+    "# Install mkntfs",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mkntfs-linux-amd64 -o /usr/local/bin/mkntfs",
+    "chmod +x /usr/local/bin/mkntfs",
+    "# Or via package manager, see /usr/sbin/mkntfs"
+  ]
+}

--- a/plugins/mkntfs/meta.json
+++ b/plugins/mkntfs/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mkntfs \u2014 mkntfs \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/mkntfs/plugin.json
+++ b/plugins/mkntfs/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mkntfs",
+  "version": "1.0.0",
+  "description": "mkntfs \u2014 mkntfs \u2014 CLI utility",
+  "source": "/usr/sbin/mkntfs",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mkntfs"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mkntfs",
+    "binary": "mkntfs",
+    "check": "which mkntfs",
+    "install_steps": [
+      "# Install mkntfs:",
+      "# apt: sudo apt-get install mkntfs",
+      "# brew: brew install mkntfs",
+      "# cargo: cargo install mkntfs",
+      "# npm: npm install -g mkntfs",
+      "# pip: pip install mkntfs",
+      "# or download from /usr/sbin/mkntfs"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mkntfs",
+      "resource": "mkntfs",
+      "action": "run",
+      "description": "Run mkntfs",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mkntfs",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mkntfs from /usr/sbin/mkntfs"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mksquashfs/install-guidance.json
+++ b/plugins/mksquashfs/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mksquashfs",
+  "binary": "mksquashfs",
+  "check": "which mksquashfs",
+  "install_steps": [
+    "# Install mksquashfs",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mksquashfs-linux-amd64 -o /usr/local/bin/mksquashfs",
+    "chmod +x /usr/local/bin/mksquashfs",
+    "# Or via package manager, see /usr/bin/mksquashfs"
+  ]
+}

--- a/plugins/mksquashfs/meta.json
+++ b/plugins/mksquashfs/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mksquashfs \u2014 mksquashfs \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/mksquashfs/plugin.json
+++ b/plugins/mksquashfs/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mksquashfs",
+  "version": "1.0.0",
+  "description": "mksquashfs \u2014 mksquashfs \u2014 CLI utility",
+  "source": "/usr/bin/mksquashfs",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mksquashfs"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mksquashfs",
+    "binary": "mksquashfs",
+    "check": "which mksquashfs",
+    "install_steps": [
+      "# Install mksquashfs:",
+      "# apt: sudo apt-get install mksquashfs",
+      "# brew: brew install mksquashfs",
+      "# cargo: cargo install mksquashfs",
+      "# npm: npm install -g mksquashfs",
+      "# pip: pip install mksquashfs",
+      "# or download from /usr/bin/mksquashfs"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mksquashfs",
+      "resource": "mksquashfs",
+      "action": "run",
+      "description": "Run mksquashfs",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mksquashfs",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mksquashfs from /usr/bin/mksquashfs"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mkswap/install-guidance.json
+++ b/plugins/mkswap/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mkswap",
+  "binary": "mkswap",
+  "check": "which mkswap",
+  "install_steps": [
+    "# Install mkswap",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mkswap-linux-amd64 -o /usr/local/bin/mkswap",
+    "chmod +x /usr/local/bin/mkswap",
+    "# Or via package manager, see /usr/sbin/mkswap"
+  ]
+}

--- a/plugins/mkswap/meta.json
+++ b/plugins/mkswap/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mkswap \u2014 mkswap \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/mkswap/plugin.json
+++ b/plugins/mkswap/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mkswap",
+  "version": "1.0.0",
+  "description": "mkswap \u2014 mkswap \u2014 CLI utility",
+  "source": "/usr/sbin/mkswap",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mkswap"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mkswap",
+    "binary": "mkswap",
+    "check": "which mkswap",
+    "install_steps": [
+      "# Install mkswap:",
+      "# apt: sudo apt-get install mkswap",
+      "# brew: brew install mkswap",
+      "# cargo: cargo install mkswap",
+      "# npm: npm install -g mkswap",
+      "# pip: pip install mkswap",
+      "# or download from /usr/sbin/mkswap"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mkswap",
+      "resource": "mkswap",
+      "action": "run",
+      "description": "Run mkswap",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mkswap",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mkswap from /usr/sbin/mkswap"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mmv/install-guidance.json
+++ b/plugins/mmv/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mmv",
+  "binary": "mmv",
+  "check": "which mmv",
+  "install_steps": [
+    "# Install mmv",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mmv-linux-amd64 -o /usr/local/bin/mmv",
+    "chmod +x /usr/local/bin/mmv",
+    "# Or via package manager, see github.com/itchyny/mmv"
+  ]
+}

--- a/plugins/mmv/meta.json
+++ b/plugins/mmv/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mmv \u2014 Mass file rename",
+  "tags": [
+    "utility",
+    "rename"
+  ],
+  "has_learn": false
+}

--- a/plugins/mmv/plugin.json
+++ b/plugins/mmv/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mmv",
+  "version": "1.0.0",
+  "description": "mmv \u2014 Mass file rename",
+  "source": "github.com/itchyny/mmv",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mmv"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mmv",
+    "binary": "mmv",
+    "check": "which mmv",
+    "install_steps": [
+      "# Install mmv:",
+      "# apt: sudo apt-get install mmv",
+      "# brew: brew install mmv",
+      "# cargo: cargo install mmv",
+      "# npm: npm install -g mmv",
+      "# pip: pip install mmv",
+      "# or download from github.com/itchyny/mmv"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mmv",
+      "resource": "mmv",
+      "action": "run",
+      "description": "Run mmv",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mmv",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mmv from github.com/itchyny/mmv"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/modinfo/install-guidance.json
+++ b/plugins/modinfo/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "modinfo",
+  "binary": "modinfo",
+  "check": "which modinfo",
+  "install_steps": [
+    "# Install modinfo",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/modinfo-linux-amd64 -o /usr/local/bin/modinfo",
+    "chmod +x /usr/local/bin/modinfo",
+    "# Or via package manager, see /usr/sbin/modinfo"
+  ]
+}

--- a/plugins/modinfo/meta.json
+++ b/plugins/modinfo/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "modinfo \u2014 modinfo \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/modinfo/plugin.json
+++ b/plugins/modinfo/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "modinfo",
+  "version": "1.0.0",
+  "description": "modinfo \u2014 modinfo \u2014 CLI utility",
+  "source": "/usr/sbin/modinfo",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "modinfo"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "modinfo",
+    "binary": "modinfo",
+    "check": "which modinfo",
+    "install_steps": [
+      "# Install modinfo:",
+      "# apt: sudo apt-get install modinfo",
+      "# brew: brew install modinfo",
+      "# cargo: cargo install modinfo",
+      "# npm: npm install -g modinfo",
+      "# pip: pip install modinfo",
+      "# or download from /usr/sbin/modinfo"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "modinfo",
+      "resource": "modinfo",
+      "action": "run",
+      "description": "Run modinfo",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "modinfo",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install modinfo from /usr/sbin/modinfo"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mpv/install-guidance.json
+++ b/plugins/mpv/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mpv",
+  "binary": "mpv",
+  "check": "which mpv",
+  "install_steps": [
+    "# Install mpv",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mpv-linux-amd64 -o /usr/local/bin/mpv",
+    "chmod +x /usr/local/bin/mpv",
+    "# Or via package manager, see mpv.io"
+  ]
+}

--- a/plugins/mpv/meta.json
+++ b/plugins/mpv/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mpv \u2014 Media player",
+  "tags": [
+    "media",
+    "player"
+  ],
+  "has_learn": false
+}

--- a/plugins/mpv/plugin.json
+++ b/plugins/mpv/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mpv",
+  "version": "1.0.0",
+  "description": "mpv \u2014 Media player",
+  "source": "mpv.io",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mpv"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mpv",
+    "binary": "mpv",
+    "check": "which mpv",
+    "install_steps": [
+      "# Install mpv:",
+      "# apt: sudo apt-get install mpv",
+      "# brew: brew install mpv",
+      "# cargo: cargo install mpv",
+      "# npm: npm install -g mpv",
+      "# pip: pip install mpv",
+      "# or download from mpv.io"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mpv",
+      "resource": "mpv",
+      "action": "run",
+      "description": "Run mpv",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mpv",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mpv from mpv.io"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mt/install-guidance.json
+++ b/plugins/mt/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "mt",
+  "binary": "mt",
+  "check": "which mt",
+  "install_steps": [
+    "# Install mt",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/mt-linux-amd64 -o /usr/local/bin/mt",
+    "chmod +x /usr/local/bin/mt",
+    "# Or via package manager, see /usr/bin/mt"
+  ]
+}

--- a/plugins/mt/meta.json
+++ b/plugins/mt/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "mt \u2014 mt \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/mt/plugin.json
+++ b/plugins/mt/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mt",
+  "version": "1.0.0",
+  "description": "mt \u2014 mt \u2014 CLI utility",
+  "source": "/usr/bin/mt",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mt"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mt",
+    "binary": "mt",
+    "check": "which mt",
+    "install_steps": [
+      "# Install mt:",
+      "# apt: sudo apt-get install mt",
+      "# brew: brew install mt",
+      "# cargo: cargo install mt",
+      "# npm: npm install -g mt",
+      "# pip: pip install mt",
+      "# or download from /usr/bin/mt"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "mt",
+      "resource": "mt",
+      "action": "run",
+      "description": "Run mt",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mt",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install mt from /usr/bin/mt"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Batch 013 of 31 — adding 20 new bundled plugin definitions.

## Plugins

- 
-   UID USER             PROC PWD-LOCK PWD-DENY LAST-LOGIN GECOS
    0 root               18        0        0      21:27 root
    1 daemon              0        0        0            daemon
    2 bin                 0        0        0            bin
    3 sys                 0        0        0            sys
    4 sync                0        0        0            sync
    5 games               0        0        0            games
    6 man                 0        0        0            man
    7 lp                  0        0        0            lp
    8 mail                0        0        0            mail
    9 news                0        0        0            news
   10 uucp                0        0        0            uucp
   13 proxy               0        0        0            proxy
   33 www-data            0        0        0            www-data
   34 backup              0        0        0            backup
   38 list                0        0        0            Mailing List Manager
   39 irc                 0        0        0            ircd
   42 _apt                0        0        0            
  100 dhcpcd              0        1        0            DHCP Client Daemon,,,
  101 messagebus          1        1        0            
  102 syslog              1        1        0            
  103 sshd                0        1        0            
  104 postfix             0        1        0            
  105 uuidd               0        1        0            
  106 tcpdump             0        1        0            
  992 systemd-resolve     1        0        0            systemd Resolver
  997 systemd-timesync    0        0        0            systemd Time Synchronization
  998 systemd-network     1        0        0            systemd Network Management
 1000 paseo               3        1        0            
 1001 agent               0        1        0            
65534 nobody              0        0        0            nobody
- 
- 
- 
- Make sure you have a link to you X include files called
/usr/include/X11 first.
- mkfs.fat 4.2 (2021-01-31)
No device specified.
- 
- 
- 
- 
- 
- 
- 
Usage: mkntfs [options] device [number-of-sectors]

Basic options:
    -f, --fast                      Perform a quick format
    -Q, --quick                     Perform a quick format
    -L, --label STRING              Set the volume label
    -C, --enable-compression        Enable compression on the volume
    -I, --no-indexing               Disable indexing on the volume
    -n, --no-action                 Do not write to disk

Advanced options:
    -c, --cluster-size BYTES        Specify the cluster size for the volume
    -s, --sector-size BYTES         Specify the sector size for the device
    -p, --partition-start SECTOR    Specify the partition start sector
    -H, --heads NUM                 Specify the number of heads
    -S, --sectors-per-track NUM     Specify the number of sectors per track
    -z, --mft-zone-multiplier NUM   Set the MFT zone multiplier
    -T, --zero-time                 Fake the time to be 00:00 UTC, Jan 1, 1970
    -F, --force                     Force execution despite errors

Output options:
    -q, --quiet                     Quiet execution
    -v, --verbose                   Verbose execution
        --debug                     Very verbose execution

Help options:
    -V, --version                   Display version
    -l, --license                   Display licensing information
    -h, --help                      Display this help

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/
- 
- 
- 
- 
- 
- 

## Details
- Auto-generated from curated CLI tool list
- Each plugin includes plugin.json, meta.json, install-guidance.json
- Binary checks reference install guidance