### PR TITLE
feat: add 20 bundled plugins (batch 022/31)

### DIFF
--- a/plugins/bzcmp/install-guidance.json
+++ b/plugins/bzcmp/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "bzcmp",
+  "binary": "bzcmp",
+  "check": "which bzcmp",
+  "install_steps": [
+    "Install via package manager: apt install bzcmp or brew install bzcmp"
+  ]
+}

--- a/plugins/bzcmp/meta.json
+++ b/plugins/bzcmp/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "bzcmp \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/bzcmp/plugin.json
+++ b/plugins/bzcmp/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "bzcmp",
+  "version": "1.0.0",
+  "description": "bzcmp \u2014 CLI bzcmp \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=bzcmp+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bzcmp"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bzcmp",
+    "binary": "bzcmp",
+    "check": "which bzcmp",
+    "install_steps": [
+      "Install via package manager: apt install bzcmp or brew install bzcmp"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bzcmp",
+      "resource": "run",
+      "action": "exec",
+      "description": "bzcmp \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bzcmp",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bzcmp via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bzdiff/install-guidance.json
+++ b/plugins/bzdiff/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "bzdiff",
+  "binary": "bzdiff",
+  "check": "which bzdiff",
+  "install_steps": [
+    "Install via package manager: apt install bzdiff or brew install bzdiff"
+  ]
+}

--- a/plugins/bzdiff/meta.json
+++ b/plugins/bzdiff/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "bzdiff \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/bzdiff/plugin.json
+++ b/plugins/bzdiff/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "bzdiff",
+  "version": "1.0.0",
+  "description": "bzdiff \u2014 CLI bzdiff \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=bzdiff+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bzdiff"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bzdiff",
+    "binary": "bzdiff",
+    "check": "which bzdiff",
+    "install_steps": [
+      "Install via package manager: apt install bzdiff or brew install bzdiff"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bzdiff",
+      "resource": "run",
+      "action": "exec",
+      "description": "bzdiff \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bzdiff",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bzdiff via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bzegrep/install-guidance.json
+++ b/plugins/bzegrep/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "bzegrep",
+  "binary": "bzegrep",
+  "check": "which bzegrep",
+  "install_steps": [
+    "Install via package manager: apt install bzegrep or brew install bzegrep"
+  ]
+}

--- a/plugins/bzegrep/meta.json
+++ b/plugins/bzegrep/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "bzegrep \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/bzegrep/plugin.json
+++ b/plugins/bzegrep/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "bzegrep",
+  "version": "1.0.0",
+  "description": "bzegrep \u2014 CLI bzegrep \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=bzegrep+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bzegrep"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bzegrep",
+    "binary": "bzegrep",
+    "check": "which bzegrep",
+    "install_steps": [
+      "Install via package manager: apt install bzegrep or brew install bzegrep"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bzegrep",
+      "resource": "run",
+      "action": "exec",
+      "description": "bzegrep \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bzegrep",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bzegrep via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bzexe/install-guidance.json
+++ b/plugins/bzexe/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "bzexe",
+  "binary": "bzexe",
+  "check": "which bzexe",
+  "install_steps": [
+    "Install via package manager: apt install bzexe or brew install bzexe"
+  ]
+}

--- a/plugins/bzexe/meta.json
+++ b/plugins/bzexe/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "bzexe \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/bzexe/plugin.json
+++ b/plugins/bzexe/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "bzexe",
+  "version": "1.0.0",
+  "description": "bzexe \u2014 CLI bzexe \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=bzexe+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bzexe"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bzexe",
+    "binary": "bzexe",
+    "check": "which bzexe",
+    "install_steps": [
+      "Install via package manager: apt install bzexe or brew install bzexe"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bzexe",
+      "resource": "run",
+      "action": "exec",
+      "description": "bzexe \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bzexe",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bzexe via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bzfgrep/install-guidance.json
+++ b/plugins/bzfgrep/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "bzfgrep",
+  "binary": "bzfgrep",
+  "check": "which bzfgrep",
+  "install_steps": [
+    "Install via package manager: apt install bzfgrep or brew install bzfgrep"
+  ]
+}

