### PR TITLE
feat: add 20 bundled plugins (batch 014/31)

### DIFF
--- a/plugins/nc.openbsd/install-guidance.json
+++ b/plugins/nc.openbsd/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "nc.openbsd",
+  "binary": "nc.openbsd",
+  "check": "which nc.openbsd",
+  "install_steps": [
+    "# Install nc.openbsd",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/nc.openbsd-linux-amd64 -o /usr/local/bin/nc.openbsd",
+    "chmod +x /usr/local/bin/nc.openbsd",
+    "# Or via package manager, see /usr/bin/nc.openbsd"
+  ]
+}

--- a/plugins/nc.openbsd/meta.json
+++ b/plugins/nc.openbsd/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "nc.openbsd \u2014 nc.openbsd \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/nc.openbsd/plugin.json
+++ b/plugins/nc.openbsd/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "nc.openbsd",
+  "version": "1.0.0",
+  "description": "nc.openbsd \u2014 nc.openbsd \u2014 CLI utility",
+  "source": "/usr/bin/nc.openbsd",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "nc.openbsd"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "nc.openbsd",
+    "binary": "nc.openbsd",
+    "check": "which nc.openbsd",
+    "install_steps": [
+      "# Install nc.openbsd:",
+      "# apt: sudo apt-get install nc.openbsd",
+      "# brew: brew install nc.openbsd",
+      "# cargo: cargo install nc.openbsd",
+      "# npm: npm install -g nc.openbsd",
+      "# pip: pip install nc.openbsd",
+      "# or download from /usr/bin/nc.openbsd"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "nc.openbsd",
+      "resource": "nc.openbsd",
+      "action": "run",
+      "description": "Run nc.openbsd",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "nc.openbsd",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install nc.openbsd from /usr/bin/nc.openbsd"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/nitro/install-guidance.json
+++ b/plugins/nitro/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "nitro",
+  "binary": "nitro",
+  "check": "which nitro",
+  "install_steps": [
+    "# Install nitro",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/nitro-linux-amd64 -o /usr/local/bin/nitro",
+    "chmod +x /usr/local/bin/nitro",
+    "# Or via package manager, see github.com/nitro/nitro"
+  ]
+}

--- a/plugins/nitro/meta.json
+++ b/plugins/nitro/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "nitro \u2014 High-performance HTTP server",
+  "tags": [
+    "web",
+    "server"
+  ],
+  "has_learn": false
+}

--- a/plugins/nitro/plugin.json
+++ b/plugins/nitro/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "nitro",
+  "version": "1.0.0",
+  "description": "nitro \u2014 High-performance HTTP server",
+  "source": "github.com/nitro/nitro",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "nitro"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "nitro",
+    "binary": "nitro",
+    "check": "which nitro",
+    "install_steps": [
+      "# Install nitro:",
+      "# apt: sudo apt-get install nitro",
+      "# brew: brew install nitro",
+      "# cargo: cargo install nitro",
+      "# npm: npm install -g nitro",
+      "# pip: pip install nitro",
+      "# or download from github.com/nitro/nitro"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "nitro",
+      "resource": "nitro",
+      "action": "run",
+      "description": "Run nitro",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "nitro",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install nitro from github.com/nitro/nitro"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/npm-check/install-guidance.json
+++ b/plugins/npm-check/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "npm-check",
+  "binary": "npm-check",
+  "check": "which npm-check",
+  "install_steps": [
+    "# Install npm-check",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/npm-check-linux-amd64 -o /usr/local/bin/npm-check",
+    "chmod +x /usr/local/bin/npm-check",
+    "# Or via package manager, see github.com/dylang/npm-check"
+  ]
+}

--- a/plugins/npm-check/meta.json
+++ b/plugins/npm-check/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "npm-check \u2014 Check npm dependencies",
+  "tags": [
+    "javascript",
+    "dependencies"
+  ],
+  "has_learn": false
+}

