### PR TITLE
automaintainer: Add new bundled plugins to supercli. Primary pipeline: cand…

### DIFF
--- a/plugins/dkit/install-guidance.json
+++ b/plugins/dkit/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "dkit",
+  "binary": "dkit",
+  "check": "which dkit",
+  "install_steps": [
+    "cargo install dkit",
+    "Verify: dkit --version",
+    "supercli plugins install ./plugins/dkit --on-conflict replace --json"
+  ],
+  "note": "Requires Rust toolchain. Alternatively, download a prebuilt binary from GitHub releases."
+}

--- a/plugins/dkit/meta.json
+++ b/plugins/dkit/meta.json
@@ -1,0 +1,16 @@
+{
+  "description": "Swiss army knife for data format conversion, querying, and exploration. Convert between JSON, CSV, YAML, TOML, XML, MessagePack, Parquet, Excel, SQLite, and more. Includes query engine, table viewer, diff, and statistics.",
+  "tags": [
+    "dkit",
+    "data",
+    "converter",
+    "json",
+    "csv",
+    "yaml",
+    "toml",
+    "xml",
+    "query",
+    "format"
+  ],
+  "has_learn": true
+}

--- a/plugins/dkit/plugin.json
+++ b/plugins/dkit/plugin.json
@@ -1,0 +1,163 @@
+{
+  "name": "dkit",
+  "version": "0.1.0",
+  "description": "Swiss army knife for data format conversion, querying, and exploration",
+  "source": "https://github.com/syang0531/dkit",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "dkit"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "dkit",
+    "binary": "dkit",
+    "check": "which dkit",
+    "install_steps": [
+      "cargo install dkit",
+      "Verify: dkit --version",
+      "supercli plugins install ./plugins/dkit --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "dkit",
+      "resource": "self",
+      "action": "version",
+      "description": "Print dkit version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dkit",
+        "missingDependencyHelp": "Install dkit: cargo install dkit",
+        "baseArgs": ["--version"]
+      },
+      "args": []
+    },
+    {
+      "namespace": "dkit",
+      "resource": "data",
+      "action": "convert",
+      "description": "Convert data between formats (JSON, CSV, YAML, TOML, XML, etc.)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dkit",
+        "baseArgs": ["convert"],
+        "passthrough": true,
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install dkit: cargo install dkit"
+      },
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "Conversion arguments (e.g. input file, --from, --to)"
+        }
+      ]
+    },
+    {
+      "namespace": "dkit",
+      "resource": "data",
+      "action": "query",
+      "description": "Query data using dot notation",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dkit",
+        "baseArgs": ["query"],
+        "passthrough": true,
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install dkit: cargo install dkit"
+      },
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "Query arguments"
+        }
+      ]
+    },
+    {
+      "namespace": "dkit",
+      "resource": "data",
+      "action": "view",
+      "description": "View data as formatted table",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dkit",
+        "baseArgs": ["view"],
+        "passthrough": true,
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install dkit: cargo install dkit"
+      },
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "View arguments"
+        }
+      ]
+    },
+    {
+      "namespace": "dkit",
+      "resource": "data",
+      "action": "stats",
+      "description": "Compute statistics on data files",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dkit",
+        "baseArgs": ["stats"],
+        "passthrough": true,
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install dkit: cargo install dkit"
+      },
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "Stats arguments (use --output-format json for structured output)"
+        }
+      ]
+    },
+    {
+      "namespace": "dkit",
+      "resource": "data",
+      "action": "diff",
+      "description": "Diff two data files, even across formats",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dkit",
+        "baseArgs": ["diff"],
+        "passthrough": true,
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install dkit: cargo install dkit"
+      },
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "Diff arguments"
+        }
+      ]
+    },
+    {
+      "namespace": "dkit",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to dkit CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dkit",
+        "passthrough": true,
+        "missingDependencyHelp": "Install dkit: cargo install dkit"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/dkit/skills/quickstart/SKILL.md
+++ b/plugins/dkit/skills/quickstart/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: dkit
+description: Use this skill when the user wants to convert, query, or explore data across formats (JSON, CSV, YAML, TOML, XML, etc.).
+---
+
+# dkit Plugin
+
+Unified CLI to convert, query, and explore data across 20+ formats. Acts as a swiss army knife for data format manipulation.
+
+## Commands
+- `dkit self version` — Print dkit version
+- `dkit data convert` — Convert data between formats (JSON, CSV, YAML, TOML, XML, etc.)
+- `dkit data query` — Query data using dot notation
+- `dkit data view` — View data as formatted table
+- `dkit data stats` — Compute statistics on data files
+- `dkit data diff` — Diff two data files, even across formats
+
+## Usage Examples
+- "convert this JSON file to YAML"
+- "query the records where name contains Smith"
+- "view this CSV as a table"
+- "get statistics on this data file"
+
+## Installation
+
+```bash
+cargo install dkit
+```
+
+## Key Features
+- Convert between JSON, CSV, YAML, TOML, XML, MessagePack, Parquet, Excel, SQLite, and more
+- Built-in query engine with dot notation
+- Table preview for any data format
+- File diff across different formats
+- Statistics: count, average, percentiles, histograms

--- a/plugins/scute/install-guidance.json
+++ b/plugins/scute/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "scute",
+  "binary": "scute",
+  "check": "which scute",
+  "install_steps": [
+    "cargo install scute",
+    "Verify: scute --version",
+    "supercli plugins install ./plugins/scute --on-conflict replace --json"
+  ],
+  "note": "Requires Rust toolchain. All output is structured JSON by default."
+}

