### PR TITLE
automaintainer: Add 2 new useful plugins to the plugins/ directory. Each pl…

### DIFF
--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generated_at": "2026-06-04T19:58:48.603Z",
-  "count": 5017,
+  "generated_at": "2026-06-04T20:04:06.811Z",
+  "count": 5018,
   "plugins": [
     {
       "name": "[",
@@ -13822,6 +13822,10 @@
     {
       "name": "php",
       "checksum": "b1144f50ca421fa9"
+    },
+    {
+      "name": "pi",
+      "checksum": "cdb13d3178a1efcc"
     },
     {
       "name": "picard",

--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generated_at": "2026-06-04T20:04:06.811Z",
-  "count": 5018,
+  "generated_at": "2026-06-04T20:04:17.025Z",
+  "count": 5019,
   "plugins": [
     {
       "name": "[",
@@ -17430,6 +17430,10 @@
     {
       "name": "systemctl",
       "checksum": "cb2dc93bdfb12733"
+    },
+    {
+      "name": "systemd-analyze",
+      "checksum": "ce515d2490180153"
     },
     {
       "name": "systemtap",

--- a/plugins/pi/install-guidance.json
+++ b/plugins/pi/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "pi",
+  "binary": "pi",
+  "check": "which pi",
+  "install_steps": [
+    "npm install -g @earendil-works/pi-coding-agent",
+    "Verify: pi --version"
+  ],
+  "note": "Also installable via: brew install pi, cargo install pi-cli. Requires a provider API key (e.g., OPENAI_API_KEY, ANTHROPIC_API_KEY). Supports multiple providers: Google, OpenAI, Anthropic, and more. See pi --help for configuration options."
+}

--- a/plugins/pi/meta.json
+++ b/plugins/pi/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Pi Coding Agent — AI coding assistant with read, bash, edit, write, and grep tools. Supports multiple AI providers and extensible via plugins.",
+  "tags": ["pi", "ai", "coding", "assistant", "cli", "agent"],
+  "has_learn": false
+}

--- a/plugins/pi/plugin.json
+++ b/plugins/pi/plugin.json
@@ -1,0 +1,116 @@
+{
+  "name": "pi",
+  "version": "0.1.0",
+  "description": "Pi Coding Agent — AI coding assistant with read, bash, edit, write, and grep tools. Supports multiple AI providers and extensible via plugins.",
+  "source": "https://github.com/pi-coding/pi-cli",
+  "checks": [
+    { "type": "binary", "name": "pi" }
+  ],
+  "install_guidance": {
+    "plugin": "pi",
+    "binary": "pi",
+    "check": "which pi",
+    "install_steps": [
+      "npm install -g @earendil-works/pi-coding-agent",
+      "Verify: pi --version"
+    ],
+    "note": "Also installable via: brew install pi, cargo install pi-cli. Requires a provider API key (e.g., OPENAI_API_KEY, ANTHROPIC_API_KEY)."
+  },
+  "commands": [
+    {
+      "namespace": "pi",
+      "resource": "version",
+      "action": "get",
+      "description": "Show pi version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pi",
+        "baseArgs": ["--version"],
+        "parseJson": false,
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "Install pi: npm install -g @earendil-works/pi-coding-agent"
+      },
+      "args": []
+    },
+    {
+      "namespace": "pi",
+      "resource": "extension",
+      "action": "list",
+      "description": "List installed extensions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pi",
+        "baseArgs": ["list"],
+        "parseJson": false,
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install pi: npm install -g @earendil-works/pi-coding-agent"
+      },
+      "args": []
+    },
+    {
+      "namespace": "pi",
+      "resource": "extension",
+      "action": "install",
+      "description": "Install a pi extension from source",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pi",
+        "baseArgs": ["install"],
+        "parseJson": false,
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install pi: npm install -g @earendil-works/pi-coding-agent"
+      },
+      "args": [
+        { "name": "source", "type": "string", "required": true, "description": "Extension source path or URL" },
+        { "name": "--local", "type": "boolean", "description": "Install from local path" }
+      ]
+    },
+    {
+      "namespace": "pi",
+      "resource": "extension",
+      "action": "remove",
+      "description": "Remove a pi extension",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pi",
+        "baseArgs": ["remove"],
+        "parseJson": false,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install pi: npm install -g @earendil-works/pi-coding-agent"
+      },
+      "args": [
+        { "name": "source", "type": "string", "required": true, "description": "Extension source to remove" }
+      ]
+    },
+    {
+      "namespace": "pi",
+      "resource": "self",
+      "action": "update",
+      "description": "Update pi or its extensions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pi",
+        "baseArgs": ["update"],
+        "parseJson": false,
+        "timeout_ms": 120000,
+        "missingDependencyHelp": "Install pi: npm install -g @earendil-works/pi-coding-agent"
+      },
+      "args": [
+        { "name": "target", "type": "string", "required": false, "description": "Target to update (source, self, or pi)" }
+      ]
+    },
+    {
+      "namespace": "pi",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to pi CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pi",
+        "passthrough": true,
+        "missingDependencyHelp": "Install pi: npm install -g @earendil-works/pi-coding-agent"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/systemd-analyze/install-guidance.json
+++ b/plugins/systemd-analyze/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "systemd-analyze",
+  "binary": "systemd-analyze",
+  "check": "which systemd-analyze",
+  "install_steps": [
+    "Pre-installed on all systemd-based Linux distributions (Fedora, Debian, Ubuntu, Arch, etc.)",
+    "Verify: systemd-analyze --version"
+  ],
+  "note": "Part of the systemd package. Available on any modern Linux distribution using systemd as init system. Install via: apt install systemd (Debian/Ubuntu), dnf install systemd (Fedora), pacman -S systemd (Arch). Not available on macOS or Windows."
+}

--- a/plugins/systemd-analyze/meta.json
+++ b/plugins/systemd-analyze/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Analyze systemd boot performance, service dependencies, and unit timing — visualize blame, critical chain, and generate SVG plots of the boot sequence.",
+  "tags": ["systemd", "analyze", "boot", "performance", "linux", "system", "service", "timing"],
+  "has_learn": false
+}