--- a/plugins/npm-check/plugin.json
+++ b/plugins/npm-check/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "npm-check",
+  "version": "1.0.0",
+  "description": "npm-check \u2014 Check npm dependencies",
+  "source": "github.com/dylang/npm-check",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "npm-check"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "npm-check",
+    "binary": "npm-check",
+    "check": "which npm-check",
+    "install_steps": [
+      "# Install npm-check:",
+      "# apt: sudo apt-get install npm-check",
+      "# brew: brew install npm-check",
+      "# cargo: cargo install npm-check",
+      "# npm: npm install -g npm-check",
+      "# pip: pip install npm-check",
+      "# or download from github.com/dylang/npm-check"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "npm",
+      "resource": "check",
+      "action": "run",
+      "description": "Run npm-check",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "npm-check",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install npm-check from github.com/dylang/npm-check"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/nsenter/install-guidance.json
+++ b/plugins/nsenter/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "nsenter",
+  "binary": "nsenter",
+  "check": "which nsenter",
+  "install_steps": [
+    "# Install nsenter",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/nsenter-linux-amd64 -o /usr/local/bin/nsenter",
+    "chmod +x /usr/local/bin/nsenter",
+    "# Or via package manager, see /usr/bin/nsenter"
+  ]
+}

--- a/plugins/nsenter/meta.json
+++ b/plugins/nsenter/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "nsenter \u2014 nsenter \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/nsenter/plugin.json
+++ b/plugins/nsenter/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "nsenter",
+  "version": "1.0.0",
+  "description": "nsenter \u2014 nsenter \u2014 CLI utility",
+  "source": "/usr/bin/nsenter",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "nsenter"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "nsenter",
+    "binary": "nsenter",
+    "check": "which nsenter",
+    "install_steps": [
+      "# Install nsenter:",
+      "# apt: sudo apt-get install nsenter",
+      "# brew: brew install nsenter",
+      "# cargo: cargo install nsenter",
+      "# npm: npm install -g nsenter",
+      "# pip: pip install nsenter",
+      "# or download from /usr/bin/nsenter"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "nsenter",
+      "resource": "nsenter",
+      "action": "run",
+      "description": "Run nsenter",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "nsenter",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install nsenter from /usr/bin/nsenter"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfs-3g.probe/install-guidance.json
+++ b/plugins/ntfs-3g.probe/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfs-3g.probe",
+  "binary": "ntfs-3g.probe",
+  "check": "which ntfs-3g.probe",
+  "install_steps": [
+    "# Install ntfs-3g.probe",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfs-3g.probe-linux-amd64 -o /usr/local/bin/ntfs-3g.probe",
+    "chmod +x /usr/local/bin/ntfs-3g.probe",
+    "# Or via package manager, see /usr/bin/ntfs-3g.probe"
+  ]
+}

--- a/plugins/ntfs-3g.probe/meta.json
+++ b/plugins/ntfs-3g.probe/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfs-3g.probe \u2014 ntfs-3g.probe \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfs-3g.probe/plugin.json
+++ b/plugins/ntfs-3g.probe/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfs-3g.probe",
+  "version": "1.0.0",
+  "description": "ntfs-3g.probe \u2014 ntfs-3g.probe \u2014 CLI utility",
+  "source": "/usr/bin/ntfs-3g.probe",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfs-3g.probe"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfs-3g.probe",
+    "binary": "ntfs-3g.probe",
+    "check": "which ntfs-3g.probe",
+    "install_steps": [
+      "# Install ntfs-3g.probe:",
+      "# apt: sudo apt-get install ntfs-3g.probe",
+      "# brew: brew install ntfs-3g.probe",
+      "# cargo: cargo install ntfs-3g.probe",
+      "# npm: npm install -g ntfs-3g.probe",
+      "# pip: pip install ntfs-3g.probe",
+      "# or download from /usr/bin/ntfs-3g.probe"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfs",
+      "resource": "3g.probe",
+      "action": "run",
+      "description": "Run ntfs-3g.probe",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfs-3g.probe",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfs-3g.probe from /usr/bin/ntfs-3g.probe"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfs-3g/install-guidance.json
+++ b/plugins/ntfs-3g/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfs-3g",
+  "binary": "ntfs-3g",
+  "check": "which ntfs-3g",
+  "install_steps": [
+    "# Install ntfs-3g",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfs-3g-linux-amd64 -o /usr/local/bin/ntfs-3g",
+    "chmod +x /usr/local/bin/ntfs-3g",
+    "# Or via package manager, see /usr/bin/ntfs-3g"
+  ]
+}

