### PR TITLE
feat: add curated CLI tools (batch 023/31)

### DIFF
--- a/plugins/choom/install-guidance.json
+++ b/plugins/choom/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "choom",
+  "binary": "choom",
+  "check": "which choom",
+  "install_steps": [
+    "Install via package manager: apt install choom or brew install choom"
+  ]
+}

--- a/plugins/choom/meta.json
+++ b/plugins/choom/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "choom \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/choom/plugin.json
+++ b/plugins/choom/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "choom",
+  "version": "1.0.0",
+  "description": "choom \u2014 CLI choom \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=choom+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "choom"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "choom",
+    "binary": "choom",
+    "check": "which choom",
+    "install_steps": [
+      "Install via package manager: apt install choom or brew install choom"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "choom",
+      "resource": "run",
+      "action": "exec",
+      "description": "choom \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "choom",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install choom via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/chown/install-guidance.json
+++ b/plugins/chown/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "chown",
+  "binary": "chown",
+  "check": "which chown",
+  "install_steps": [
+    "Install via package manager: apt install chown or brew install chown"
+  ]
+}

--- a/plugins/chown/meta.json
+++ b/plugins/chown/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "chown \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/chown/plugin.json
+++ b/plugins/chown/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "chown",
+  "version": "1.0.0",
+  "description": "chown \u2014 CLI chown \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=chown+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "chown"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "chown",
+    "binary": "chown",
+    "check": "which chown",
+    "install_steps": [
+      "Install via package manager: apt install chown or brew install chown"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "chown",
+      "resource": "run",
+      "action": "exec",
+      "description": "chown \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "chown",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install chown via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/chpasswd/install-guidance.json
+++ b/plugins/chpasswd/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "chpasswd",
+  "binary": "chpasswd",
+  "check": "which chpasswd",
+  "install_steps": [
+    "Install via package manager: apt install chpasswd or brew install chpasswd"
+  ]
+}

--- a/plugins/chpasswd/meta.json
+++ b/plugins/chpasswd/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "chpasswd \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/chpasswd/plugin.json
+++ b/plugins/chpasswd/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "chpasswd",
+  "version": "1.0.0",
+  "description": "chpasswd \u2014 CLI chpasswd \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=chpasswd+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "chpasswd"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "chpasswd",
+    "binary": "chpasswd",
+    "check": "which chpasswd",
+    "install_steps": [
+      "Install via package manager: apt install chpasswd or brew install chpasswd"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "chpasswd",
+      "resource": "run",
+      "action": "exec",
+      "description": "chpasswd \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "chpasswd",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install chpasswd via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/chvt/install-guidance.json
+++ b/plugins/chvt/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "chvt",
+  "binary": "chvt",
+  "check": "which chvt",
+  "install_steps": [
+    "Install via package manager: apt install chvt or brew install chvt"
+  ]
+}

--- a/plugins/chvt/meta.json
+++ b/plugins/chvt/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "chvt \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/chvt/plugin.json
+++ b/plugins/chvt/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "chvt",
+  "version": "1.0.0",
+  "description": "chvt \u2014 CLI chvt \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=chvt+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "chvt"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "chvt",
+    "binary": "chvt",
+    "check": "which chvt",
+    "install_steps": [
+      "Install via package manager: apt install chvt or brew install chvt"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "chvt",
+      "resource": "run",
+      "action": "exec",
+      "description": "chvt \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "chvt",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install chvt via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cifsiostat/install-guidance.json
+++ b/plugins/cifsiostat/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "cifsiostat",
+  "binary": "cifsiostat",
+  "check": "which cifsiostat",
+  "install_steps": [
+    "Install via package manager: apt install cifsiostat or brew install cifsiostat"
+  ]
+}

