### PR TITLE
feat: add 20 bundled plugins (batch 018/31)

### DIFF
--- a/plugins/pstree.x11/install-guidance.json
+++ b/plugins/pstree.x11/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "pstree.x11",
+  "binary": "pstree.x11",
+  "check": "which pstree.x11",
+  "install_steps": [
+    "# Install pstree.x11",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/pstree.x11-linux-amd64 -o /usr/local/bin/pstree.x11",
+    "chmod +x /usr/local/bin/pstree.x11",
+    "# Or via package manager, see /usr/bin/pstree.x11"
+  ]
+}

--- a/plugins/pstree.x11/meta.json
+++ b/plugins/pstree.x11/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "pstree.x11 \u2014 pstree.x11 \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/pstree.x11/plugin.json
+++ b/plugins/pstree.x11/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "pstree.x11",
+  "version": "1.0.0",
+  "description": "pstree.x11 \u2014 pstree.x11 \u2014 CLI utility",
+  "source": "/usr/bin/pstree.x11",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "pstree.x11"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "pstree.x11",
+    "binary": "pstree.x11",
+    "check": "which pstree.x11",
+    "install_steps": [
+      "# Install pstree.x11:",
+      "# apt: sudo apt-get install pstree.x11",
+      "# brew: brew install pstree.x11",
+      "# cargo: cargo install pstree.x11",
+      "# npm: npm install -g pstree.x11",
+      "# pip: pip install pstree.x11",
+      "# or download from /usr/bin/pstree.x11"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "pstree.x11",
+      "resource": "pstree.x11",
+      "action": "run",
+      "description": "Run pstree.x11",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pstree.x11",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install pstree.x11 from /usr/bin/pstree.x11"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ptar/install-guidance.json
+++ b/plugins/ptar/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ptar",
+  "binary": "ptar",
+  "check": "which ptar",
+  "install_steps": [
+    "# Install ptar",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ptar-linux-amd64 -o /usr/local/bin/ptar",
+    "chmod +x /usr/local/bin/ptar",
+    "# Or via package manager, see /usr/bin/ptar"
+  ]
+}

--- a/plugins/ptar/meta.json
+++ b/plugins/ptar/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ptar \u2014 ptar \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ptar/plugin.json
+++ b/plugins/ptar/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ptar",
+  "version": "1.0.0",
+  "description": "ptar \u2014 ptar \u2014 CLI utility",
+  "source": "/usr/bin/ptar",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ptar"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ptar",
+    "binary": "ptar",
+    "check": "which ptar",
+    "install_steps": [
+      "# Install ptar:",
+      "# apt: sudo apt-get install ptar",
+      "# brew: brew install ptar",
+      "# cargo: cargo install ptar",
+      "# npm: npm install -g ptar",
+      "# pip: pip install ptar",
+      "# or download from /usr/bin/ptar"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ptar",
+      "resource": "ptar",
+      "action": "run",
+      "description": "Run ptar",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ptar",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ptar from /usr/bin/ptar"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ptardiff/install-guidance.json
+++ b/plugins/ptardiff/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ptardiff",
+  "binary": "ptardiff",
+  "check": "which ptardiff",
+  "install_steps": [
+    "# Install ptardiff",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ptardiff-linux-amd64 -o /usr/local/bin/ptardiff",
+    "chmod +x /usr/local/bin/ptardiff",
+    "# Or via package manager, see /usr/bin/ptardiff"
+  ]
+}