--- a/plugins/ntfs-3g/meta.json
+++ b/plugins/ntfs-3g/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfs-3g \u2014 ntfs-3g \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfs-3g/plugin.json
+++ b/plugins/ntfs-3g/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfs-3g",
+  "version": "1.0.0",
+  "description": "ntfs-3g \u2014 ntfs-3g \u2014 CLI utility",
+  "source": "/usr/bin/ntfs-3g",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfs-3g"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfs-3g",
+    "binary": "ntfs-3g",
+    "check": "which ntfs-3g",
+    "install_steps": [
+      "# Install ntfs-3g:",
+      "# apt: sudo apt-get install ntfs-3g",
+      "# brew: brew install ntfs-3g",
+      "# cargo: cargo install ntfs-3g",
+      "# npm: npm install -g ntfs-3g",
+      "# pip: pip install ntfs-3g",
+      "# or download from /usr/bin/ntfs-3g"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfs",
+      "resource": "3g",
+      "action": "run",
+      "description": "Run ntfs-3g",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfs-3g",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfs-3g from /usr/bin/ntfs-3g"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfscat/install-guidance.json
+++ b/plugins/ntfscat/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfscat",
+  "binary": "ntfscat",
+  "check": "which ntfscat",
+  "install_steps": [
+    "# Install ntfscat",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfscat-linux-amd64 -o /usr/local/bin/ntfscat",
+    "chmod +x /usr/local/bin/ntfscat",
+    "# Or via package manager, see /usr/bin/ntfscat"
+  ]
+}

--- a/plugins/ntfscat/meta.json
+++ b/plugins/ntfscat/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfscat \u2014 ntfscat \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfscat/plugin.json
+++ b/plugins/ntfscat/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfscat",
+  "version": "1.0.0",
+  "description": "ntfscat \u2014 ntfscat \u2014 CLI utility",
+  "source": "/usr/bin/ntfscat",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfscat"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfscat",
+    "binary": "ntfscat",
+    "check": "which ntfscat",
+    "install_steps": [
+      "# Install ntfscat:",
+      "# apt: sudo apt-get install ntfscat",
+      "# brew: brew install ntfscat",
+      "# cargo: cargo install ntfscat",
+      "# npm: npm install -g ntfscat",
+      "# pip: pip install ntfscat",
+      "# or download from /usr/bin/ntfscat"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfscat",
+      "resource": "ntfscat",
+      "action": "run",
+      "description": "Run ntfscat",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfscat",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfscat from /usr/bin/ntfscat"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfsclone/install-guidance.json
+++ b/plugins/ntfsclone/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfsclone",
+  "binary": "ntfsclone",
+  "check": "which ntfsclone",
+  "install_steps": [
+    "# Install ntfsclone",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfsclone-linux-amd64 -o /usr/local/bin/ntfsclone",
+    "chmod +x /usr/local/bin/ntfsclone",
+    "# Or via package manager, see /usr/sbin/ntfsclone"
+  ]
+}

--- a/plugins/ntfsclone/meta.json
+++ b/plugins/ntfsclone/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfsclone \u2014 ntfsclone \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfsclone/plugin.json
+++ b/plugins/ntfsclone/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfsclone",
+  "version": "1.0.0",
+  "description": "ntfsclone \u2014 ntfsclone \u2014 CLI utility",
+  "source": "/usr/sbin/ntfsclone",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfsclone"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfsclone",
+    "binary": "ntfsclone",
+    "check": "which ntfsclone",
+    "install_steps": [
+      "# Install ntfsclone:",
+      "# apt: sudo apt-get install ntfsclone",
+      "# brew: brew install ntfsclone",
+      "# cargo: cargo install ntfsclone",
+      "# npm: npm install -g ntfsclone",
+      "# pip: pip install ntfsclone",
+      "# or download from /usr/sbin/ntfsclone"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfsclone",
+      "resource": "ntfsclone",
+      "action": "run",
+      "description": "Run ntfsclone",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfsclone",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfsclone from /usr/sbin/ntfsclone"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfscluster/install-guidance.json
+++ b/plugins/ntfscluster/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfscluster",
+  "binary": "ntfscluster",
+  "check": "which ntfscluster",
+  "install_steps": [
+    "# Install ntfscluster",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfscluster-linux-amd64 -o /usr/local/bin/ntfscluster",
+    "chmod +x /usr/local/bin/ntfscluster",
+    "# Or via package manager, see /usr/bin/ntfscluster"
+  ]
+}