--- a/plugins/cifsiostat/meta.json
+++ b/plugins/cifsiostat/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "cifsiostat \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/cifsiostat/plugin.json
+++ b/plugins/cifsiostat/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "cifsiostat",
+  "version": "1.0.0",
+  "description": "cifsiostat \u2014 CLI cifsiostat \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=cifsiostat+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cifsiostat"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cifsiostat",
+    "binary": "cifsiostat",
+    "check": "which cifsiostat",
+    "install_steps": [
+      "Install via package manager: apt install cifsiostat or brew install cifsiostat"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cifsiostat",
+      "resource": "run",
+      "action": "exec",
+      "description": "cifsiostat \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cifsiostat",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cifsiostat via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ckbcomp/install-guidance.json
+++ b/plugins/ckbcomp/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "ckbcomp",
+  "binary": "ckbcomp",
+  "check": "which ckbcomp",
+  "install_steps": [
+    "Install via package manager: apt install ckbcomp or brew install ckbcomp"
+  ]
+}

--- a/plugins/ckbcomp/meta.json
+++ b/plugins/ckbcomp/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "ckbcomp \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/ckbcomp/plugin.json
+++ b/plugins/ckbcomp/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "ckbcomp",
+  "version": "1.0.0",
+  "description": "ckbcomp \u2014 CLI ckbcomp \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=ckbcomp+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ckbcomp"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ckbcomp",
+    "binary": "ckbcomp",
+    "check": "which ckbcomp",
+    "install_steps": [
+      "Install via package manager: apt install ckbcomp or brew install ckbcomp"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ckbcomp",
+      "resource": "run",
+      "action": "exec",
+      "description": "ckbcomp \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ckbcomp",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ckbcomp via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/codepage/install-guidance.json
+++ b/plugins/codepage/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "codepage",
+  "binary": "codepage",
+  "check": "which codepage",
+  "install_steps": [
+    "Install via package manager: apt install codepage or brew install codepage"
+  ]
+}

--- a/plugins/codepage/meta.json
+++ b/plugins/codepage/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "codepage \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/codepage/plugin.json
+++ b/plugins/codepage/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "codepage",
+  "version": "1.0.0",
+  "description": "codepage \u2014 CLI codepage \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=codepage+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "codepage"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "codepage",
+    "binary": "codepage",
+    "check": "which codepage",
+    "install_steps": [
+      "Install via package manager: apt install codepage or brew install codepage"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "codepage",
+      "resource": "run",
+      "action": "exec",
+      "description": "codepage \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "codepage",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install codepage via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/colcrt/install-guidance.json
+++ b/plugins/colcrt/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "colcrt",
+  "binary": "colcrt",
+  "check": "which colcrt",
+  "install_steps": [
+    "Install via package manager: apt install colcrt or brew install colcrt"
+  ]
+}

--- a/plugins/colcrt/meta.json
+++ b/plugins/colcrt/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "colcrt \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/colcrt/plugin.json
+++ b/plugins/colcrt/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "colcrt",
+  "version": "1.0.0",
+  "description": "colcrt \u2014 CLI colcrt \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=colcrt+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "colcrt"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "colcrt",
+    "binary": "colcrt",
+    "check": "which colcrt",
+    "install_steps": [
+      "Install via package manager: apt install colcrt or brew install colcrt"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "colcrt",
+      "resource": "run",
+      "action": "exec",
+      "description": "colcrt \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "colcrt",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install colcrt via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/colima/install-guidance.json
+++ b/plugins/colima/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "colima",
+  "binary": "colima",
+  "check": "which colima",
+  "install_steps": [
+    "Install colima via package manager: apt install colima or brew install colima"
+  ]
+}

--- a/plugins/colima/meta.json
+++ b/plugins/colima/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "colima \u2014 CLI utility",
+  "tags": [
+    "multiple",
+    "cli",
+    "colima"
+  ],
+  "has_learn": false
+}

--- a/plugins/colima/plugin.json
+++ b/plugins/colima/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "colima",
+  "version": "1.0.0",
+  "description": "colima \u2014 CLI CLI utility",
+  "source": "https://github.com/search?q=colima+cli&type=repositories",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "colima"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "colima",
+    "binary": "colima",
+    "check": "which colima",
+    "install_steps": [
+      "Install colima via package manager: apt install colima or brew install colima"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "colima",
+      "resource": "run",
+      "action": "exec",
+      "description": "colima \u2014 CLI utility",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "colima",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install colima via your package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/commitizen/install-guidance.json
+++ b/plugins/commitizen/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "commitizen",
+  "binary": "commitizen",
+  "check": "which commitizen",
+  "install_steps": [
+    "Install commitizen via package manager: apt install commitizen or brew install commitizen"
+  ]
+}

