### PR TITLE
automaintainer: Add 2 new useful plugins to the plugins/ directory. Each pl…

### DIFF
--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generated_at": "2026-06-04T20:04:17.025Z",
-  "count": 5019,
+  "generated_at": "2026-06-04T20:12:37.627Z",
+  "count": 5020,
   "plugins": [
     {
       "name": "[",
@@ -10750,6 +10750,10 @@
     {
       "name": "logger",
       "checksum": "b26e3d0d5431e21d"
+    },
+    {
+      "name": "loginctl",
+      "checksum": "c193698e4d86af1e"
     },
     {
       "name": "logname",

--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generated_at": "2026-06-04T20:12:37.627Z",
-  "count": 5020,
+  "generated_at": "2026-06-04T20:12:54.661Z",
+  "count": 5021,
   "plugins": [
     {
       "name": "[",
@@ -12250,6 +12250,10 @@
     {
       "name": "netstat",
       "checksum": "f705aafe2baf6b37"
+    },
+    {
+      "name": "networkctl",
+      "checksum": "dbb9d1cdc4d469fd"
     },
     {
       "name": "new-api",

--- a/plugins/loginctl/install-guidance.json
+++ b/plugins/loginctl/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "loginctl",
+  "binary": "loginctl",
+  "check": "which loginctl",
+  "install_steps": [
+    "Pre-installed on most Linux systems with systemd (systemd-container package)",
+    "Debian/Ubuntu: apt-get install systemd-container",
+    "Arch: pacman -S systemd (included in base)",
+    "Verify: loginctl --version"
+  ]
+}

--- a/plugins/loginctl/meta.json
+++ b/plugins/loginctl/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "loginctl — control the systemd login manager. List/manage user sessions, seats, and users.",
+  "tags": ["systemd", "loginctl", "login", "session", "seat", "user", "linux"],
+  "has_learn": false
+}

--- a/plugins/loginctl/plugin.json
+++ b/plugins/loginctl/plugin.json
@@ -1,0 +1,347 @@
+{
+  "name": "loginctl",
+  "version": "0.1.0",
+  "description": "loginctl — control the systemd login manager. List/manage user sessions, seats, and users on systemd-based systems.",
+  "source": "https://www.freedesktop.org/software/systemd/man/latest/loginctl.html",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "loginctl"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "loginctl",
+    "binary": "loginctl",
+    "check": "which loginctl",
+    "install_steps": [
+      "Pre-installed on most Linux systems with systemd (systemd-container package)",
+      "Debian/Ubuntu: apt-get install systemd-container",
+      "Verify: loginctl --version",
+      "supercli plugins install ./plugins/loginctl --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "loginctl",
+      "resource": "session",
+      "action": "list",
+      "description": "List all current sessions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["list-sessions", "--no-legend", "--no-pager"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": []
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "session",
+      "action": "status",
+      "description": "Show session status for one or more session IDs",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["session-status", "--no-pager"],
+        "positionalArgs": ["session_id"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": [
+        {
+          "name": "session_id",
+          "type": "string",
+          "required": true,
+          "description": "Session ID (e.g. '1' or 'c1')"
+        }
+      ]
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "session",
+      "action": "show",
+      "description": "Show properties of one or more sessions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["show-session", "--no-pager"],
+        "positionalArgs": ["session_id"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": [
+        {
+          "name": "session_id",
+          "type": "string",
+          "required": true,
+          "description": "Session ID (e.g. '1' or 'c1')"
+        }
+      ]
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "session",
+      "action": "lock",
+      "description": "Screen lock one or more sessions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["lock-session"],
+        "positionalArgs": ["session_id"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": [
+        {
+          "name": "session_id",
+          "type": "string",
+          "required": true,
+          "description": "Session ID to lock"
+        }
+      ]
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "session",
+      "action": "unlock",
+      "description": "Screen unlock one or more sessions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["unlock-session"],
+        "positionalArgs": ["session_id"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": [
+        {
+          "name": "session_id",
+          "type": "string",
+          "required": true,
+          "description": "Session ID to unlock"
+        }
+      ]
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "session",
+      "action": "terminate",
+      "description": "Terminate one or more sessions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["terminate-session"],
+        "positionalArgs": ["session_id"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": [
+        {
+          "name": "session_id",
+          "type": "string",
+          "required": true,
+          "description": "Session ID to terminate"
+        }
+      ]
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "user",
+      "action": "list",
+      "description": "List all currently logged in users",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["list-users", "--no-legend", "--no-pager"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": []
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "user",
+      "action": "status",
+      "description": "Show user status for one or more users",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["user-status", "--no-pager"],
+        "positionalArgs": ["user_id"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": [
+        {
+          "name": "user_id",
+          "type": "string",
+          "required": true,
+          "description": "Username or UID"
+        }
+      ]
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "user",
+      "action": "show",
+      "description": "Show properties of one or more users",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["show-user", "--no-pager"],
+        "positionalArgs": ["user_id"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": [
+        {
+          "name": "user_id",
+          "type": "string",
+          "required": true,
+          "description": "Username or UID"
+        }
+      ]
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "user",
+      "action": "enable-linger",
+      "description": "Enable linger state for one or more users (allows user processes to survive logout)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["enable-linger"],
+        "positionalArgs": ["user_id"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": [
+        {
+          "name": "user_id",
+          "type": "string",
+          "required": true,
+          "description": "Username or UID"
+        }
+      ]
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "user",
+      "action": "disable-linger",
+      "description": "Disable linger state for one or more users",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["disable-linger"],
+        "positionalArgs": ["user_id"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": [
+        {
+          "name": "user_id",
+          "type": "string",
+          "required": true,
+          "description": "Username or UID"
+        }
+      ]
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "seat",
+      "action": "list",
+      "description": "List all available seats",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["list-seats", "--no-legend", "--no-pager"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": []
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "seat",
+      "action": "status",
+      "description": "Show seat status for one or more seats",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["seat-status", "--no-pager"],
+        "positionalArgs": ["seat_name"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": [
+        {
+          "name": "seat_name",
+          "type": "string",
+          "required": true,
+          "description": "Seat name (e.g. 'seat0')"
+        }
+      ]
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "seat",
+      "action": "show",
+      "description": "Show properties of one or more seats",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["show-seat", "--no-pager"],
+        "positionalArgs": ["seat_name"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": [
+        {
+          "name": "seat_name",
+          "type": "string",
+          "required": true,
+          "description": "Seat name (e.g. 'seat0')"
+        }
+      ]
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "self",
+      "action": "version",
+      "description": "Show loginctl version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": []
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "session",
+      "action": "lock-all",
+      "description": "Screen lock all current sessions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["lock-sessions"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": []
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "session",
+      "action": "unlock-all",
+      "description": "Screen unlock all current sessions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "baseArgs": ["unlock-sessions"],
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": []
+    },
+    {
+      "namespace": "loginctl",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to loginctl CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "loginctl",
+        "passthrough": true,
+        "missingDependencyHelp": "Install loginctl: apt-get install systemd-container"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/networkctl/install-guidance.json
+++ b/plugins/networkctl/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "networkctl",
+  "binary": "networkctl",
+  "check": "which networkctl",
+  "install_steps": [
+    "Pre-installed on most Linux systems with systemd (systemd-networkd package)",
+    "Debian/Ubuntu: apt-get install systemd-networkd",
+    "Arch: pacman -S systemd (included in base)",
+    "Verify: networkctl --version"
+  ]
+}

--- a/plugins/networkctl/meta.json
+++ b/plugins/networkctl/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "networkctl — query and control the systemd networking subsystem. List links, show status, configure and manage network interfaces.",
+  "tags": ["systemd", "networkctl", "network", "link", "interface", "lldp", "linux"],
+  "has_learn": false
+}

--- a/plugins/networkctl/plugin.json
+++ b/plugins/networkctl/plugin.json
@@ -1,0 +1,273 @@
+{
+  "name": "networkctl",
+  "version": "0.1.0",
+  "description": "networkctl — query and control the systemd networking subsystem. List links, show status, manage network interfaces on systemd-based systems.",
+  "source": "https://www.freedesktop.org/software/systemd/man/latest/networkctl.html",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "networkctl"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "networkctl",
+    "binary": "networkctl",
+    "check": "which networkctl",
+    "install_steps": [
+      "Pre-installed on most Linux systems with systemd (systemd-networkd package)",
+      "Debian/Ubuntu: apt-get install systemd-networkd",
+      "Verify: networkctl --version",
+      "supercli plugins install ./plugins/networkctl --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "networkctl",
+      "resource": "link",
+      "action": "list",
+      "description": "List all network links",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "baseArgs": ["list", "--no-legend", "--no-pager"],
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": [
+        {
+          "name": "pattern",
+          "type": "string",
+          "required": false,
+          "description": "Optional pattern to filter links by name"
+        }
+      ]
+    },
+    {
+      "namespace": "networkctl",
+      "resource": "link",
+      "action": "status",
+      "description": "Show detailed status of network links",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "baseArgs": ["status", "--no-pager"],
+        "positionalArgs": ["pattern"],
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": [
+        {
+          "name": "pattern",
+          "type": "string",
+          "required": false,
+          "description": "Link name or pattern (e.g. 'eth0', 'en*')"
+        }
+      ]
+    },
+    {
+      "namespace": "networkctl",
+      "resource": "link",
+      "action": "up",
+      "description": "Bring network links up",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "baseArgs": ["up"],
+        "positionalArgs": ["device"],
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": [
+        {
+          "name": "device",
+          "type": "string",
+          "required": true,
+          "description": "Device name(s) to bring up (space separated)"
+        }
+      ]
+    },
+    {
+      "namespace": "networkctl",
+      "resource": "link",
+      "action": "down",
+      "description": "Bring network links down",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "baseArgs": ["down"],
+        "positionalArgs": ["device"],
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": [
+        {
+          "name": "device",
+          "type": "string",
+          "required": true,
+          "description": "Device name(s) to bring down (space separated)"
+        }
+      ]
+    },
+    {
+      "namespace": "networkctl",
+      "resource": "link",
+      "action": "renew",
+      "description": "Renew dynamic configurations (DHCP) for interfaces",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "baseArgs": ["renew"],
+        "positionalArgs": ["device"],
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": [
+        {
+          "name": "device",
+          "type": "string",
+          "required": true,
+          "description": "Device name(s) to renew DHCP leases"
+        }
+      ]
+    },
+    {
+      "namespace": "networkctl",
+      "resource": "link",
+      "action": "reconfigure",
+      "description": "Reconfigure network interfaces (reloads .network files)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "baseArgs": ["reconfigure"],
+        "positionalArgs": ["device"],
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": [
+        {
+          "name": "device",
+          "type": "string",
+          "required": true,
+          "description": "Device name(s) to reconfigure"
+        }
+      ]
+    },
+    {
+      "namespace": "networkctl",
+      "resource": "link",
+      "action": "delete",
+      "description": "Delete virtual network devices",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "baseArgs": ["delete"],
+        "positionalArgs": ["device"],
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": [
+        {
+          "name": "device",
+          "type": "string",
+          "required": true,
+          "description": "Virtual device name(s) to delete"
+        }
+      ]
+    },
+    {
+      "namespace": "networkctl",
+      "resource": "lldp",
+      "action": "list",
+      "description": "Show LLDP neighbors",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "baseArgs": ["lldp", "--no-pager"],
+        "positionalArgs": ["pattern"],
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": [
+        {
+          "name": "pattern",
+          "type": "string",
+          "required": false,
+          "description": "Optional link name pattern to filter"
+        }
+      ]
+    },
+    {
+      "namespace": "networkctl",
+      "resource": "config",
+      "action": "reload",
+      "description": "Reload .network and .netdev configuration files",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "baseArgs": ["reload"],
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": []
+    },
+    {
+      "namespace": "networkctl",
+      "resource": "config",
+      "action": "show",
+      "description": "Show network configuration files for a device",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "baseArgs": ["cat"],
+        "positionalArgs": ["device"],
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": [
+        {
+          "name": "device",
+          "type": "string",
+          "required": true,
+          "description": "Device name to show config for"
+        }
+      ]
+    },
+    {
+      "namespace": "networkctl",
+      "resource": "config",
+      "action": "edit",
+      "description": "Edit network configuration files for a device",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "baseArgs": ["edit"],
+        "positionalArgs": ["device"],
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": [
+        {
+          "name": "device",
+          "type": "string",
+          "required": true,
+          "description": "Device name to edit config for"
+        }
+      ]
+    },
+    {
+      "namespace": "networkctl",
+      "resource": "self",
+      "action": "version",
+      "description": "Show networkctl version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": []
+    },
+    {
+      "namespace": "networkctl",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to networkctl CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "networkctl",
+        "passthrough": true,
+        "missingDependencyHelp": "Install networkctl: apt-get install systemd-networkd"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Add 2 new useful plugins to the plugins/ directory. Each plugin must wrap a real CLI tool (e.g. jq, yq, bat, fzf, or a developer tool). Follow the pattern of existing plugins: create plugins/<name>/plugin.json, meta.json, install-guidance.json. Update plugins/catalog.json. Write the plugin in JavaScript under plugins/<name>/index.js if applicable. Make 2 separate commits, one per plugin.

**Branch:** `am/am-f17c27-tg4ih6`

```
plugins/catalog.json                     |  12 +-
 plugins/loginctl/install-guidance.json   |  11 +
 plugins/loginctl/meta.json               |   5 +
 plugins/loginctl/plugin.json             | 347 +++++++++++++++++++++++++++++++
 plugins/networkctl/install-guidance.json |  11 +
 plugins/networkctl/meta.json             |   5 +
 plugins/networkctl/plugin.json           | 273 ++++++++++++++++++++++++
 7 files changed, 662 insertions(+), 2 deletions(-)
```