--- a/plugins/ntfscluster/meta.json
+++ b/plugins/ntfscluster/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfscluster \u2014 ntfscluster \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfscluster/plugin.json
+++ b/plugins/ntfscluster/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfscluster",
+  "version": "1.0.0",
+  "description": "ntfscluster \u2014 ntfscluster \u2014 CLI utility",
+  "source": "/usr/bin/ntfscluster",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfscluster"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfscluster",
+    "binary": "ntfscluster",
+    "check": "which ntfscluster",
+    "install_steps": [
+      "# Install ntfscluster:",
+      "# apt: sudo apt-get install ntfscluster",
+      "# brew: brew install ntfscluster",
+      "# cargo: cargo install ntfscluster",
+      "# npm: npm install -g ntfscluster",
+      "# pip: pip install ntfscluster",
+      "# or download from /usr/bin/ntfscluster"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfscluster",
+      "resource": "ntfscluster",
+      "action": "run",
+      "description": "Run ntfscluster",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfscluster",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfscluster from /usr/bin/ntfscluster"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfscmp/install-guidance.json
+++ b/plugins/ntfscmp/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfscmp",
+  "binary": "ntfscmp",
+  "check": "which ntfscmp",
+  "install_steps": [
+    "# Install ntfscmp",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfscmp-linux-amd64 -o /usr/local/bin/ntfscmp",
+    "chmod +x /usr/local/bin/ntfscmp",
+    "# Or via package manager, see /usr/bin/ntfscmp"
+  ]
+}

--- a/plugins/ntfscmp/meta.json
+++ b/plugins/ntfscmp/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfscmp \u2014 ntfscmp \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfscmp/plugin.json
+++ b/plugins/ntfscmp/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfscmp",
+  "version": "1.0.0",
+  "description": "ntfscmp \u2014 ntfscmp \u2014 CLI utility",
+  "source": "/usr/bin/ntfscmp",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfscmp"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfscmp",
+    "binary": "ntfscmp",
+    "check": "which ntfscmp",
+    "install_steps": [
+      "# Install ntfscmp:",
+      "# apt: sudo apt-get install ntfscmp",
+      "# brew: brew install ntfscmp",
+      "# cargo: cargo install ntfscmp",
+      "# npm: npm install -g ntfscmp",
+      "# pip: pip install ntfscmp",
+      "# or download from /usr/bin/ntfscmp"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfscmp",
+      "resource": "ntfscmp",
+      "action": "run",
+      "description": "Run ntfscmp",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfscmp",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfscmp from /usr/bin/ntfscmp"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfscp/install-guidance.json
+++ b/plugins/ntfscp/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfscp",
+  "binary": "ntfscp",
+  "check": "which ntfscp",
+  "install_steps": [
+    "# Install ntfscp",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfscp-linux-amd64 -o /usr/local/bin/ntfscp",
+    "chmod +x /usr/local/bin/ntfscp",
+    "# Or via package manager, see /usr/sbin/ntfscp"
+  ]
+}

--- a/plugins/ntfscp/meta.json
+++ b/plugins/ntfscp/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfscp \u2014 ntfscp \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfscp/plugin.json
+++ b/plugins/ntfscp/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfscp",
+  "version": "1.0.0",
+  "description": "ntfscp \u2014 ntfscp \u2014 CLI utility",
+  "source": "/usr/sbin/ntfscp",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfscp"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfscp",
+    "binary": "ntfscp",
+    "check": "which ntfscp",
+    "install_steps": [
+      "# Install ntfscp:",
+      "# apt: sudo apt-get install ntfscp",
+      "# brew: brew install ntfscp",
+      "# cargo: cargo install ntfscp",
+      "# npm: npm install -g ntfscp",
+      "# pip: pip install ntfscp",
+      "# or download from /usr/sbin/ntfscp"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfscp",
+      "resource": "ntfscp",
+      "action": "run",
+      "description": "Run ntfscp",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfscp",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfscp from /usr/sbin/ntfscp"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfsdecrypt/install-guidance.json
+++ b/plugins/ntfsdecrypt/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfsdecrypt",
+  "binary": "ntfsdecrypt",
+  "check": "which ntfsdecrypt",
+  "install_steps": [
+    "# Install ntfsdecrypt",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfsdecrypt-linux-amd64 -o /usr/local/bin/ntfsdecrypt",
+    "chmod +x /usr/local/bin/ntfsdecrypt",
+    "# Or via package manager, see /usr/bin/ntfsdecrypt"
+  ]
+}