--- a/plugins/ptardiff/meta.json
+++ b/plugins/ptardiff/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ptardiff \u2014 ptardiff \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ptardiff/plugin.json
+++ b/plugins/ptardiff/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ptardiff",
+  "version": "1.0.0",
+  "description": "ptardiff \u2014 ptardiff \u2014 CLI utility",
+  "source": "/usr/bin/ptardiff",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ptardiff"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ptardiff",
+    "binary": "ptardiff",
+    "check": "which ptardiff",
+    "install_steps": [
+      "# Install ptardiff:",
+      "# apt: sudo apt-get install ptardiff",
+      "# brew: brew install ptardiff",
+      "# cargo: cargo install ptardiff",
+      "# npm: npm install -g ptardiff",
+      "# pip: pip install ptardiff",
+      "# or download from /usr/bin/ptardiff"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ptardiff",
+      "resource": "ptardiff",
+      "action": "run",
+      "description": "Run ptardiff",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ptardiff",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ptardiff from /usr/bin/ptardiff"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ptargrep/install-guidance.json
+++ b/plugins/ptargrep/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ptargrep",
+  "binary": "ptargrep",
+  "check": "which ptargrep",
+  "install_steps": [
+    "# Install ptargrep",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/ptargrep-linux-amd64 -o /usr/local/bin/ptargrep",
+    "chmod +x /usr/local/bin/ptargrep",
+    "# Or via package manager, see /usr/bin/ptargrep"
+  ]
+}

--- a/plugins/ptargrep/meta.json
+++ b/plugins/ptargrep/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "ptargrep \u2014 ptargrep \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/ptargrep/plugin.json
+++ b/plugins/ptargrep/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "ptargrep",
+  "version": "1.0.0",
+  "description": "ptargrep \u2014 ptargrep \u2014 CLI utility",
+  "source": "/usr/bin/ptargrep",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ptargrep"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ptargrep",
+    "binary": "ptargrep",
+    "check": "which ptargrep",
+    "install_steps": [
+      "# Install ptargrep:",
+      "# apt: sudo apt-get install ptargrep",
+      "# brew: brew install ptargrep",
+      "# cargo: cargo install ptargrep",
+      "# npm: npm install -g ptargrep",
+      "# pip: pip install ptargrep",
+      "# or download from /usr/bin/ptargrep"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ptargrep",
+      "resource": "ptargrep",
+      "action": "run",
+      "description": "Run ptargrep",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ptargrep",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ptargrep from /usr/bin/ptargrep"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pwck/install-guidance.json
+++ b/plugins/pwck/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "pwck",
+  "binary": "pwck",
+  "check": "which pwck",
+  "install_steps": [
+    "# Install pwck",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/pwck-linux-amd64 -o /usr/local/bin/pwck",
+    "chmod +x /usr/local/bin/pwck",
+    "# Or via package manager, see /usr/sbin/pwck"
+  ]
+}

--- a/plugins/pwck/meta.json
+++ b/plugins/pwck/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "pwck \u2014 pwck \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/pwck/plugin.json
+++ b/plugins/pwck/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "pwck",
+  "version": "1.0.0",
+  "description": "pwck \u2014 pwck \u2014 CLI utility",
+  "source": "/usr/sbin/pwck",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "pwck"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "pwck",
+    "binary": "pwck",
+    "check": "which pwck",
+    "install_steps": [
+      "# Install pwck:",
+      "# apt: sudo apt-get install pwck",
+      "# brew: brew install pwck",
+      "# cargo: cargo install pwck",
+      "# npm: npm install -g pwck",
+      "# pip: pip install pwck",
+      "# or download from /usr/sbin/pwck"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "pwck",
+      "resource": "pwck",
+      "action": "run",
+      "description": "Run pwck",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pwck",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install pwck from /usr/sbin/pwck"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pwconv/install-guidance.json
+++ b/plugins/pwconv/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "pwconv",
+  "binary": "pwconv",
+  "check": "which pwconv",
+  "install_steps": [
+    "# Install pwconv",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/pwconv-linux-amd64 -o /usr/local/bin/pwconv",
+    "chmod +x /usr/local/bin/pwconv",
+    "# Or via package manager, see /usr/sbin/pwconv"
+  ]
+}

