### PR TITLE
 Add proto plugin — polyglot toolchain manager … (+1 more)

### DIFF
--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generated_at": "2026-06-05T08:13:37.892Z",
-  "count": 5042,
+  "generated_at": "2026-06-05T08:52:08.713Z",
+  "count": 5043,
   "plugins": [
     {
       "name": "[",
@@ -16082,6 +16082,10 @@
     {
       "name": "scanopy",
       "checksum": "915ad3f461e5ddd4"
+    },
+    {
+      "name": "scarb",
+      "checksum": "a92ac68ecb158058"
     },
     {
       "name": "scc",

--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generated_at": "2026-06-05T08:52:08.713Z",
-  "count": 5043,
+  "generated_at": "2026-06-05T08:52:56.259Z",
+  "count": 5044,
   "plugins": [
     {
       "name": "[",
@@ -14542,6 +14542,10 @@
     {
       "name": "prospector",
       "checksum": "bd52e76d0aa6205b"
+    },
+    {
+      "name": "proto",
+      "checksum": "9761f1e1734c3fca"
     },
     {
       "name": "protoc",

--- a/plugins/proto/install-guidance.json
+++ b/plugins/proto/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "proto",
+  "binary": "proto",
+  "check": "proto --version",
+  "install_steps": [
+    "curl -fsSL https://moonrepo.dev/install/proto.sh | sh",
+    "Verify: proto --version",
+    "supercli plugins install ./plugins/proto --on-conflict replace --json"
+  ],
+  "note": "Proto is a polyglot toolchain manager from moonrepo. It manages language runtimes (Node.js, Rust, Go, Python, etc.), package managers, and dev tools with per-directory version pinning via .proto files."
+}

--- a/plugins/proto/meta.json
+++ b/plugins/proto/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Polyglot toolchain manager — install and manage language runtimes, package managers, and dev tools across projects with per-directory version pinning.",
+  "tags": ["proto", "toolchain", "runtime", "package-manager", "polyglot", "moonrepo"],
+  "has_learn": true
+}

--- a/plugins/proto/plugin.json
+++ b/plugins/proto/plugin.json
@@ -1,0 +1,133 @@
+{
+  "name": "proto",
+  "version": "0.1.0",
+  "description": "Polyglot toolchain manager — install and manage language runtimes, package managers, and dev tools",
+  "source": "https://moonrepo.dev/proto",
+  "checks": [
+    { "type": "binary", "name": "proto" }
+  ],
+  "install_guidance": {
+    "plugin": "proto",
+    "binary": "proto",
+    "check": "proto --version",
+    "install_steps": [
+      "curl -fsSL https://moonrepo.dev/install/proto.sh | sh",
+      "Verify: proto --version",
+      "supercli plugins install ./plugins/proto --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "proto",
+      "resource": "self",
+      "action": "version",
+      "description": "Print proto version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "proto",
+        "baseArgs": ["--version"],
+        "cwd": "invoke_cwd",
+        "missingDependencyHelp": "Install proto: curl -fsSL https://moonrepo.dev/install/proto.sh | sh"
+      },
+      "args": []
+    },
+    {
+      "namespace": "proto",
+      "resource": "tool",
+      "action": "install",
+      "description": "Install a tool (language runtime, package manager, or dev tool)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "proto",
+        "baseArgs": ["install"],
+        "cwd": "invoke_cwd",
+        "missingDependencyHelp": "Install proto: curl -fsSL https://moonrepo.dev/install/proto.sh | sh"
+      },
+      "args": [
+        { "name": "tool", "type": "string", "required": true, "description": "Tool name (e.g. node, npm, rust, go)" },
+        { "name": "--version", "type": "string", "required": false, "description": "Specific version to install" },
+        { "name": "--pin", "type": "boolean", "required": false, "description": "Pin the installed version" }
+      ]
+    },
+    {
+      "namespace": "proto",
+      "resource": "tool",
+      "action": "list",
+      "description": "List all installed tools",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "proto",
+        "baseArgs": ["list"],
+        "cwd": "invoke_cwd",
+        "missingDependencyHelp": "Install proto: curl -fsSL https://moonrepo.dev/install/proto.sh | sh"
+      },
+      "args": []
+    },
+    {
+      "namespace": "proto",
+      "resource": "tool",
+      "action": "list-remote",
+      "description": "List available versions for a tool",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "proto",
+        "baseArgs": ["list-remote"],
+        "cwd": "invoke_cwd",
+        "missingDependencyHelp": "Install proto: curl -fsSL https://moonrepo.dev/install/proto.sh | sh"
+      },
+      "args": [
+        { "name": "tool", "type": "string", "required": true, "description": "Tool name to list versions for" }
+      ]
+    },
+    {
+      "namespace": "proto",
+      "resource": "tool",
+      "action": "uninstall",
+      "description": "Uninstall a tool",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "proto",
+        "baseArgs": ["uninstall"],
+        "cwd": "invoke_cwd",
+        "missingDependencyHelp": "Install proto: curl -fsSL https://moonrepo.dev/install/proto.sh | sh"
+      },
+      "args": [
+        { "name": "tool", "type": "string", "required": true, "description": "Tool name to uninstall" }
+      ]
+    },
+    {
+      "namespace": "proto",
+      "resource": "tool",
+      "action": "run",
+      "description": "Run a tool at its installed version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "proto",
+        "baseArgs": ["run"],
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "missingDependencyHelp": "Install proto: curl -fsSL https://moonrepo.dev/install/proto.sh | sh"
+      },
+      "args": [
+        { "name": "tool", "type": "string", "required": true, "description": "Tool name to run" }
+      ]
+    },
+    {
+      "namespace": "proto",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to proto CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "proto",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "missingDependencyHelp": "Install proto: curl -fsSL https://moonrepo.dev/install/proto.sh | sh"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/proto/skills/quickstart/SKILL.md
+++ b/plugins/proto/skills/quickstart/SKILL.md
@@ -1,0 +1,57 @@
+# Proto Quick Start
+
+Proto is a polyglot toolchain manager from moonrepo. It manages language runtimes, package managers, and dev tools.
+
+## Prerequisites
+
+- Install Proto: `curl -fsSL https://moonrepo.dev/install/proto.sh | sh`
+
+## Basic Usage
+
+### Install a tool
+```bash
+proto install node
+proto install node --version 20
+proto install rust
+proto install go
+```
+
+### List installed tools
+```bash
+proto list
+```
+
+### List available versions
+```bash
+proto list-remote node
+```
+
+### Run a tool
+```bash
+proto run node -- --version
+```
+
+### Uninstall a tool
+```bash
+proto uninstall node
+```
+
+### Check version
+```bash
+proto --version
+```
+
+## Per-Directory Version Pinning
+
+Proto supports `.proto` files for pinning tool versions per directory:
+```
+node = "20.11.0"
+rust = "1.75.0"
+```
+
+## Passthrough
+
+Any proto command can be run directly:
+```bash
+proto <any-subcommand> [args...]
+```

--- a/plugins/scarb/install-guidance.json
+++ b/plugins/scarb/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "scarb",
+  "binary": "scarb",
+  "check": "scarb --version",
+  "install_steps": [
+    "curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh",
+    "Verify: scarb --version",
+    "supercli plugins install ./plugins/scarb --on-conflict replace --json"
+  ],
+  "note": "Scarb is the Cairo package manager from Software Mansion. It manages dependencies, compiles Cairo code, and runs tests for Starknet smart contracts."
+}