--- a/plugins/ntfsdecrypt/meta.json
+++ b/plugins/ntfsdecrypt/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfsdecrypt \u2014 ntfsdecrypt \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfsdecrypt/plugin.json
+++ b/plugins/ntfsdecrypt/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfsdecrypt",
+  "version": "1.0.0",
+  "description": "ntfsdecrypt \u2014 ntfsdecrypt \u2014 CLI utility",
+  "source": "/usr/bin/ntfsdecrypt",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfsdecrypt"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfsdecrypt",
+    "binary": "ntfsdecrypt",
+    "check": "which ntfsdecrypt",
+    "install_steps": [
+      "# Install ntfsdecrypt:",
+      "# apt: sudo apt-get install ntfsdecrypt",
+      "# brew: brew install ntfsdecrypt",
+      "# cargo: cargo install ntfsdecrypt",
+      "# npm: npm install -g ntfsdecrypt",
+      "# pip: pip install ntfsdecrypt",
+      "# or download from /usr/bin/ntfsdecrypt"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfsdecrypt",
+      "resource": "ntfsdecrypt",
+      "action": "run",
+      "description": "Run ntfsdecrypt",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfsdecrypt",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfsdecrypt from /usr/bin/ntfsdecrypt"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfsfallocate/install-guidance.json
+++ b/plugins/ntfsfallocate/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfsfallocate",
+  "binary": "ntfsfallocate",
+  "check": "which ntfsfallocate",
+  "install_steps": [
+    "# Install ntfsfallocate",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfsfallocate-linux-amd64 -o /usr/local/bin/ntfsfallocate",
+    "chmod +x /usr/local/bin/ntfsfallocate",
+    "# Or via package manager, see /usr/bin/ntfsfallocate"
+  ]
+}

--- a/plugins/ntfsfallocate/meta.json
+++ b/plugins/ntfsfallocate/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfsfallocate \u2014 ntfsfallocate \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfsfallocate/plugin.json
+++ b/plugins/ntfsfallocate/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfsfallocate",
+  "version": "1.0.0",
+  "description": "ntfsfallocate \u2014 ntfsfallocate \u2014 CLI utility",
+  "source": "/usr/bin/ntfsfallocate",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfsfallocate"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfsfallocate",
+    "binary": "ntfsfallocate",
+    "check": "which ntfsfallocate",
+    "install_steps": [
+      "# Install ntfsfallocate:",
+      "# apt: sudo apt-get install ntfsfallocate",
+      "# brew: brew install ntfsfallocate",
+      "# cargo: cargo install ntfsfallocate",
+      "# npm: npm install -g ntfsfallocate",
+      "# pip: pip install ntfsfallocate",
+      "# or download from /usr/bin/ntfsfallocate"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfsfallocate",
+      "resource": "ntfsfallocate",
+      "action": "run",
+      "description": "Run ntfsfallocate",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfsfallocate",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfsfallocate from /usr/bin/ntfsfallocate"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfsfix/install-guidance.json
+++ b/plugins/ntfsfix/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfsfix",
+  "binary": "ntfsfix",
+  "check": "which ntfsfix",
+  "install_steps": [
+    "# Install ntfsfix",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfsfix-linux-amd64 -o /usr/local/bin/ntfsfix",
+    "chmod +x /usr/local/bin/ntfsfix",
+    "# Or via package manager, see /usr/bin/ntfsfix"
+  ]
+}

--- a/plugins/ntfsfix/meta.json
+++ b/plugins/ntfsfix/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfsfix \u2014 ntfsfix \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfsfix/plugin.json
+++ b/plugins/ntfsfix/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfsfix",
+  "version": "1.0.0",
+  "description": "ntfsfix \u2014 ntfsfix \u2014 CLI utility",
+  "source": "/usr/bin/ntfsfix",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfsfix"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfsfix",
+    "binary": "ntfsfix",
+    "check": "which ntfsfix",
+    "install_steps": [
+      "# Install ntfsfix:",
+      "# apt: sudo apt-get install ntfsfix",
+      "# brew: brew install ntfsfix",
+      "# cargo: cargo install ntfsfix",
+      "# npm: npm install -g ntfsfix",
+      "# pip: pip install ntfsfix",
+      "# or download from /usr/bin/ntfsfix"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfsfix",
+      "resource": "ntfsfix",
+      "action": "run",
+      "description": "Run ntfsfix",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfsfix",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfsfix from /usr/bin/ntfsfix"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfsinfo/install-guidance.json
+++ b/plugins/ntfsinfo/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfsinfo",
+  "binary": "ntfsinfo",
+  "check": "which ntfsinfo",
+  "install_steps": [
+    "# Install ntfsinfo",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfsinfo-linux-amd64 -o /usr/local/bin/ntfsinfo",
+    "chmod +x /usr/local/bin/ntfsinfo",
+    "# Or via package manager, see /usr/bin/ntfsinfo"
+  ]
+}