--- a/plugins/pwconv/meta.json
+++ b/plugins/pwconv/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "pwconv \u2014 pwconv \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/pwconv/plugin.json
+++ b/plugins/pwconv/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "pwconv",
+  "version": "1.0.0",
+  "description": "pwconv \u2014 pwconv \u2014 CLI utility",
+  "source": "/usr/sbin/pwconv",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "pwconv"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "pwconv",
+    "binary": "pwconv",
+    "check": "which pwconv",
+    "install_steps": [
+      "# Install pwconv:",
+      "# apt: sudo apt-get install pwconv",
+      "# brew: brew install pwconv",
+      "# cargo: cargo install pwconv",
+      "# npm: npm install -g pwconv",
+      "# pip: pip install pwconv",
+      "# or download from /usr/sbin/pwconv"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "pwconv",
+      "resource": "pwconv",
+      "action": "run",
+      "description": "Run pwconv",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pwconv",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install pwconv from /usr/sbin/pwconv"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pwd/install-guidance.json
+++ b/plugins/pwd/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "pwd",
+  "binary": "pwd",
+  "check": "which pwd",
+  "install_steps": [
+    "# Install pwd",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/pwd-linux-amd64 -o /usr/local/bin/pwd",
+    "chmod +x /usr/local/bin/pwd",
+    "# Or via package manager, see /usr/bin/pwd"
+  ]
+}

--- a/plugins/pwd/meta.json
+++ b/plugins/pwd/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "pwd \u2014 pwd \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/pwd/plugin.json
+++ b/plugins/pwd/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "pwd",
+  "version": "1.0.0",
+  "description": "pwd \u2014 pwd \u2014 CLI utility",
+  "source": "/usr/bin/pwd",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "pwd"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "pwd",
+    "binary": "pwd",
+    "check": "which pwd",
+    "install_steps": [
+      "# Install pwd:",
+      "# apt: sudo apt-get install pwd",
+      "# brew: brew install pwd",
+      "# cargo: cargo install pwd",
+      "# npm: npm install -g pwd",
+      "# pip: pip install pwd",
+      "# or download from /usr/bin/pwd"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "pwd",
+      "resource": "pwd",
+      "action": "run",
+      "description": "Run pwd",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pwd",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install pwd from /usr/bin/pwd"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pwhistory_helper/install-guidance.json
+++ b/plugins/pwhistory_helper/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "pwhistory_helper",
+  "binary": "pwhistory_helper",
+  "check": "which pwhistory_helper",
+  "install_steps": [
+    "# Install pwhistory_helper",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/pwhistory_helper-linux-amd64 -o /usr/local/bin/pwhistory_helper",
+    "chmod +x /usr/local/bin/pwhistory_helper",
+    "# Or via package manager, see /usr/sbin/pwhistory_helper"
+  ]
+}

--- a/plugins/pwhistory_helper/meta.json
+++ b/plugins/pwhistory_helper/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "pwhistory_helper \u2014 pwhistory_helper \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/pwhistory_helper/plugin.json
+++ b/plugins/pwhistory_helper/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "pwhistory-helper",
+  "version": "1.0.0",
+  "description": "pwhistory-helper \u2014 pwhistory_helper \u2014 CLI utility",
+  "source": "/usr/sbin/pwhistory_helper",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "pwhistory_helper"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "pwhistory-helper",
+    "binary": "pwhistory_helper",
+    "check": "which pwhistory_helper",
+    "install_steps": [
+      "# Install pwhistory-helper:",
+      "# apt: sudo apt-get install pwhistory-helper",
+      "# brew: brew install pwhistory-helper",
+      "# cargo: cargo install pwhistory-helper",
+      "# npm: npm install -g pwhistory-helper",
+      "# pip: pip install pwhistory-helper",
+      "# or download from /usr/sbin/pwhistory_helper"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "pwhistory",
+      "resource": "helper",
+      "action": "run",
+      "description": "Run pwhistory-helper",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pwhistory_helper",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install pwhistory-helper from /usr/sbin/pwhistory_helper"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pwunconv/install-guidance.json
+++ b/plugins/pwunconv/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "pwunconv",
+  "binary": "pwunconv",
+  "check": "which pwunconv",
+  "install_steps": [
+    "# Install pwunconv",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/pwunconv-linux-amd64 -o /usr/local/bin/pwunconv",
+    "chmod +x /usr/local/bin/pwunconv",
+    "# Or via package manager, see /usr/sbin/pwunconv"
+  ]
+}