--- a/plugins/commitizen/meta.json
+++ b/plugins/commitizen/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "commitizen \u2014 CLI utility",
+  "tags": [
+    "multiple",
+    "cli",
+    "commitizen"
+  ],
+  "has_learn": false
+}

--- a/plugins/commitizen/plugin.json
+++ b/plugins/commitizen/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "commitizen",
+  "version": "1.0.0",
+  "description": "commitizen \u2014 CLI CLI utility",
+  "source": "https://github.com/search?q=commitizen+cli&type=repositories",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "commitizen"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "commitizen",
+    "binary": "commitizen",
+    "check": "which commitizen",
+    "install_steps": [
+      "Install commitizen via package manager: apt install commitizen or brew install commitizen"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "commitizen",
+      "resource": "run",
+      "action": "exec",
+      "description": "commitizen \u2014 CLI utility",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "commitizen",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install commitizen via your package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/convert/install-guidance.json
+++ b/plugins/convert/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "convert",
+  "binary": "convert",
+  "check": "which convert",
+  "install_steps": [
+    "Install convert via package manager: apt install convert or brew install convert"
+  ]
+}

--- a/plugins/convert/meta.json
+++ b/plugins/convert/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "convert \u2014 CLI utility",
+  "tags": [
+    "multiple",
+    "cli",
+    "convert"
+  ],
+  "has_learn": false
+}

--- a/plugins/convert/plugin.json
+++ b/plugins/convert/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "convert",
+  "version": "1.0.0",
+  "description": "convert \u2014 CLI CLI utility",
+  "source": "https://github.com/search?q=convert+cli&type=repositories",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "convert"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "convert",
+    "binary": "convert",
+    "check": "which convert",
+    "install_steps": [
+      "Install convert via package manager: apt install convert or brew install convert"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "convert",
+      "resource": "run",
+      "action": "exec",
+      "description": "convert \u2014 CLI utility",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "convert",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install convert via your package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/corepack/install-guidance.json
+++ b/plugins/corepack/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "corepack",
+  "binary": "corepack",
+  "check": "which corepack",
+  "install_steps": [
+    "Install via package manager: apt install corepack or brew install corepack"
+  ]
+}

--- a/plugins/corepack/meta.json
+++ b/plugins/corepack/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "corepack \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/corepack/plugin.json
+++ b/plugins/corepack/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "corepack",
+  "version": "1.0.0",
+  "description": "corepack \u2014 CLI corepack \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=corepack+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "corepack"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "corepack",
+    "binary": "corepack",
+    "check": "which corepack",
+    "install_steps": [
+      "Install via package manager: apt install corepack or brew install corepack"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "corepack",
+      "resource": "run",
+      "action": "exec",
+      "description": "corepack \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "corepack",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install corepack via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cqlsh/install-guidance.json
+++ b/plugins/cqlsh/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "cqlsh",
+  "binary": "cqlsh",
+  "check": "which cqlsh",
+  "install_steps": [
+    "Install cqlsh via package manager: apt install cqlsh or brew install cqlsh"
+  ]
+}

--- a/plugins/cqlsh/meta.json
+++ b/plugins/cqlsh/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "cqlsh \u2014 CLI utility",
+  "tags": [
+    "multiple",
+    "cli",
+    "cqlsh"
+  ],
+  "has_learn": false
+}

--- a/plugins/cqlsh/plugin.json
+++ b/plugins/cqlsh/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "cqlsh",
+  "version": "1.0.0",
+  "description": "cqlsh \u2014 CLI CLI utility",
+  "source": "https://github.com/search?q=cqlsh+cli&type=repositories",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cqlsh"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cqlsh",
+    "binary": "cqlsh",
+    "check": "which cqlsh",
+    "install_steps": [
+      "Install cqlsh via package manager: apt install cqlsh or brew install cqlsh"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cqlsh",
+      "resource": "run",
+      "action": "exec",
+      "description": "cqlsh \u2014 CLI utility",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cqlsh",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cqlsh via your package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/crossplane/install-guidance.json
+++ b/plugins/crossplane/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "crossplane",
+  "binary": "crossplane",
+  "check": "which crossplane",
+  "install_steps": [
+    "Install crossplane via package manager: apt install crossplane or brew install crossplane"
+  ]
+}