--- a/plugins/ntfsinfo/meta.json
+++ b/plugins/ntfsinfo/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfsinfo \u2014 ntfsinfo \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfsinfo/plugin.json
+++ b/plugins/ntfsinfo/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfsinfo",
+  "version": "1.0.0",
+  "description": "ntfsinfo \u2014 ntfsinfo \u2014 CLI utility",
+  "source": "/usr/bin/ntfsinfo",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfsinfo"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfsinfo",
+    "binary": "ntfsinfo",
+    "check": "which ntfsinfo",
+    "install_steps": [
+      "# Install ntfsinfo:",
+      "# apt: sudo apt-get install ntfsinfo",
+      "# brew: brew install ntfsinfo",
+      "# cargo: cargo install ntfsinfo",
+      "# npm: npm install -g ntfsinfo",
+      "# pip: pip install ntfsinfo",
+      "# or download from /usr/bin/ntfsinfo"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfsinfo",
+      "resource": "ntfsinfo",
+      "action": "run",
+      "description": "Run ntfsinfo",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfsinfo",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfsinfo from /usr/bin/ntfsinfo"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfslabel/install-guidance.json
+++ b/plugins/ntfslabel/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfslabel",
+  "binary": "ntfslabel",
+  "check": "which ntfslabel",
+  "install_steps": [
+    "# Install ntfslabel",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfslabel-linux-amd64 -o /usr/local/bin/ntfslabel",
+    "chmod +x /usr/local/bin/ntfslabel",
+    "# Or via package manager, see /usr/sbin/ntfslabel"
+  ]
+}

--- a/plugins/ntfslabel/meta.json
+++ b/plugins/ntfslabel/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfslabel \u2014 ntfslabel \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfslabel/plugin.json
+++ b/plugins/ntfslabel/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfslabel",
+  "version": "1.0.0",
+  "description": "ntfslabel \u2014 ntfslabel \u2014 CLI utility",
+  "source": "/usr/sbin/ntfslabel",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfslabel"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfslabel",
+    "binary": "ntfslabel",
+    "check": "which ntfslabel",
+    "install_steps": [
+      "# Install ntfslabel:",
+      "# apt: sudo apt-get install ntfslabel",
+      "# brew: brew install ntfslabel",
+      "# cargo: cargo install ntfslabel",
+      "# npm: npm install -g ntfslabel",
+      "# pip: pip install ntfslabel",
+      "# or download from /usr/sbin/ntfslabel"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfslabel",
+      "resource": "ntfslabel",
+      "action": "run",
+      "description": "Run ntfslabel",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfslabel",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfslabel from /usr/sbin/ntfslabel"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfsls/install-guidance.json
+++ b/plugins/ntfsls/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfsls",
+  "binary": "ntfsls",
+  "check": "which ntfsls",
+  "install_steps": [
+    "# Install ntfsls",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfsls-linux-amd64 -o /usr/local/bin/ntfsls",
+    "chmod +x /usr/local/bin/ntfsls",
+    "# Or via package manager, see /usr/bin/ntfsls"
+  ]
+}

--- a/plugins/ntfsls/meta.json
+++ b/plugins/ntfsls/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfsls \u2014 ntfsls \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfsls/plugin.json
+++ b/plugins/ntfsls/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfsls",
+  "version": "1.0.0",
+  "description": "ntfsls \u2014 ntfsls \u2014 CLI utility",
+  "source": "/usr/bin/ntfsls",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfsls"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfsls",
+    "binary": "ntfsls",
+    "check": "which ntfsls",
+    "install_steps": [
+      "# Install ntfsls:",
+      "# apt: sudo apt-get install ntfsls",
+      "# brew: brew install ntfsls",
+      "# cargo: cargo install ntfsls",
+      "# npm: npm install -g ntfsls",
+      "# pip: pip install ntfsls",
+      "# or download from /usr/bin/ntfsls"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfsls",
+      "resource": "ntfsls",
+      "action": "run",
+      "description": "Run ntfsls",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfsls",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfsls from /usr/bin/ntfsls"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfsmove/install-guidance.json
+++ b/plugins/ntfsmove/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfsmove",
+  "binary": "ntfsmove",
+  "check": "which ntfsmove",
+  "install_steps": [
+    "# Install ntfsmove",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfsmove-linux-amd64 -o /usr/local/bin/ntfsmove",
+    "chmod +x /usr/local/bin/ntfsmove",
+    "# Or via package manager, see /usr/bin/ntfsmove"
+  ]
+}