--- a/plugins/pwunconv/meta.json
+++ b/plugins/pwunconv/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "pwunconv \u2014 pwunconv \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/pwunconv/plugin.json
+++ b/plugins/pwunconv/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "pwunconv",
+  "version": "1.0.0",
+  "description": "pwunconv \u2014 pwunconv \u2014 CLI utility",
+  "source": "/usr/sbin/pwunconv",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "pwunconv"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "pwunconv",
+    "binary": "pwunconv",
+    "check": "which pwunconv",
+    "install_steps": [
+      "# Install pwunconv:",
+      "# apt: sudo apt-get install pwunconv",
+      "# brew: brew install pwunconv",
+      "# cargo: cargo install pwunconv",
+      "# npm: npm install -g pwunconv",
+      "# pip: pip install pwunconv",
+      "# or download from /usr/sbin/pwunconv"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "pwunconv",
+      "resource": "pwunconv",
+      "action": "run",
+      "description": "Run pwunconv",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pwunconv",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install pwunconv from /usr/sbin/pwunconv"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/py3clean/install-guidance.json
+++ b/plugins/py3clean/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "py3clean",
+  "binary": "py3clean",
+  "check": "which py3clean",
+  "install_steps": [
+    "# Install py3clean",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/py3clean-linux-amd64 -o /usr/local/bin/py3clean",
+    "chmod +x /usr/local/bin/py3clean",
+    "# Or via package manager, see /usr/bin/py3clean"
+  ]
+}

--- a/plugins/py3clean/meta.json
+++ b/plugins/py3clean/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "py3clean \u2014 py3clean \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/py3clean/plugin.json
+++ b/plugins/py3clean/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "py3clean",
+  "version": "1.0.0",
+  "description": "py3clean \u2014 py3clean \u2014 CLI utility",
+  "source": "/usr/bin/py3clean",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "py3clean"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "py3clean",
+    "binary": "py3clean",
+    "check": "which py3clean",
+    "install_steps": [
+      "# Install py3clean:",
+      "# apt: sudo apt-get install py3clean",
+      "# brew: brew install py3clean",
+      "# cargo: cargo install py3clean",
+      "# npm: npm install -g py3clean",
+      "# pip: pip install py3clean",
+      "# or download from /usr/bin/py3clean"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "py3clean",
+      "resource": "py3clean",
+      "action": "run",
+      "description": "Run py3clean",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "py3clean",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install py3clean from /usr/bin/py3clean"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/py3compile/install-guidance.json
+++ b/plugins/py3compile/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "py3compile",
+  "binary": "py3compile",
+  "check": "which py3compile",
+  "install_steps": [
+    "# Install py3compile",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/py3compile-linux-amd64 -o /usr/local/bin/py3compile",
+    "chmod +x /usr/local/bin/py3compile",
+    "# Or via package manager, see /usr/bin/py3compile"
+  ]
+}