--- a/plugins/crossplane/meta.json
+++ b/plugins/crossplane/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "crossplane \u2014 CLI utility",
+  "tags": [
+    "multiple",
+    "cli",
+    "crossplane"
+  ],
+  "has_learn": false
+}

--- a/plugins/crossplane/plugin.json
+++ b/plugins/crossplane/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "crossplane",
+  "version": "1.0.0",
+  "description": "crossplane \u2014 CLI CLI utility",
+  "source": "https://github.com/search?q=crossplane+cli&type=repositories",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "crossplane"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "crossplane",
+    "binary": "crossplane",
+    "check": "which crossplane",
+    "install_steps": [
+      "Install crossplane via package manager: apt install crossplane or brew install crossplane"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "crossplane",
+      "resource": "run",
+      "action": "exec",
+      "description": "crossplane \u2014 CLI utility",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "crossplane",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install crossplane via your package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ctrlaltdel/install-guidance.json
+++ b/plugins/ctrlaltdel/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "ctrlaltdel",
+  "binary": "ctrlaltdel",
+  "check": "which ctrlaltdel",
+  "install_steps": [
+    "Install via package manager: apt install ctrlaltdel or brew install ctrlaltdel"
+  ]
+}

--- a/plugins/ctrlaltdel/meta.json
+++ b/plugins/ctrlaltdel/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "ctrlaltdel \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/ctrlaltdel/plugin.json
+++ b/plugins/ctrlaltdel/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "ctrlaltdel",
+  "version": "1.0.0",
+  "description": "ctrlaltdel \u2014 CLI ctrlaltdel \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=ctrlaltdel+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ctrlaltdel"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ctrlaltdel",
+    "binary": "ctrlaltdel",
+    "check": "which ctrlaltdel",
+    "install_steps": [
+      "Install via package manager: apt install ctrlaltdel or brew install ctrlaltdel"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ctrlaltdel",
+      "resource": "run",
+      "action": "exec",
+      "description": "ctrlaltdel \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ctrlaltdel",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ctrlaltdel via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ctstat/install-guidance.json
+++ b/plugins/ctstat/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "ctstat",
+  "binary": "ctstat",
+  "check": "which ctstat",
+  "install_steps": [
+    "Install via package manager: apt install ctstat or brew install ctstat"
+  ]
+}

--- a/plugins/ctstat/meta.json
+++ b/plugins/ctstat/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "ctstat \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/ctstat/plugin.json
+++ b/plugins/ctstat/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "ctstat",
+  "version": "1.0.0",
+  "description": "ctstat \u2014 CLI ctstat \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=ctstat+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "ctstat"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "ctstat",
+    "binary": "ctstat",
+    "check": "which ctstat",
+    "install_steps": [
+      "Install via package manager: apt install ctstat or brew install ctstat"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ctstat",
+      "resource": "run",
+      "action": "exec",
+      "description": "ctstat \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ctstat",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install ctstat via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cvtsudoers/install-guidance.json
+++ b/plugins/cvtsudoers/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "cvtsudoers",
+  "binary": "cvtsudoers",
+  "check": "which cvtsudoers",
+  "install_steps": [
+    "Install via package manager: apt install cvtsudoers or brew install cvtsudoers"
+  ]
+}

--- a/plugins/cvtsudoers/meta.json
+++ b/plugins/cvtsudoers/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "cvtsudoers \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/cvtsudoers/plugin.json
+++ b/plugins/cvtsudoers/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "cvtsudoers",
+  "version": "1.0.0",
+  "description": "cvtsudoers \u2014 CLI cvtsudoers \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=cvtsudoers+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cvtsudoers"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cvtsudoers",
+    "binary": "cvtsudoers",
+    "check": "which cvtsudoers",
+    "install_steps": [
+      "Install via package manager: apt install cvtsudoers or brew install cvtsudoers"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "cvtsudoers",
+      "resource": "run",
+      "action": "exec",
+      "description": "cvtsudoers \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cvtsudoers",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cvtsudoers via package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/cz-cli/install-guidance.json
+++ b/plugins/cz-cli/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "cz-cli",
+  "binary": "cz-cli",
+  "check": "which cz-cli",
+  "install_steps": [
+    "Install cz-cli via package manager: apt install cz-cli or brew install cz-cli"
+  ]
+}

