### PR TITLE
automaintainer: Add 2 new useful plugins to the plugins/ directory. Each pl…

### DIFF
--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generated_at": "2026-06-04T20:57:02.314Z",
-  "count": 5023,
+  "generated_at": "2026-06-04T20:57:11.459Z",
+  "count": 5024,
   "plugins": [
     {
       "name": "[",
@@ -18454,6 +18454,10 @@
     {
       "name": "uconv",
       "checksum": "ab62d4a5bfa99648"
+    },
+    {
+      "name": "udevadm",
+      "checksum": "ded39cc1d2c97e37"
     },
     {
       "name": "ufw",

--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generated_at": "2026-06-04T20:31:40.028Z",
-  "count": 5022,
+  "generated_at": "2026-06-04T20:57:02.314Z",
+  "count": 5023,
   "plugins": [
     {
       "name": "[",
@@ -17434,6 +17434,10 @@
     {
       "name": "sysbench",
       "checksum": "601b6a967ef451f9"
+    },
+    {
+      "name": "sysctl",
+      "checksum": "92d937ad5ff07b3f"
     },
     {
       "name": "sysdig",

--- a/plugins/sysctl/install-guidance.json
+++ b/plugins/sysctl/install-guidance.json
@@ -1,0 +1,1 @@
+{"plugin":"sysctl","binary":"sysctl","check":"which sysctl","install_steps":["base system (procps-ng / util-linux)","Verify: sysctl --version","supercli plugins install ./plugins/sysctl --on-conflict replace --json"]}

--- a/plugins/sysctl/meta.json
+++ b/plugins/sysctl/meta.json
@@ -1,0 +1,12 @@
+{
+  "description": "sysctl — configure Linux kernel parameters at runtime (procps-ng)",
+  "tags": [
+    "sysctl",
+    "kernel",
+    "parameters",
+    "system",
+    "linux",
+    "sysadmin"
+  ],
+  "has_learn": true
+}

--- a/plugins/sysctl/plugin.json
+++ b/plugins/sysctl/plugin.json
@@ -1,0 +1,131 @@
+{
+  "name": "sysctl",
+  "version": "0.1.0",
+  "description": "sysctl — Linux kernel parameter management at runtime",
+  "source": "https",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "sysctl"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "sysctl",
+    "binary": "sysctl",
+    "check": "which sysctl",
+    "install_steps": [
+      "base system (procps-ng / util-linux)",
+      "Verify: sysctl --version",
+      "supercli plugins install ./plugins/sysctl --on-conflict replace --json"
+    ],
+    "note": "Standard Linux system utility from procps-ng."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "sysctl",
+      "resource": "self",
+      "action": "version",
+      "description": "Print sysctl version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sysctl",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "sysctl is part of procps-ng (base system)"
+      },
+      "args": []
+    },
+    {
+      "namespace": "sysctl",
+      "resource": "all",
+      "action": "list",
+      "description": "List all kernel parameters",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sysctl",
+        "baseArgs": ["-a"],
+        "missingDependencyHelp": "sysctl is part of procps-ng (base system)"
+      },
+      "args": []
+    },
+    {
+      "namespace": "sysctl",
+      "resource": "param",
+      "action": "get",
+      "description": "Get value of a kernel parameter",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sysctl",
+        "baseArgs": ["-n"],
+        "positionalArgs": ["name"],
+        "missingDependencyHelp": "sysctl is part of procps-ng (base system)"
+      },
+      "args": [
+        { "name": "name", "type": "string", "required": true, "description": "Kernel parameter name (e.g. kernel.hostname)" }
+      ]
+    },
+    {
+      "namespace": "sysctl",
+      "resource": "param",
+      "action": "set",
+      "description": "Set a kernel parameter value",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sysctl",
+        "baseArgs": ["-w"],
+        "positionalArgs": ["assignment"],
+        "missingDependencyHelp": "sysctl is part of procps-ng (base system)"
+      },
+      "args": [
+        { "name": "assignment", "type": "string", "required": true, "description": "Parameter=value (e.g. kernel.hostname=myhost)" }
+      ]
+    },
+    {
+      "namespace": "sysctl",
+      "resource": "file",
+      "action": "load",
+      "description": "Load sysctl settings from a file",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sysctl",
+        "baseArgs": ["-p"],
+        "positionalArgs": ["file"],
+        "missingDependencyHelp": "sysctl is part of procps-ng (base system)"
+      },
+      "args": [
+        { "name": "file", "type": "string", "required": false, "description": "Path to sysctl config file (default: /etc/sysctl.conf)" }
+      ]
+    },
+    {
+      "namespace": "sysctl",
+      "resource": "param",
+      "action": "search",
+      "description": "Search kernel parameters matching a pattern",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sysctl",
+        "baseArgs": ["-a", "--pattern"],
+        "positionalArgs": ["pattern"],
+        "missingDependencyHelp": "sysctl is part of procps-ng (base system)"
+      },
+      "args": [
+        { "name": "pattern", "type": "string", "required": true, "description": "Regex pattern to match parameter names" }
+      ]
+    },
+    {
+      "namespace": "sysctl",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to sysctl CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sysctl",
+        "passthrough": true,
+        "missingDependencyHelp": "sysctl is part of procps-ng (base system)"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/sysctl/skills/quickstart/SKILL.md
+++ b/plugins/sysctl/skills/quickstart/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: sysctl
+description: Configure Linux kernel parameters at runtime
+---
+# sysctl Plugin
+Configure Linux kernel parameters at runtime
+
+## Usage
+- `sysctl self version` — Print sysctl version
+- `sysctl all list` — List all kernel parameters
+- `sysctl param get <name>` — Get a parameter value (e.g. kernel.hostname)
+- `sysctl param set <name>=<value>` — Set a parameter value
+- `sysctl file load [file]` — Load settings from file
+- `sysctl param search <pattern>` — Search parameters by regex
+- `sysctl _ _ <args>` — Run sysctl with any arguments

--- a/plugins/udevadm/install-guidance.json
+++ b/plugins/udevadm/install-guidance.json
@@ -1,0 +1,1 @@
+{"plugin":"udevadm","binary":"udevadm","check":"which udevadm","install_steps":["base system (systemd / udev)","Verify: udevadm --version","supercli plugins install ./plugins/udevadm --on-conflict replace --json"]}

--- a/plugins/udevadm/meta.json
+++ b/plugins/udevadm/meta.json
@@ -1,0 +1,13 @@
+{
+  "description": "udevadm — manage and query Linux devices, udev events, and device rules",
+  "tags": [
+    "udevadm",
+    "udev",
+    "device",
+    "systemd",
+    "linux",
+    "sysadmin",
+    "hardware"
+  ],
+  "has_learn": true
+}

--- a/plugins/udevadm/plugin.json
+++ b/plugins/udevadm/plugin.json
@@ -1,0 +1,162 @@
+{
+  "name": "udevadm",
+  "version": "0.1.0",
+  "description": "udevadm — Linux device manager control and query tool",
+  "source": "https",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "udevadm"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "udevadm",
+    "binary": "udevadm",
+    "check": "which udevadm",
+    "install_steps": [
+      "base system (systemd / udev)",
+      "Verify: udevadm --version",
+      "supercli plugins install ./plugins/udevadm --on-conflict replace --json"
+    ],
+    "note": "Standard Linux system utility from systemd/udev."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "udevadm",
+      "resource": "self",
+      "action": "version",
+      "description": "Print udevadm version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "udevadm",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "udevadm is part of systemd (base system)"
+      },
+      "args": []
+    },
+    {
+      "namespace": "udevadm",
+      "resource": "device",
+      "action": "info",
+      "description": "Query sysfs or the udev database for device info",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "udevadm",
+        "baseArgs": ["info", "--query", "all"],
+        "positionalArgs": ["device"],
+        "parseJson": false,
+        "missingDependencyHelp": "udevadm is part of systemd (base system)"
+      },
+      "args": [
+        { "name": "device", "type": "string", "required": true, "description": "Device path (e.g. /dev/sda) or sysfs path" },
+        { "name": "--query", "type": "string", "description": "Query type: name, symlink, path, property, all" },
+        { "name": "--json", "type": "boolean", "description": "Output in JSON format" },
+        { "name": "--attribute-walk", "type": "boolean", "description": "Walk up the device chain" },
+        { "name": "--export-db", "type": "boolean", "description": "Export the udev database" }
+      ]
+    },
+    {
+      "namespace": "udevadm",
+      "resource": "device",
+      "action": "tree",
+      "description": "Show device tree",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "udevadm",
+        "baseArgs": ["info", "--tree"],
+        "missingDependencyHelp": "udevadm is part of systemd (base system)"
+      },
+      "args": []
+    },
+    {
+      "namespace": "udevadm",
+      "resource": "event",
+      "action": "trigger",
+      "description": "Trigger uevents from the kernel",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "udevadm",
+        "baseArgs": ["trigger"],
+        "missingDependencyHelp": "udevadm is part of systemd (base system)"
+      },
+      "args": [
+        { "name": "--type", "type": "string", "description": "Type: devices (default), subsystems, all" },
+        { "name": "--action", "type": "string", "description": "Event action: add, remove, change, move, online, offline, bind, unbind" },
+        { "name": "--subsystem-match", "type": "string", "description": "Only trigger devices from this subsystem" },
+        { "name": "--attr-match", "type": "string", "description": "Only trigger devices with matching attribute" },
+        { "name": "--property-match", "type": "string", "description": "Only trigger devices with matching property" },
+        { "name": "--tag-match", "type": "string", "description": "Only trigger devices with matching tag" },
+        { "name": "--verbose", "type": "boolean", "description": "Print list of devices" },
+        { "name": "--dry-run", "type": "boolean", "description": "Do not actually trigger events" }
+      ]
+    },
+    {
+      "namespace": "udevadm",
+      "resource": "event",
+      "action": "settle",
+      "description": "Wait for pending udev events to complete",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "udevadm",
+        "baseArgs": ["settle"],
+        "missingDependencyHelp": "udevadm is part of systemd (base system)"
+      },
+      "args": [
+        { "name": "--timeout", "type": "number", "description": "Maximum time to wait (seconds)" },
+        { "name": "--exit-if-exists", "type": "string", "description": "Stop waiting when device file appears" },
+        { "name": "--quiet", "type": "boolean", "description": "Suppress output" }
+      ]
+    },
+    {
+      "namespace": "udevadm",
+      "resource": "event",
+      "action": "monitor",
+      "description": "Listen to kernel and udev events",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "udevadm",
+        "baseArgs": ["monitor"],
+        "missingDependencyHelp": "udevadm is part of systemd (base system)"
+      },
+      "args": [
+        { "name": "--kernel", "type": "boolean", "description": "Print kernel uevents" },
+        { "name": "--udev", "type": "boolean", "description": "Print udev events" },
+        { "name": "--property", "type": "boolean", "description": "Print event properties" },
+        { "name": "--subsystem-match", "type": "string", "description": "Filter by subsystem" },
+        { "name": "--tag-match", "type": "string", "description": "Filter by tag" }
+      ]
+    },
+    {
+      "namespace": "udevadm",
+      "resource": "rules",
+      "action": "verify",
+      "description": "Verify udev rules files for syntax errors",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "udevadm",
+        "baseArgs": ["verify"],
+        "positionalArgs": ["files"],
+        "missingDependencyHelp": "udevadm is part of systemd (base system)"
+      },
+      "args": [
+        { "name": "files", "type": "string", "required": true, "description": "Path to rules files (space-separated or glob)" }
+      ]
+    },
+    {
+      "namespace": "udevadm",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to udevadm CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "udevadm",
+        "passthrough": true,
+        "missingDependencyHelp": "udevadm is part of systemd (base system)"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/udevadm/skills/quickstart/SKILL.md
+++ b/plugins/udevadm/skills/quickstart/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: udevadm
+description: Manage and query Linux devices, udev events, and device rules
+---
+# udevadm Plugin
+Manage and query Linux devices, udev events, and device rules
+
+## Usage
+- `udevadm self version` — Print udevadm version
+- `udevadm device info <device>` — Query device information
+- `udevadm device tree` — Show device tree
+- `udevadm event trigger` — Trigger kernel uevents
+- `udevadm event settle` — Wait for pending events
+- `udevadm event monitor` — Listen to events
+- `udevadm rules verify <files>` — Verify rules syntax
+- `udevadm _ _ <args>` — Run udevadm with any arguments


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Add 2 new useful plugins to the plugins/ directory. Each plugin must wrap a real CLI tool (e.g. jq, yq, bat, fzf, or a developer tool). Follow the pattern of existing plugins: create plugins/<name>/plugin.json, meta.json, install-guidance.json. Update plugins/catalog.json. Write the plugin in JavaScript under plugins/<name>/index.js if applicable. Make 2 separate commits, one per plugin.

**Branch:** `am/am-f17c27-tg4kp9`

```
plugins/catalog.json                       |  12 ++-
 plugins/sysctl/install-guidance.json       |   1 +
 plugins/sysctl/meta.json                   |  12 +++
 plugins/sysctl/plugin.json                 | 131 +++++++++++++++++++++++
 plugins/sysctl/skills/quickstart/SKILL.md  |  15 +++
 plugins/udevadm/install-guidance.json      |   1 +
 plugins/udevadm/meta.json                  |  13 +++
 plugins/udevadm/plugin.json                | 162 +++++++++++++++++++++++++++++
 plugins/udevadm/skills/quickstart/SKILL.md |  16 +++
 9 files changed, 361 insertions(+), 2 deletions(-)
```