--- a/plugins/bzfgrep/meta.json
+++ b/plugins/bzfgrep/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "bzfgrep \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/bzfgrep/plugin.json
+++ b/plugins/bzfgrep/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "bzfgrep",
+  "version": "1.0.0",
+  "description": "bzfgrep \u2014 CLI bzfgrep \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=bzfgrep+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bzfgrep"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bzfgrep",
+    "binary": "bzfgrep",
+    "check": "which bzfgrep",
+    "install_steps": [
+      "Install via package manager: apt install bzfgrep or brew install bzfgrep"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bzfgrep",
+      "resource": "run",
+      "action": "exec",
+      "description": "bzfgrep \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bzfgrep",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bzfgrep via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bzgrep/install-guidance.json
+++ b/plugins/bzgrep/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "bzgrep",
+  "binary": "bzgrep",
+  "check": "which bzgrep",
+  "install_steps": [
+    "Install via package manager: apt install bzgrep or brew install bzgrep"
+  ]
+}

--- a/plugins/bzgrep/meta.json
+++ b/plugins/bzgrep/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "bzgrep \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/bzgrep/plugin.json
+++ b/plugins/bzgrep/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "bzgrep",
+  "version": "1.0.0",
+  "description": "bzgrep \u2014 CLI bzgrep \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=bzgrep+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bzgrep"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bzgrep",
+    "binary": "bzgrep",
+    "check": "which bzgrep",
+    "install_steps": [
+      "Install via package manager: apt install bzgrep or brew install bzgrep"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bzgrep",
+      "resource": "run",
+      "action": "exec",
+      "description": "bzgrep \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bzgrep",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bzgrep via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bzip2recover/install-guidance.json
+++ b/plugins/bzip2recover/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "bzip2recover",
+  "binary": "bzip2recover",
+  "check": "which bzip2recover",
+  "install_steps": [
+    "Install via package manager: apt install bzip2recover or brew install bzip2recover"
+  ]
+}

--- a/plugins/bzip2recover/meta.json
+++ b/plugins/bzip2recover/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "bzip2recover \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/bzip2recover/plugin.json
+++ b/plugins/bzip2recover/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "bzip2recover",
+  "version": "1.0.0",
+  "description": "bzip2recover \u2014 CLI bzip2recover \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=bzip2recover+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bzip2recover"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bzip2recover",
+    "binary": "bzip2recover",
+    "check": "which bzip2recover",
+    "install_steps": [
+      "Install via package manager: apt install bzip2recover or brew install bzip2recover"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bzip2recover",
+      "resource": "run",
+      "action": "exec",
+      "description": "bzip2recover \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bzip2recover",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bzip2recover via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bzless/install-guidance.json
+++ b/plugins/bzless/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "bzless",
+  "binary": "bzless",
+  "check": "which bzless",
+  "install_steps": [
+    "Install via package manager: apt install bzless or brew install bzless"
+  ]
+}

--- a/plugins/bzless/meta.json
+++ b/plugins/bzless/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "bzless \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/bzless/plugin.json
+++ b/plugins/bzless/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "bzless",
+  "version": "1.0.0",
+  "description": "bzless \u2014 CLI bzless \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=bzless+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bzless"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bzless",
+    "binary": "bzless",
+    "check": "which bzless",
+    "install_steps": [
+      "Install via package manager: apt install bzless or brew install bzless"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bzless",
+      "resource": "run",
+      "action": "exec",
+      "description": "bzless \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bzless",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bzless via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/bzmore/install-guidance.json
+++ b/plugins/bzmore/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "bzmore",
+  "binary": "bzmore",
+  "check": "which bzmore",
+  "install_steps": [
+    "Install via package manager: apt install bzmore or brew install bzmore"
+  ]
+}