--- a/plugins/py3compile/meta.json
+++ b/plugins/py3compile/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "py3compile \u2014 py3compile \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/py3compile/plugin.json
+++ b/plugins/py3compile/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "py3compile",
+  "version": "1.0.0",
+  "description": "py3compile \u2014 py3compile \u2014 CLI utility",
+  "source": "/usr/bin/py3compile",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "py3compile"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "py3compile",
+    "binary": "py3compile",
+    "check": "which py3compile",
+    "install_steps": [
+      "# Install py3compile:",
+      "# apt: sudo apt-get install py3compile",
+      "# brew: brew install py3compile",
+      "# cargo: cargo install py3compile",
+      "# npm: npm install -g py3compile",
+      "# pip: pip install py3compile",
+      "# or download from /usr/bin/py3compile"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "py3compile",
+      "resource": "py3compile",
+      "action": "run",
+      "description": "Run py3compile",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "py3compile",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install py3compile from /usr/bin/py3compile"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/py3versions/install-guidance.json
+++ b/plugins/py3versions/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "py3versions",
+  "binary": "py3versions",
+  "check": "which py3versions",
+  "install_steps": [
+    "# Install py3versions",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/py3versions-linux-amd64 -o /usr/local/bin/py3versions",
+    "chmod +x /usr/local/bin/py3versions",
+    "# Or via package manager, see /usr/bin/py3versions"
+  ]
+}

--- a/plugins/py3versions/meta.json
+++ b/plugins/py3versions/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "py3versions \u2014 py3versions \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/py3versions/plugin.json
+++ b/plugins/py3versions/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "py3versions",
+  "version": "1.0.0",
+  "description": "py3versions \u2014 py3versions \u2014 CLI utility",
+  "source": "/usr/bin/py3versions",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "py3versions"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "py3versions",
+    "binary": "py3versions",
+    "check": "which py3versions",
+    "install_steps": [
+      "# Install py3versions:",
+      "# apt: sudo apt-get install py3versions",
+      "# brew: brew install py3versions",
+      "# cargo: cargo install py3versions",
+      "# npm: npm install -g py3versions",
+      "# pip: pip install py3versions",
+      "# or download from /usr/bin/py3versions"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "py3versions",
+      "resource": "py3versions",
+      "action": "run",
+      "description": "Run py3versions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "py3versions",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install py3versions from /usr/bin/py3versions"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pygettext3.12/install-guidance.json
+++ b/plugins/pygettext3.12/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "pygettext3.12",
+  "binary": "pygettext3.12",
+  "check": "which pygettext3.12",
+  "install_steps": [
+    "# Install pygettext3.12",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/pygettext3.12-linux-amd64 -o /usr/local/bin/pygettext3.12",
+    "chmod +x /usr/local/bin/pygettext3.12",
+    "# Or via package manager, see /usr/bin/pygettext3.12"
+  ]
+}

--- a/plugins/pygettext3.12/meta.json
+++ b/plugins/pygettext3.12/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "pygettext3.12 \u2014 pygettext3.12 \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/pygettext3.12/plugin.json
+++ b/plugins/pygettext3.12/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "pygettext3.12",
+  "version": "1.0.0",
+  "description": "pygettext3.12 \u2014 pygettext3.12 \u2014 CLI utility",
+  "source": "/usr/bin/pygettext3.12",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "pygettext3.12"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "pygettext3.12",
+    "binary": "pygettext3.12",
+    "check": "which pygettext3.12",
+    "install_steps": [
+      "# Install pygettext3.12:",
+      "# apt: sudo apt-get install pygettext3.12",
+      "# brew: brew install pygettext3.12",
+      "# cargo: cargo install pygettext3.12",
+      "# npm: npm install -g pygettext3.12",
+      "# pip: pip install pygettext3.12",
+      "# or download from /usr/bin/pygettext3.12"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "pygettext3.12",
+      "resource": "pygettext3.12",
+      "action": "run",
+      "description": "Run pygettext3.12",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pygettext3.12",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install pygettext3.12 from /usr/bin/pygettext3.12"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pygettext3/install-guidance.json
+++ b/plugins/pygettext3/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "pygettext3",
+  "binary": "pygettext3",
+  "check": "which pygettext3",
+  "install_steps": [
+    "# Install pygettext3",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/pygettext3-linux-amd64 -o /usr/local/bin/pygettext3",
+    "chmod +x /usr/local/bin/pygettext3",
+    "# Or via package manager, see /usr/bin/pygettext3"
+  ]
+}