--- a/plugins/systemd-analyze/plugin.json
+++ b/plugins/systemd-analyze/plugin.json
@@ -1,0 +1,198 @@
+{
+  "name": "systemd-analyze",
+  "version": "0.1.0",
+  "description": "Analyze systemd boot performance, service dependencies, and unit timing — visualize blame, critical chain, and generate SVG plots of the boot sequence.",
+  "source": "https://www.freedesktop.org/software/systemd/man/latest/systemd-analyze.html",
+  "checks": [
+    { "type": "binary", "name": "systemd-analyze" }
+  ],
+  "install_guidance": {
+    "plugin": "systemd-analyze",
+    "binary": "systemd-analyze",
+    "check": "which systemd-analyze",
+    "install_steps": [
+      "Pre-installed on all systemd-based Linux distributions (Fedora, Debian, Ubuntu, Arch, etc.)",
+      "Verify: systemd-analyze --version"
+    ],
+    "note": "Part of the systemd package. Available on any modern Linux distribution using systemd as init system."
+  },
+  "commands": [
+    {
+      "namespace": "systemd",
+      "resource": "boot",
+      "action": "time",
+      "description": "Show total boot time breakdown (kernel, initrd, userspace)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "systemd-analyze",
+        "baseArgs": ["time"],
+        "parseJson": false,
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "systemd-analyze is part of systemd; install systemd package."
+      },
+      "args": []
+    },
+    {
+      "namespace": "systemd",
+      "resource": "boot",
+      "action": "blame",
+      "description": "Show boot time per unit, sorted by time (slowest first)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "systemd-analyze",
+        "baseArgs": ["blame"],
+        "parseJson": false,
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "systemd-analyze is part of systemd; install systemd package."
+      },
+      "args": []
+    },
+    {
+      "namespace": "systemd",
+      "resource": "boot",
+      "action": "critical-chain",
+      "description": "Show the critical boot chain with timestamps",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "systemd-analyze",
+        "baseArgs": ["critical-chain"],
+        "parseJson": false,
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "systemd-analyze is part of systemd; install systemd package."
+      },
+      "args": [
+        { "name": "unit", "type": "string", "required": false, "description": "Start from this unit instead of the default target" }
+      ]
+    },
+    {
+      "namespace": "systemd",
+      "resource": "boot",
+      "action": "plot",
+      "description": "Generate an SVG plot of the boot sequence",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "systemd-analyze",
+        "baseArgs": ["plot"],
+        "parseJson": false,
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "systemd-analyze is part of systemd; install systemd package."
+      },
+      "args": []
+    },
+    {
+      "namespace": "systemd",
+      "resource": "unit",
+      "action": "dependency",
+      "description": "Show unit dependency graph (dot format)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "systemd-analyze",
+        "baseArgs": ["dot"],
+        "parseJson": false,
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "systemd-analyze is part of systemd; install systemd package."
+      },
+      "args": [
+        { "name": "unit", "type": "string", "required": false, "description": "Specific unit to analyze dependencies for" }
+      ]
+    },
+    {
+      "namespace": "systemd",
+      "resource": "security",
+      "action": "audit",
+      "description": "Audit unit security settings",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "systemd-analyze",
+        "baseArgs": ["security"],
+        "parseJson": false,
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "systemd-analyze is part of systemd; install systemd package."
+      },
+      "args": [
+        { "name": "unit", "type": "string", "required": false, "description": "Unit to audit" }
+      ]
+    },
+    {
+      "namespace": "systemd",
+      "resource": "service",
+      "action": "condition",
+      "description": "Verify condition/assert expressions in unit files",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "systemd-analyze",
+        "baseArgs": ["condition"],
+        "parseJson": false,
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "systemd-analyze is part of systemd; install systemd package."
+      },
+      "args": [
+        { "name": "condition", "type": "string", "required": true, "description": "Condition or assert expression to verify" }
+      ]
+    },
+    {
+      "namespace": "systemd",
+      "resource": "unit",
+      "action": "verify",
+      "description": "Verify unit file correctness",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "systemd-analyze",
+        "baseArgs": ["verify"],
+        "parseJson": false,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "systemd-analyze is part of systemd; install systemd package."
+      },
+      "args": [
+        { "name": "files", "type": "string", "required": true, "description": "Unit files to verify" }
+      ]
+    },
+    {
+      "namespace": "systemd",
+      "resource": "boot",
+      "action": "calendar",
+      "description": "Parse and explain calendar event expressions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "systemd-analyze",
+        "baseArgs": ["calendar"],
+        "parseJson": false,
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "systemd-analyze is part of systemd; install systemd package."
+      },
+      "args": [
+        { "name": "expression", "type": "string", "required": true, "description": "Calendar event expression (e.g., '*-*-* *:0/15:00')" }
+      ]
+    },
+    {
+      "namespace": "systemd",
+      "resource": "boot",
+      "action": "timestamp",
+      "description": "Parse and explain timestamp expressions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "systemd-analyze",
+        "baseArgs": ["timestamp"],
+        "parseJson": false,
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "systemd-analyze is part of systemd; install systemd package."
+      },
+      "args": [
+        { "name": "expression", "type": "string", "required": true, "description": "Timestamp expression (e.g., '12h', 'now')" }
+      ]
+    },
+    {
+      "namespace": "systemd",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to systemd-analyze CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "systemd-analyze",
+        "passthrough": true,
+        "missingDependencyHelp": "systemd-analyze is part of systemd; install systemd package."
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Add 2 new useful plugins to the plugins/ directory. Each plugin must wrap a real CLI tool (e.g. jq, yq, bat, fzf, or a developer tool). Follow the pattern of existing plugins: create plugins/<name>/plugin.json, meta.json, install-guidance.json. Update plugins/catalog.json. Write the plugin in JavaScript under plugins/<name>/index.js if applicable. Make 2 separate commits, one per plugin.

**Branch:** `am/am-f17c27-tg4i6b`

```
plugins/catalog.json                          |  12 +-
 plugins/pi/install-guidance.json              |  10 ++
 plugins/pi/meta.json                          |   5 +
 plugins/pi/plugin.json                        | 116 +++++++++++++++
 plugins/systemd-analyze/install-guidance.json |  10 ++
 plugins/systemd-analyze/meta.json             |   5 +
 plugins/systemd-analyze/plugin.json           | 198 ++++++++++++++++++++++++++
 7 files changed, 354 insertions(+), 2 deletions(-)
```