--- a/plugins/bzmore/meta.json
+++ b/plugins/bzmore/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "bzmore \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/bzmore/plugin.json
+++ b/plugins/bzmore/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "bzmore",
+  "version": "1.0.0",
+  "description": "bzmore \u2014 CLI bzmore \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=bzmore+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "bzmore"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "bzmore",
+    "binary": "bzmore",
+    "check": "which bzmore",
+    "install_steps": [
+      "Install via package manager: apt install bzmore or brew install bzmore"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "bzmore",
+      "resource": "run",
+      "action": "exec",
+      "description": "bzmore \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "bzmore",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install bzmore via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/c89-gcc/install-guidance.json
+++ b/plugins/c89-gcc/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "c89-gcc",
+  "binary": "c89-gcc",
+  "check": "which c89-gcc",
+  "install_steps": [
+    "Install via package manager: apt install c89-gcc or brew install c89-gcc"
+  ]
+}

--- a/plugins/c89-gcc/meta.json
+++ b/plugins/c89-gcc/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "c89-gcc \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/c89-gcc/plugin.json
+++ b/plugins/c89-gcc/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "c89-gcc",
+  "version": "1.0.0",
+  "description": "c89-gcc \u2014 CLI c89-gcc \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=c89-gcc+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "c89-gcc"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "c89-gcc",
+    "binary": "c89-gcc",
+    "check": "which c89-gcc",
+    "install_steps": [
+      "Install via package manager: apt install c89-gcc or brew install c89-gcc"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "c89gcc",
+      "resource": "run",
+      "action": "exec",
+      "description": "c89-gcc \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "c89-gcc",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install c89-gcc via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/c89/install-guidance.json
+++ b/plugins/c89/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "c89",
+  "binary": "c89",
+  "check": "which c89",
+  "install_steps": [
+    "Install via package manager: apt install c89 or brew install c89"
+  ]
+}

--- a/plugins/c89/meta.json
+++ b/plugins/c89/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "c89 \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/c89/plugin.json
+++ b/plugins/c89/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "c89",
+  "version": "1.0.0",
+  "description": "c89 \u2014 CLI c89 \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=c89+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "c89"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "c89",
+    "binary": "c89",
+    "check": "which c89",
+    "install_steps": [
+      "Install via package manager: apt install c89 or brew install c89"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "c89",
+      "resource": "run",
+      "action": "exec",
+      "description": "c89 \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "c89",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install c89 via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/c99-gcc/install-guidance.json
+++ b/plugins/c99-gcc/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "c99-gcc",
+  "binary": "c99-gcc",
+  "check": "which c99-gcc",
+  "install_steps": [
+    "Install via package manager: apt install c99-gcc or brew install c99-gcc"
+  ]
+}

--- a/plugins/c99-gcc/meta.json
+++ b/plugins/c99-gcc/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "c99-gcc \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/c99-gcc/plugin.json
+++ b/plugins/c99-gcc/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "c99-gcc",
+  "version": "1.0.0",
+  "description": "c99-gcc \u2014 CLI c99-gcc \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=c99-gcc+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "c99-gcc"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "c99-gcc",
+    "binary": "c99-gcc",
+    "check": "which c99-gcc",
+    "install_steps": [
+      "Install via package manager: apt install c99-gcc or brew install c99-gcc"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "c99gcc",
+      "resource": "run",
+      "action": "exec",
+      "description": "c99-gcc \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "c99-gcc",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install c99-gcc via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/c99/install-guidance.json
+++ b/plugins/c99/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "c99",
+  "binary": "c99",
+  "check": "which c99",
+  "install_steps": [
+    "Install via package manager: apt install c99 or brew install c99"
+  ]
+}