--- a/plugins/pygettext3/meta.json
+++ b/plugins/pygettext3/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "pygettext3 \u2014 pygettext3 \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/pygettext3/plugin.json
+++ b/plugins/pygettext3/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "pygettext3",
+  "version": "1.0.0",
+  "description": "pygettext3 \u2014 pygettext3 \u2014 CLI utility",
+  "source": "/usr/bin/pygettext3",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "pygettext3"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "pygettext3",
+    "binary": "pygettext3",
+    "check": "which pygettext3",
+    "install_steps": [
+      "# Install pygettext3:",
+      "# apt: sudo apt-get install pygettext3",
+      "# brew: brew install pygettext3",
+      "# cargo: cargo install pygettext3",
+      "# npm: npm install -g pygettext3",
+      "# pip: pip install pygettext3",
+      "# or download from /usr/bin/pygettext3"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "pygettext3",
+      "resource": "pygettext3",
+      "action": "run",
+      "description": "Run pygettext3",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pygettext3",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install pygettext3 from /usr/bin/pygettext3"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pypy/install-guidance.json
+++ b/plugins/pypy/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "pypy",
+  "binary": "pypy",
+  "check": "which pypy",
+  "install_steps": [
+    "# Install pypy",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/pypy-linux-amd64 -o /usr/local/bin/pypy",
+    "chmod +x /usr/local/bin/pypy",
+    "# Or via package manager, see pypy.org"
+  ]
+}

--- a/plugins/pypy/meta.json
+++ b/plugins/pypy/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "pypy \u2014 Python JIT implementation",
+  "tags": [
+    "python",
+    "runtime"
+  ],
+  "has_learn": false
+}

--- a/plugins/pypy/plugin.json
+++ b/plugins/pypy/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "pypy",
+  "version": "1.0.0",
+  "description": "pypy \u2014 Python JIT implementation",
+  "source": "pypy.org",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "pypy"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "pypy",
+    "binary": "pypy",
+    "check": "which pypy",
+    "install_steps": [
+      "# Install pypy:",
+      "# apt: sudo apt-get install pypy",
+      "# brew: brew install pypy",
+      "# cargo: cargo install pypy",
+      "# npm: npm install -g pypy",
+      "# pip: pip install pypy",
+      "# or download from pypy.org"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "pypy",
+      "resource": "pypy",
+      "action": "run",
+      "description": "Run pypy",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pypy",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install pypy from pypy.org"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/qemu/install-guidance.json
+++ b/plugins/qemu/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "qemu",
+  "binary": "qemu",
+  "check": "which qemu",
+  "install_steps": [
+    "# Install qemu",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/qemu-linux-amd64 -o /usr/local/bin/qemu",
+    "chmod +x /usr/local/bin/qemu",
+    "# Or via package manager, see qemu.org"
+  ]
+}

--- a/plugins/qemu/meta.json
+++ b/plugins/qemu/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "qemu \u2014 Machine emulator CLI",
+  "tags": [
+    "virtualization",
+    "emulator"
+  ],
+  "has_learn": false
+}

--- a/plugins/qemu/plugin.json
+++ b/plugins/qemu/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "qemu",
+  "version": "1.0.0",
+  "description": "qemu \u2014 Machine emulator CLI",
+  "source": "qemu.org",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "qemu"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "qemu",
+    "binary": "qemu",
+    "check": "which qemu",
+    "install_steps": [
+      "# Install qemu:",
+      "# apt: sudo apt-get install qemu",
+      "# brew: brew install qemu",
+      "# cargo: cargo install qemu",
+      "# npm: npm install -g qemu",
+      "# pip: pip install qemu",
+      "# or download from qemu.org"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "qemu",
+      "resource": "qemu",
+      "action": "run",
+      "description": "Run qemu",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "qemu",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install qemu from qemu.org"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/qmqp-sink/install-guidance.json
+++ b/plugins/qmqp-sink/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "qmqp-sink",
+  "binary": "qmqp-sink",
+  "check": "which qmqp-sink",
+  "install_steps": [
+    "# Install qmqp-sink",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/qmqp-sink-linux-amd64 -o /usr/local/bin/qmqp-sink",
+    "chmod +x /usr/local/bin/qmqp-sink",
+    "# Or via package manager, see /usr/sbin/qmqp-sink"
+  ]
+}

