### PR TITLE
 docs: fix broken doc references and stale dcli names in core docs

### DIFF
--- a/cli/help.js
+++ b/cli/help.js
@@ -38,8 +38,8 @@ function displayJsonHelp() {
     ],
     documentation: [
       "Full README: https://github.com/javimosch/supercli#readme",
-      "Supported Harnesses: docs/supported-harnesses.md",
-      "Plugin Creation Guide: docs/plugin-harness-guide.md",
+      "Supported Harnesses: docs/plugins-available.md",
+      "Plugin Creation Guide: docs/plugins-how-to.md",
     ],
     output_modes: [
       "(default)   JSON output",
@@ -90,8 +90,8 @@ function displayComprehensiveHelp() {
   console.log("    supercli offboard              # Remove installed skill\n");
   console.log("  📖 DOCUMENTATION & RESOURCES:");
   console.log("    Full README: https://github.com/javimosch/supercli#readme");
-  console.log("    Supported Harnesses: docs/supported-harnesses.md");
-  console.log("    Plugin Creation Guide: docs/plugin-harness-guide.md\n");
+  console.log("    Supported Harnesses: docs/plugins-available.md");
+  console.log("    Plugin Creation Guide: docs/plugins-how-to.md\n");
   console.log("  🏷️  OUTPUT MODES:");
   console.log("    (default)   JSON output");
   console.log("    --json      Structured JSON envelope");

--- a/docs/plugins-available.md
+++ b/docs/plugins-available.md
@@ -281,12 +281,12 @@ These harnesses are in active development and will be available as plugins. Stat
 
 Want to create a plugin for your favorite CLI? Follow these steps:
 
-1. **Review the Plugin Guide**: See [plugin-harness-guide.md](plugin-harness-guide.md)
+1. **Review the Plugin Guide**: See [plugins-how-to.md](plugins-how-to.md)
 2. **Create a Manifest**: Define your `plugin.json`
 3. **Test Locally**: Use `supercli plugins install ./your-plugin`
 4. **Publish**: Submit to the plugin registry via `supercli plugins publish`
 
-For detailed instructions, see [plugin-harness-guide.md](plugin-harness-guide.md).
+For detailed instructions, see [plugins-how-to.md](plugins-how-to.md).
 
 ## Request a Harness
 

--- a/docs/plugins-examples.md
+++ b/docs/plugins-examples.md
@@ -4,7 +4,7 @@ Real-world examples of plugin harnesses you can use as reference for creating yo
 
 ## Example 1: beads - Wrapped Commands
 
-The beads plugin demonstrates selective command wrapping. It exposes key beads_rust commands through dcli's interface.
+The beads plugin demonstrates selective command wrapping. It exposes key beads_rust commands through supercli's interface.
 
 ```json
 {
@@ -260,7 +260,7 @@ A template for creating your own wrapped command plugin:
 {
   "name": "my-cli",
   "version": "0.1.0",
-  "description": "Wrap my-cli with dcli integration",
+  "description": "Wrap my-cli with supercli integration",
   "source": "https://github.com/user/my-cli",
   "tags": ["category", "keyword"],
   "author": "Your Name",
@@ -394,4 +394,4 @@ supercli plugins doctor my-cli
 4. **Iterate**: Refine based on usage feedback
 5. **Publish**: Share with the community via GitHub
 
-See [plugin-harness-guide.md](plugin-harness-guide.md) for detailed documentation.
+See [plugins-how-to.md](plugins-how-to.md) for detailed documentation.


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Improve supercli static documentation: README, CONTRIBUTING, or docs/ files. Make ONE atomic commit with clear summary explaining what documentation was improved and WHY. Use fix:/docs: prefix. Keep it focused and reviewable.

**Branch:** `am/am-f17c27-tg5lou`

```
cli/help.js               | 8 ++++----
 docs/plugins-available.md | 4 ++--
 docs/plugins-examples.md  | 6 +++---
 3 files changed, 9 insertions(+), 9 deletions(-)
```