--- a/plugins/scute/meta.json
+++ b/plugins/scute/meta.json
@@ -1,0 +1,13 @@
+{
+  "description": "Open-source toolkit for deterministic code quality fitness checks, guardrails, and harness engineering. Checks complexity, similarity, commit messages, and dependency freshness with structured JSON output.",
+  "tags": [
+    "scute",
+    "code-quality",
+    "linting",
+    "complexity",
+    "duplication",
+    "commit-lint",
+    "fitness"
+  ],
+  "has_learn": true
+}

--- a/plugins/scute/plugin.json
+++ b/plugins/scute/plugin.json
@@ -1,0 +1,141 @@
+{
+  "name": "scute",
+  "version": "0.1.0",
+  "description": "Code quality guardrails: complexity, duplication, commit messages, dependency freshness",
+  "source": "https://github.com/scute-sh/scute",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "scute"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "scute",
+    "binary": "scute",
+    "check": "which scute",
+    "install_steps": [
+      "cargo install scute",
+      "Verify: scute --version",
+      "supercli plugins install ./plugins/scute --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "scute",
+      "resource": "self",
+      "action": "version",
+      "description": "Print scute version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "scute",
+        "missingDependencyHelp": "Install scute: cargo install scute",
+        "baseArgs": ["--version"]
+      },
+      "args": []
+    },
+    {
+      "namespace": "scute",
+      "resource": "code",
+      "action": "complexity",
+      "description": "Check code complexity fitness",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "scute",
+        "baseArgs": ["check", "code-complexity"],
+        "passthrough": true,
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install scute: cargo install scute"
+      },
+      "args": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "Path to source directory or file"
+        }
+      ]
+    },
+    {
+      "namespace": "scute",
+      "resource": "code",
+      "action": "similarity",
+      "description": "Check code similarity / duplication",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "scute",
+        "baseArgs": ["check", "code-similarity"],
+        "passthrough": true,
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install scute: cargo install scute"
+      },
+      "args": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "Path to source directory"
+        }
+      ]
+    },
+    {
+      "namespace": "scute",
+      "resource": "commit",
+      "action": "lint",
+      "description": "Lint commit messages",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "scute",
+        "baseArgs": ["check", "commit-message"],
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install scute: cargo install scute"
+      },
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "Commit message or range arguments"
+        }
+      ]
+    },
+    {
+      "namespace": "scute",
+      "resource": "dependencies",
+      "action": "freshness",
+      "description": "Check dependency freshness",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "scute",
+        "baseArgs": ["check", "dependency-freshness"],
+        "passthrough": true,
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install scute: cargo install scute"
+      },
+      "args": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "Path to project directory"
+        }
+      ]
+    },
+    {
+      "namespace": "scute",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to scute CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "scute",
+        "passthrough": true,
+        "missingDependencyHelp": "Install scute: cargo install scute"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/scute/skills/quickstart/SKILL.md
+++ b/plugins/scute/skills/quickstart/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: scute
+description: Use this skill when the user wants to enforce code quality guardrails — check complexity, duplication, commit message linting, or dependency freshness.
+---
+
+# scute Plugin
+
+Open-source toolkit for deterministic fitness checks, guardrails, and harness engineering. All output is structured JSON by default.
+
+## Commands
+- `scute self version` — Print scute version
+- `scute code complexity` — Check code complexity fitness
+- `scute code similarity` — Check code similarity / duplication
+- `scute commit lint` — Lint commit messages
+- `scute dependencies freshness` — Check dependency freshness
+
+## Usage Examples
+- "check code complexity in src/"
+- "find code duplication in the project"
+- "lint the last commit message"
+- "check if dependencies are up to date"
+
+## Installation
+
+```bash
+cargo install scute
+```
+
+## Key Features
+- Deterministic — same input always produces same output
+- Agent-native — all output is structured JSON
+- No cloud dependency — runs fully offline
+- Multiple check categories: complexity, similarity, commit messages, dependencies
+- Threshold-based pass/fail with detailed evidence


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Add new bundled plugins to supercli. Primary pipeline: candidates.json. Fallback: GitHub search.

## Pipeline Priority
### 1. Check candidates.json FIRST (speed)
Read /root/candidates.json — pick the first 2 entries NOT yet added as plugins (check plugins/<name>/ directory and sc mem).
  sc agentmemory-cli memory search --query "Created plugins" --project supercli-candidates --json

### 2. Fallback to GitHub search (if candidates.json empty or exhausted)
Search GitHub for recently created headless CLI tools (Rust/Go/TypeScript, stars>100):
  webfetch "https://github.com/search?q=created%3A%3E2025-01-01+stars%3A%3E100+language%3Arust+topic%3Acli&type=repositories&s=stars&p=1"
Skip TUI, dashboard, gui, agent, auth tools.
Must have --json/--quiet flag, simple install, no auth.

## Per Plugin
1. Create plugins/<name>/plugin.json (manifest + commands)
2. Create plugins/<name>/meta.json (description, tags)
3. Create plugins/<name>/install-guidance.json (install steps)
4. Create plugins/<name>/skills/quickstart/SKILL.md (agent usage)
5. Validate: node -e 'JSON.parse(...)' for each JSON
6. Commit: 'feat: add <name> bundled plugin'
7. Save to sc mem: sc agentmemory-cli memory save --text "Created plugins: <name>" --project supercli-candidates --json

## Constraints
- Do NOT edit plugins/plugins.json or cli/* — isolated per-plugin files only
- Target: 2 plugins per session
- If both pipelines exhausted, stop and note it

**Branch:** `am/am-0e131c-tfz560`

```
plugins/dkit/install-guidance.json       |  11 +++
 plugins/dkit/meta.json                   |  16 +++
 plugins/dkit/plugin.json                 | 163 +++++++++++++++++++++++++++++++
 plugins/dkit/skills/quickstart/SKILL.md  |  35 +++++++
 plugins/scute/install-guidance.json      |  11 +++
 plugins/scute/meta.json                  |  13 +++
 plugins/scute/plugin.json                | 141 ++++++++++++++++++++++++++
 plugins/scute/skills/quickstart/SKILL.md |  34 +++++++
 8 files changed, 424 insertions(+)
```