--- a/plugins/scarb/meta.json
+++ b/plugins/scarb/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Cairo package manager — compile, test, and manage dependencies for Starknet smart contracts and Cairo programs.",
+  "tags": ["scarb", "cairo", "starknet", "blockchain", "smart-contracts", "package-manager"],
+  "has_learn": true
+}

--- a/plugins/scarb/plugin.json
+++ b/plugins/scarb/plugin.json
@@ -1,0 +1,113 @@
+{
+  "name": "scarb",
+  "version": "0.1.0",
+  "description": "Cairo package manager — manage dependencies, compile, and test Starknet smart contracts",
+  "source": "https://docs.swmansion.com/scarb/",
+  "checks": [
+    { "type": "binary", "name": "scarb" }
+  ],
+  "install_guidance": {
+    "plugin": "scarb",
+    "binary": "scarb",
+    "check": "scarb --version",
+    "install_steps": [
+      "curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh",
+      "Verify: scarb --version",
+      "supercli plugins install ./plugins/scarb --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "scarb",
+      "resource": "self",
+      "action": "version",
+      "description": "Print scarb version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "scarb",
+        "baseArgs": ["--version"],
+        "cwd": "invoke_cwd",
+        "missingDependencyHelp": "Install scarb: curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh"
+      },
+      "args": []
+    },
+    {
+      "namespace": "scarb",
+      "resource": "project",
+      "action": "init",
+      "description": "Initialize a new Scarb project",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "scarb",
+        "baseArgs": ["init"],
+        "cwd": "invoke_cwd",
+        "missingDependencyHelp": "Install scarb: curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh"
+      },
+      "args": [
+        { "name": "--name", "type": "string", "required": false, "description": "Set the project name" },
+        { "name": "--no-git", "type": "boolean", "required": false, "description": "Do not initialize git repository" }
+      ]
+    },
+    {
+      "namespace": "scarb",
+      "resource": "project",
+      "action": "build",
+      "description": "Compile the current project",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "scarb",
+        "baseArgs": ["build"],
+        "cwd": "invoke_cwd",
+        "missingDependencyHelp": "Install scarb: curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh"
+      },
+      "args": []
+    },
+    {
+      "namespace": "scarb",
+      "resource": "project",
+      "action": "test",
+      "description": "Run project tests",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "scarb",
+        "baseArgs": ["test"],
+        "cwd": "invoke_cwd",
+        "missingDependencyHelp": "Install scarb: curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh"
+      },
+      "args": [
+        { "name": "--filter", "type": "string", "required": false, "description": "Filter tests by name" }
+      ]
+    },
+    {
+      "namespace": "scarb",
+      "resource": "project",
+      "action": "clean",
+      "description": "Remove build artifacts",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "scarb",
+        "baseArgs": ["clean"],
+        "cwd": "invoke_cwd",
+        "missingDependencyHelp": "Install scarb: curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh"
+      },
+      "args": []
+    },
+    {
+      "namespace": "scarb",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to scarb CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "scarb",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "missingDependencyHelp": "Install scarb: curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/scarb/skills/quickstart/SKILL.md
+++ b/plugins/scarb/skills/quickstart/SKILL.md
@@ -1,0 +1,47 @@
+# Scarb Quick Start
+
+Scarb is the Cairo package manager for Starknet smart contracts and Cairo programs.
+
+## Prerequisites
+
+- Install Scarb: `curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh`
+
+## Basic Usage
+
+### Initialize a new project
+```bash
+scarb init --name my-project
+```
+
+### Build the project
+```bash
+scarb build
+```
+
+### Run tests
+```bash
+scarb test
+```
+
+### Clean build artifacts
+```bash
+scarb clean
+```
+
+### Check version
+```bash
+scarb --version
+```
+
+## Passthrough
+
+Any scarb command can be run directly:
+```bash
+scarb <any-subcommand> [args...]
+```
+
+## Tips
+
+- Scarb manages Cairo dependencies via `Scarb.toml`
+- Use `scarb fmt` to format code
+- Use `scarb tree` to display dependency tree


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Add 2 new useful plugins to the plugins/ directory. Each plugin must wrap a real CLI tool (e.g. jq, yq, bat, fzf, or a developer tool). Follow the pattern of existing plugins: create plugins/<name>/plugin.json, meta.json, install-guidance.json. Update plugins/catalog.json. Write the plugin in JavaScript under plugins/<name>/index.js if applicable. Make 2 separate commits, one per plugin.

**Branch:** `am/am-f17c27-tg5hpj`

```
plugins/catalog.json                     |  12 ++-
 plugins/proto/install-guidance.json      |  11 +++
 plugins/proto/meta.json                  |   5 ++
 plugins/proto/plugin.json                | 133 +++++++++++++++++++++++++++++++
 plugins/proto/skills/quickstart/SKILL.md |  57 +++++++++++++
 plugins/scarb/install-guidance.json      |  11 +++
 plugins/scarb/meta.json                  |   5 ++
 plugins/scarb/plugin.json                | 113 ++++++++++++++++++++++++++
 plugins/scarb/skills/quickstart/SKILL.md |  47 +++++++++++
 9 files changed, 392 insertions(+), 2 deletions(-)
```