--- a/plugins/qmqp-sink/meta.json
+++ b/plugins/qmqp-sink/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "qmqp-sink \u2014 qmqp-sink \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/qmqp-sink/plugin.json
+++ b/plugins/qmqp-sink/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "qmqp-sink",
+  "version": "1.0.0",
+  "description": "qmqp-sink \u2014 qmqp-sink \u2014 CLI utility",
+  "source": "/usr/sbin/qmqp-sink",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "qmqp-sink"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "qmqp-sink",
+    "binary": "qmqp-sink",
+    "check": "which qmqp-sink",
+    "install_steps": [
+      "# Install qmqp-sink:",
+      "# apt: sudo apt-get install qmqp-sink",
+      "# brew: brew install qmqp-sink",
+      "# cargo: cargo install qmqp-sink",
+      "# npm: npm install -g qmqp-sink",
+      "# pip: pip install qmqp-sink",
+      "# or download from /usr/sbin/qmqp-sink"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "qmqp",
+      "resource": "sink",
+      "action": "run",
+      "description": "Run qmqp-sink",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "qmqp-sink",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install qmqp-sink from /usr/sbin/qmqp-sink"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/qmqp-source/install-guidance.json
+++ b/plugins/qmqp-source/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "qmqp-source",
+  "binary": "qmqp-source",
+  "check": "which qmqp-source",
+  "install_steps": [
+    "# Install qmqp-source",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/qmqp-source-linux-amd64 -o /usr/local/bin/qmqp-source",
+    "chmod +x /usr/local/bin/qmqp-source",
+    "# Or via package manager, see /usr/sbin/qmqp-source"
+  ]
+}

--- a/plugins/qmqp-source/meta.json
+++ b/plugins/qmqp-source/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "qmqp-source \u2014 qmqp-source \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/qmqp-source/plugin.json
+++ b/plugins/qmqp-source/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "qmqp-source",
+  "version": "1.0.0",
+  "description": "qmqp-source \u2014 qmqp-source \u2014 CLI utility",
+  "source": "/usr/sbin/qmqp-source",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "qmqp-source"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "qmqp-source",
+    "binary": "qmqp-source",
+    "check": "which qmqp-source",
+    "install_steps": [
+      "# Install qmqp-source:",
+      "# apt: sudo apt-get install qmqp-source",
+      "# brew: brew install qmqp-source",
+      "# cargo: cargo install qmqp-source",
+      "# npm: npm install -g qmqp-source",
+      "# pip: pip install qmqp-source",
+      "# or download from /usr/sbin/qmqp-source"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "qmqp",
+      "resource": "source",
+      "action": "run",
+      "description": "Run qmqp-source",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "qmqp-source",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install qmqp-source from /usr/sbin/qmqp-source"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/qrss/install-guidance.json
+++ b/plugins/qrss/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "qrss",
+  "binary": "qrss",
+  "check": "which qrss",
+  "install_steps": [
+    "# Install qrss",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/qrss-linux-amd64 -o /usr/local/bin/qrss",
+    "chmod +x /usr/local/bin/qrss",
+    "# Or via package manager, see github.com/lord63/qrss"
+  ]
+}

--- a/plugins/qrss/meta.json
+++ b/plugins/qrss/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "qrss \u2014 QR code in terminal",
+  "tags": [
+    "utility",
+    "qr"
+  ],
+  "has_learn": false
+}