--- a/plugins/c99/meta.json
+++ b/plugins/c99/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "c99 \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/c99/plugin.json
+++ b/plugins/c99/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "c99",
+  "version": "1.0.0",
+  "description": "c99 \u2014 CLI c99 \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=c99+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "c99"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "c99",
+    "binary": "c99",
+    "check": "which c99",
+    "install_steps": [
+      "Install via package manager: apt install c99 or brew install c99"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "c99",
+      "resource": "run",
+      "action": "exec",
+      "description": "c99 \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "c99",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install c99 via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cachegrind/install-guidance.json
+++ b/plugins/cachegrind/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "cachegrind",
+  "binary": "cachegrind",
+  "check": "which cachegrind",
+  "install_steps": [
+    "Install cachegrind via package manager: apt install cachegrind or brew install cachegrind"
+  ]
+}

--- a/plugins/cachegrind/meta.json
+++ b/plugins/cachegrind/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "cachegrind \u2014 CLI utility",
+  "tags": [
+    "multiple",
+    "cli",
+    "cachegrind"
+  ],
+  "has_learn": false
+}

--- a/plugins/cachegrind/plugin.json
+++ b/plugins/cachegrind/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "cachegrind",
+  "version": "1.0.0",
+  "description": "cachegrind \u2014 CLI CLI utility",
+  "source": "https://github.com/search?q=cachegrind+cli&type=repositories",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cachegrind"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cachegrind",
+    "binary": "cachegrind",
+    "check": "which cachegrind",
+    "install_steps": [
+      "Install cachegrind via package manager: apt install cachegrind or brew install cachegrind"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cachegrind",
+      "resource": "run",
+      "action": "exec",
+      "description": "cachegrind \u2014 CLI utility",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cachegrind",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cachegrind via your package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/captoinfo/install-guidance.json
+++ b/plugins/captoinfo/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "captoinfo",
+  "binary": "captoinfo",
+  "check": "which captoinfo",
+  "install_steps": [
+    "Install via package manager: apt install captoinfo or brew install captoinfo"
+  ]
+}

--- a/plugins/captoinfo/meta.json
+++ b/plugins/captoinfo/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "captoinfo \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/captoinfo/plugin.json
+++ b/plugins/captoinfo/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "captoinfo",
+  "version": "1.0.0",
+  "description": "captoinfo \u2014 CLI captoinfo \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=captoinfo+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "captoinfo"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "captoinfo",
+    "binary": "captoinfo",
+    "check": "which captoinfo",
+    "install_steps": [
+      "Install via package manager: apt install captoinfo or brew install captoinfo"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "captoinfo",
+      "resource": "run",
+      "action": "exec",
+      "description": "captoinfo \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "captoinfo",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install captoinfo via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cdk8s/install-guidance.json
+++ b/plugins/cdk8s/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "cdk8s",
+  "binary": "cdk8s",
+  "check": "which cdk8s",
+  "install_steps": [
+    "Install cdk8s via package manager: apt install cdk8s or brew install cdk8s"
+  ]
+}

--- a/plugins/cdk8s/meta.json
+++ b/plugins/cdk8s/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "cdk8s \u2014 CLI utility",
+  "tags": [
+    "multiple",
+    "cli",
+    "cdk8s"
+  ],
+  "has_learn": false
+}

--- a/plugins/cdk8s/plugin.json
+++ b/plugins/cdk8s/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "cdk8s",
+  "version": "1.0.0",
+  "description": "cdk8s \u2014 CLI CLI utility",
+  "source": "https://github.com/search?q=cdk8s+cli&type=repositories",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cdk8s"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cdk8s",
+    "binary": "cdk8s",
+    "check": "which cdk8s",
+    "install_steps": [
+      "Install cdk8s via package manager: apt install cdk8s or brew install cdk8s"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cdk8s",
+      "resource": "run",
+      "action": "exec",
+      "description": "cdk8s \u2014 CLI utility",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cdk8s",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cdk8s via your package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/chattr/install-guidance.json
+++ b/plugins/chattr/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "chattr",
+  "binary": "chattr",
+  "check": "which chattr",
+  "install_steps": [
+    "Install via package manager: apt install chattr or brew install chattr"
+  ]
+}

