### PR TITLE
 docs: fix stale references in static documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,7 @@ docs(readme): update installation instructions
 
 - `/docs/` - Main documentation directory
 - `/docs/plugins-how-to.md` - Plugin development guide
-- `/docs/skills/` - Skill system documentation
+- `/docs/skills-catalog.md` - Skill document catalog and provider management
 - `/README.md` - Project overview and quick start
 - Plugin-specific docs in `/plugins/*/README.md`
 

--- a/docs/plugins-available.md
+++ b/docs/plugins-available.md
@@ -290,7 +290,7 @@ For detailed instructions, see [plugins-how-to.md](plugins-how-to.md).
 
 ## Request a Harness
 
-Missing a CLI you'd like to use with supercli? [Open an issue](https://github.com/anomalyco/supercli/issues) with:
+Missing a CLI you'd like to use with supercli? [Open an issue](https://github.com/javimosch/supercli/issues) with:
 - CLI name and link
 - Use cases in your workflow
 - Relevant commands/operations

--- a/docs/server.md
+++ b/docs/server.md
@@ -20,7 +20,7 @@ The shell adapter executes bash scripts with argument interpolation. Use `{{vari
 
 Arguments defined in the command schema are interpolated before execution. For example, with an argument named `name`:
 
-- Command: `sc system test foo --name Pedro`
+- Command: `supercli system test foo --name Pedro`
 - Interpolated script: `echo 'Hello Pedro'`
 
 **Important:** Shell adapter requires `adapterConfig.unsafe=true` for security policy reasons.


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Improve supercli static documentation: README, CONTRIBUTING, or docs/ files. Make ONE atomic commit with clear summary explaining what documentation was improved and WHY. Use fix:/docs: prefix. Keep it focused and reviewable.

**Branch:** `am/am-f17c27-tg5mvi`

```
CONTRIBUTING.md           | 2 +-
 docs/plugins-available.md | 2 +-
 docs/server.md            | 2 +-
 3 files changed, 3 insertions(+), 3 deletions(-)
```