--- a/plugins/ntfsmove/meta.json
+++ b/plugins/ntfsmove/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfsmove \u2014 ntfsmove \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfsmove/plugin.json
+++ b/plugins/ntfsmove/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfsmove",
+  "version": "1.0.0",
+  "description": "ntfsmove \u2014 ntfsmove \u2014 CLI utility",
+  "source": "/usr/bin/ntfsmove",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfsmove"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfsmove",
+    "binary": "ntfsmove",
+    "check": "which ntfsmove",
+    "install_steps": [
+      "# Install ntfsmove:",
+      "# apt: sudo apt-get install ntfsmove",
+      "# brew: brew install ntfsmove",
+      "# cargo: cargo install ntfsmove",
+      "# npm: npm install -g ntfsmove",
+      "# pip: pip install ntfsmove",
+      "# or download from /usr/bin/ntfsmove"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfsmove",
+      "resource": "ntfsmove",
+      "action": "run",
+      "description": "Run ntfsmove",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfsmove",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfsmove from /usr/bin/ntfsmove"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfsrecover/install-guidance.json
+++ b/plugins/ntfsrecover/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfsrecover",
+  "binary": "ntfsrecover",
+  "check": "which ntfsrecover",
+  "install_steps": [
+    "# Install ntfsrecover",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfsrecover-linux-amd64 -o /usr/local/bin/ntfsrecover",
+    "chmod +x /usr/local/bin/ntfsrecover",
+    "# Or via package manager, see /usr/bin/ntfsrecover"
+  ]
+}

--- a/plugins/ntfsrecover/meta.json
+++ b/plugins/ntfsrecover/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfsrecover \u2014 ntfsrecover \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfsrecover/plugin.json
+++ b/plugins/ntfsrecover/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfsrecover",
+  "version": "1.0.0",
+  "description": "ntfsrecover \u2014 ntfsrecover \u2014 CLI utility",
+  "source": "/usr/bin/ntfsrecover",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfsrecover"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfsrecover",
+    "binary": "ntfsrecover",
+    "check": "which ntfsrecover",
+    "install_steps": [
+      "# Install ntfsrecover:",
+      "# apt: sudo apt-get install ntfsrecover",
+      "# brew: brew install ntfsrecover",
+      "# cargo: cargo install ntfsrecover",
+      "# npm: npm install -g ntfsrecover",
+      "# pip: pip install ntfsrecover",
+      "# or download from /usr/bin/ntfsrecover"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfsrecover",
+      "resource": "ntfsrecover",
+      "action": "run",
+      "description": "Run ntfsrecover",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfsrecover",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfsrecover from /usr/bin/ntfsrecover"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ntfsresize/install-guidance.json
+++ b/plugins/ntfsresize/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ntfsresize",
+  "binary": "ntfsresize",
+  "check": "which ntfsresize",
+  "install_steps": [
+    "# Install ntfsresize",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ntfsresize-linux-amd64 -o /usr/local/bin/ntfsresize",
+    "chmod +x /usr/local/bin/ntfsresize",
+    "# Or via package manager, see /usr/sbin/ntfsresize"
+  ]
+}