--- a/plugins/chattr/meta.json
+++ b/plugins/chattr/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "chattr \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/chattr/plugin.json
+++ b/plugins/chattr/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "chattr",
+  "version": "1.0.0",
+  "description": "chattr \u2014 CLI chattr \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=chattr+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "chattr"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "chattr",
+    "binary": "chattr",
+    "check": "which chattr",
+    "install_steps": [
+      "Install via package manager: apt install chattr or brew install chattr"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "chattr",
+      "resource": "run",
+      "action": "exec",
+      "description": "chattr \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "chattr",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install chattr via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/chcpu/install-guidance.json
+++ b/plugins/chcpu/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "chcpu",
+  "binary": "chcpu",
+  "check": "which chcpu",
+  "install_steps": [
+    "Install via package manager: apt install chcpu or brew install chcpu"
+  ]
+}

--- a/plugins/chcpu/meta.json
+++ b/plugins/chcpu/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "chcpu \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/chcpu/plugin.json
+++ b/plugins/chcpu/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "chcpu",
+  "version": "1.0.0",
+  "description": "chcpu \u2014 CLI chcpu \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=chcpu+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "chcpu"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "chcpu",
+    "binary": "chcpu",
+    "check": "which chcpu",
+    "install_steps": [
+      "Install via package manager: apt install chcpu or brew install chcpu"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "chcpu",
+      "resource": "run",
+      "action": "exec",
+      "description": "chcpu \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "chcpu",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install chcpu via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/chmem/install-guidance.json
+++ b/plugins/chmem/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "chmem",
+  "binary": "chmem",
+  "check": "which chmem",
+  "install_steps": [
+    "Install via package manager: apt install chmem or brew install chmem"
+  ]
+}

--- a/plugins/chmem/meta.json
+++ b/plugins/chmem/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "chmem \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/chmem/plugin.json
+++ b/plugins/chmem/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "chmem",
+  "version": "1.0.0",
+  "description": "chmem \u2014 CLI chmem \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=chmem+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "chmem"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "chmem",
+    "binary": "chmem",
+    "check": "which chmem",
+    "install_steps": [
+      "Install via package manager: apt install chmem or brew install chmem"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "chmem",
+      "resource": "run",
+      "action": "exec",
+      "description": "chmem \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "chmem",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install chmem via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/chmod/install-guidance.json
+++ b/plugins/chmod/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "chmod",
+  "binary": "chmod",
+  "check": "which chmod",
+  "install_steps": [
+    "Install via package manager: apt install chmod or brew install chmod"
+  ]
+}

--- a/plugins/chmod/meta.json
+++ b/plugins/chmod/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "chmod \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/chmod/plugin.json
+++ b/plugins/chmod/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "chmod",
+  "version": "1.0.0",
+  "description": "chmod \u2014 CLI chmod \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=chmod+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "chmod"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "chmod",
+    "binary": "chmod",
+    "check": "which chmod",
+    "install_steps": [
+      "Install via package manager: apt install chmod or brew install chmod"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "chmod",
+      "resource": "run",
+      "action": "exec",
+      "description": "chmod \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "chmod",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install chmod via package manager"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Batch 022 of 31 — adding 20 new bundled plugin definitions.\n\n## Plugins\n\n- Usage: bzcmp [cmp_options] file [file]
- Usage: bzdiff [diff_options] file [file]
- grep through bzip2 files
usage: bzegrep [grep_options] pattern [files]
- compress executables. original file foo is renamed to foo~
usage: bzexe [-d] files...
   -d  decompress the executables
- grep through bzip2 files
usage: bzfgrep [grep_options] pattern [files]
- grep through bzip2 files
usage: bzgrep [grep_options] pattern [files]
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 