--- a/plugins/cz-cli/meta.json
+++ b/plugins/cz-cli/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "cz-cli \u2014 CLI utility",
+  "tags": [
+    "multiple",
+    "cli",
+    "cz"
+  ],
+  "has_learn": false
+}

--- a/plugins/cz-cli/plugin.json
+++ b/plugins/cz-cli/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "cz-cli",
+  "version": "1.0.0",
+  "description": "cz-cli \u2014 CLI CLI utility",
+  "source": "https://github.com/search?q=cz-cli+cli&type=repositories",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cz-cli"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cz-cli",
+    "binary": "cz-cli",
+    "check": "which cz-cli",
+    "install_steps": [
+      "Install cz-cli via package manager: apt install cz-cli or brew install cz-cli"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "czcli",
+      "resource": "run",
+      "action": "exec",
+      "description": "cz-cli \u2014 CLI utility",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cz-cli",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install cz-cli via your package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/datadog-agent/install-guidance.json
+++ b/plugins/datadog-agent/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "datadog-agent",
+  "binary": "datadog-agent",
+  "check": "which datadog-agent",
+  "install_steps": [
+    "Install datadog-agent via package manager: apt install datadog-agent or brew install datadog-agent"
+  ]
+}

--- a/plugins/datadog-agent/meta.json
+++ b/plugins/datadog-agent/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "datadog-agent \u2014 CLI utility",
+  "tags": [
+    "multiple",
+    "cli",
+    "datadog"
+  ],
+  "has_learn": false
+}

--- a/plugins/datadog-agent/plugin.json
+++ b/plugins/datadog-agent/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "datadog-agent",
+  "version": "1.0.0",
+  "description": "datadog-agent \u2014 CLI CLI utility",
+  "source": "https://github.com/search?q=datadog-agent+cli&type=repositories",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "datadog-agent"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "datadog-agent",
+    "binary": "datadog-agent",
+    "check": "which datadog-agent",
+    "install_steps": [
+      "Install datadog-agent via package manager: apt install datadog-agent or brew install datadog-agent"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "datadogagent",
+      "resource": "run",
+      "action": "exec",
+      "description": "datadog-agent \u2014 CLI utility",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "datadog-agent",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install datadog-agent via your package manager"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/date/install-guidance.json
+++ b/plugins/date/install-guidance.json
@@ -1,0 +1,8 @@
+{
+  "plugin": "date",
+  "binary": "date",
+  "check": "which date",
+  "install_steps": [
+    "Install via package manager: apt install date or brew install date"
+  ]
+}

--- a/plugins/date/meta.json
+++ b/plugins/date/meta.json
@@ -1,0 +1,9 @@
+{
+  "description": "date \u2014 Command-line utility for system administration",
+  "tags": [
+    "cli",
+    "utility",
+    "system"
+  ],
+  "has_learn": false
+}

--- a/plugins/date/plugin.json
+++ b/plugins/date/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "date",
+  "version": "1.0.0",
+  "description": "date \u2014 CLI date \u2014 Command-line utility for system administration",
+  "source": "https://github.com/search?q=date+cli",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "date"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "date",
+    "binary": "date",
+    "check": "which date",
+    "install_steps": [
+      "Install via package manager: apt install date or brew install date"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "date",
+      "resource": "run",
+      "action": "exec",
+      "description": "date \u2014 Command-line utility for system administration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "date",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install date via package manager"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Batch 023 of 31 — adding bundled plugin definitions.

Auto-generated from curated CLI tool list.
Each plugin includes plugin.json, meta.json, install-guidance.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added plugin support for 30+ command-line utilities (choom, chown, chpasswd, chvt, cifsiostat, ckbcomp, codepage, colcrt, colima, commitizen, convert, corepack, cqlsh, crossplane, ctrlaltdel, ctstat, cvtsudoers, cz-cli, datadog-agent, date, and others), including installation guidance and command execution configuration for each.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->