--- a/plugins/qrss/plugin.json
+++ b/plugins/qrss/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "qrss",
+  "version": "1.0.0",
+  "description": "qrss \u2014 QR code in terminal",
+  "source": "github.com/lord63/qrss",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "qrss"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "qrss",
+    "binary": "qrss",
+    "check": "which qrss",
+    "install_steps": [
+      "# Install qrss:",
+      "# apt: sudo apt-get install qrss",
+      "# brew: brew install qrss",
+      "# cargo: cargo install qrss",
+      "# npm: npm install -g qrss",
+      "# pip: pip install qrss",
+      "# or download from github.com/lord63/qrss"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "qrss",
+      "resource": "qrss",
+      "action": "run",
+      "description": "Run qrss",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "qrss",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install qrss from github.com/lord63/qrss"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/qshape/install-guidance.json
+++ b/plugins/qshape/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "qshape",
+  "binary": "qshape",
+  "check": "which qshape",
+  "install_steps": [
+    "# Install qshape",
+    "curl -sS https://github.com/$REPO/$REPO/releases/latest/download/qshape-linux-amd64 -o /usr/local/bin/qshape",
+    "chmod +x /usr/local/bin/qshape",
+    "# Or via package manager, see /usr/sbin/qshape"
+  ]
+}

--- a/plugins/qshape/meta.json
+++ b/plugins/qshape/meta.json
@@ -1,0 +1,8 @@
+{
+  "description": "qshape \u2014 qshape \u2014 CLI utility",
+  "tags": [
+    "utility",
+    "cli"
+  ],
+  "has_learn": false
+}

--- a/plugins/qshape/plugin.json
+++ b/plugins/qshape/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "qshape",
+  "version": "1.0.0",
+  "description": "qshape \u2014 qshape \u2014 CLI utility",
+  "source": "/usr/sbin/qshape",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "qshape"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "qshape",
+    "binary": "qshape",
+    "check": "which qshape",
+    "install_steps": [
+      "# Install qshape:",
+      "# apt: sudo apt-get install qshape",
+      "# brew: brew install qshape",
+      "# cargo: cargo install qshape",
+      "# npm: npm install -g qshape",
+      "# pip: pip install qshape",
+      "# or download from /usr/sbin/qshape"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "qshape",
+      "resource": "qshape",
+      "action": "run",
+      "description": "Run qshape",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "qshape",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install qshape from /usr/sbin/qshape"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Batch 018 of 31 — adding 20 new bundled plugin definitions.

## Plugins

- systemd-+-dbus-daemon
        |-python-+-bash---python3---sh---pstree.x11
        |        |-timeout
        |        `-10*[{python}]
        |-systemd-journal
        |-systemd-network
        `-systemd-resolve
- 
- 
- No pattern specified
Usage:
      ptargrep [options] <pattern> <tar file> ...

      Options:

       --basename|-b     ignore directory paths from archive
       --ignore-case|-i  do case-insensitive pattern matching
       --list-only|-l    list matching filenames rather than extracting matches
       --verbose|-v      write debugging message to STDERR
       --help|-?         detailed help message
- user 'lp': directory '/var/spool/lpd' does not exist
user 'news': directory '/var/spool/news' does not exist
user 'uucp': directory '/var/spool/uucp' does not exist
user 'www-data': directory '/var/www' does not exist
user 'list': directory '/var/list' does not exist
user 'irc': directory '/run/ircd' does not exist
pwck: no changes
- 
- /root/projects/supercli
- 
- 
- Usage: py3clean [-V VERSION] [-p PACKAGE] [DIR_OR_FILE]
- Usage: py3compile [-V [X.Y][-][A.B]] DIR_OR_FILE [-X REGEXPR]
       py3compile -p PACKAGE
- 
- 
- 
- 
- 
- 
- 
- 
-                                          T  5 10 20 40 80 160 320 640 1280 1280+
                                  TOTAL  0  0  0  0  0  0   0   0   0    0     0

## Details
- Auto-generated from curated CLI tool list
- Each plugin includes plugin.json, meta.json, install-guidance.json
- Binary checks reference install guidance