--- a/plugins/ntfsresize/meta.json
+++ b/plugins/ntfsresize/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ntfsresize \u2014 ntfsresize \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ntfsresize/plugin.json
+++ b/plugins/ntfsresize/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ntfsresize",
+  "version": "1.0.0",
+  "description": "ntfsresize \u2014 ntfsresize \u2014 CLI utility",
+  "source": "/usr/sbin/ntfsresize",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ntfsresize"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ntfsresize",
+    "binary": "ntfsresize",
+    "check": "which ntfsresize",
+    "install_steps": [
+      "# Install ntfsresize:",
+      "# apt: sudo apt-get install ntfsresize",
+      "# brew: brew install ntfsresize",
+      "# cargo: cargo install ntfsresize",
+      "# npm: npm install -g ntfsresize",
+      "# pip: pip install ntfsresize",
+      "# or download from /usr/sbin/ntfsresize"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ntfsresize",
+      "resource": "ntfsresize",
+      "action": "run",
+      "description": "Run ntfsresize",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ntfsresize",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ntfsresize from /usr/sbin/ntfsresize"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Batch 014 of 31 — adding 20 new bundled plugin definitions.

## Plugins

- 
- 
- 
- 
- 
- 
- 
- 
- 
Usage: ntfscluster [options] device
    -i, --info           Print information about the volume (default)

    -c, --cluster RANGE  Look for objects in this range of clusters
    -s, --sector RANGE   Look for objects in this range of sectors
    -I, --inode NUM      Show information about this inode
    -F, --filename NAME  Show information about this file

    -f, --force          Use less caution
    -q, --quiet          Less output
    -v, --verbose        More output
    -V, --version        Version information
    -h, --help           Print this help

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/
- ntfscmp v2022.10.3 (libntfs-3g)
ERROR: You must specify exactly 2 volumes.

Usage: ntfscmp [OPTIONS] DEVICE1 DEVICE2
    Compare two NTFS volumes and tell the differences.

    -P, --no-progress-bar  Don't show progress bar
    -v, --verbose          More output
    -h, --help             Display this help

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/
- 
- 
- 
- ERROR: You must specify a device.
ntfsfix v2022.10.3 (libntfs-3g)

Usage: ntfsfix [options] device
    Attempt to fix an NTFS partition.

    -b, --clear-bad-sectors Clear the bad sector list
    -d, --clear-dirty       Clear the volume dirty flag
    -h, --help              Display this help
    -n, --no-action         Do not write anything
    -V, --version           Display version information

For example: ntfsfix /dev/hda6

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/
- 
Usage: ntfsinfo [options] device
    -i, --inode NUM  Display information about this inode
    -F, --file FILE  Display information about this file (absolute path)
    -m, --mft        Dump information about the volume
    -t, --notime     Don't report timestamps

    -f, --force      Use less caution
    -q, --quiet      Less output
    -v, --verbose    More output
    -V, --version    Display version information
    -h, --help       Display this help

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/

Failed to parse command line options
- 
Usage: ntfslabel [options] device [label]
    -n, --no-action    Do not write to disk
    -f, --force        Use less caution
        --new-serial   Set a new serial number
        --new-half-serial Set a partial new serial number
    -q, --quiet        Less output
    -v, --verbose      More output
    -V, --version      Display version information
    -h, --help         Display this help

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/
- 
Usage: ntfsls [options] device

    -a, --all            Display all files
    -F, --classify       Display classification
    -f, --force          Use less caution
    -h, --help           Display this help
    -i, --inode          Display inode numbers
    -l, --long           Display long info
    -p, --path PATH      Directory whose contents to list
    -q, --quiet          Less output
    -R, --recursive      Recursively list subdirectories
    -s, --system         Display system files
    -V, --version        Display version information
    -v, --verbose        More output
    -x, --dos            Use short (DOS 8.3) names

NOTE: If neither -a nor -s is specified, the program defaults to -a.

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/
- 
Usage: ntfsmove [options] device file

    -S      --start        Move to the start of the volume
    -B      --best         Move to the best place on the volume
    -E      --end          Move to the end of the volume
    -C num  --cluster num  Move to this cluster offset

    -D      --no-dirty     Do not mark volume dirty (require chkdsk)
    -n      --no-action    Do not write to disk
    -f      --force        Use less caution
    -h      --help         Print this help
    -q      --quiet        Less output
    -V      --version      Version information
    -v      --verbose      More output

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/
- 
- ntfsresize v2022.10.3 (libntfs-3g)

Usage: ntfsresize [OPTIONS] DEVICE
    Resize an NTFS volume non-destructively, safely move any data if needed.

    -c, --check            Check to ensure that the device is ready for resize
    -i, --info             Estimate the smallest shrunken size or the smallest
                                expansion size
    -m, --info-mb-only     Estimate the smallest shrunken size possible,
                                output size in MB only
    -s, --size SIZE        Resize volume to SIZE[k|M|G] bytes
    -x, --expand           Expand to full partition

    -n, --no-action        Do not write to disk
    -b, --bad-sectors      Support disks having bad sectors
    -f, --force            Force to progress
    -P, --no-progress-bar  Don't show progress bar
    -v, --verbose          More output
    -V, --version          Display version information
    -h, --help             Display this help

    The options -i and -x are exclusive of option -s, and -m is exclusive
    of option -x. If options -i, -m, -s and -x are are all omitted
    then the NTFS volume will be enlarged to the DEVICE size.

Developers' email address: ntfs-3g-devel@lists.sf.net
News, support and information:  https://github.com/tuxera/ntfs-3g/
Ntfsresize FAQ: http://linux-ntfs.sourceforge.net/info/ntfsresize.html

## Details
- Auto-generated from curated CLI tool list
- Each plugin includes plugin.json, meta.json, install-guidance.json
- Binary checks reference install guidance