### PR TITLE
 docs: fix stale plugin counts across documentation files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,8 +184,8 @@ If `install_guidance` is defined in `plugin.json` but no separate `install-guida
 
 ## Plugin Count
 
-- Total plugins: ~5,047
-- Short descriptions (<30 chars): ~1,176 (target: 0)
+- Total plugins: ~5,046
+- Short descriptions (<30 chars): ~807 (target: 0)
 - Avg description length: 72 chars (target: 80+)
 
 ## Other Agent Instructions

--- a/ARCHITECTURE_PLAN.md
+++ b/ARCHITECTURE_PLAN.md
@@ -3,7 +3,7 @@
 ## 1. Current State Assessment
 
 ### What SuperCLI Is
-A config-driven, universal CLI capability router that wraps 4,000+ CLI tools, APIs, MCP servers, and workflows behind a uniform `namespace resource action` command interface. Lives on npm as `superacli` v1.31.1.
+A config-driven, universal CLI capability router that wraps 5,000+ CLI tools, APIs, MCP servers, and workflows behind a uniform `namespace resource action` command interface. Lives on npm as `superacli` v1.31.1.
 
 ### Dual-Implementation Architecture
 | Feature | sc-zig (Zig 0.16.0) | sc (Node.js) |
@@ -18,7 +18,7 @@ A config-driven, universal CLI capability router that wraps 4,000+ CLI tools, AP
 | OpenAPI adapter | ❌ | ✅ |
 
 ### Repository Stats
-- 5,047 bundled plugins in `plugins/<name>/` dirs (each with `plugin.json` + `meta.json`)
+- 5,046 bundled plugins in `plugins/<name>/` dirs (each with `plugin.json` + `meta.json`)
 - 8,888 commands exposed through plugins
 - 90 Jest test files covering CLI, adapters, plugins, server
 - 36 smoke test scripts in `tests/`
@@ -28,7 +28,7 @@ A config-driven, universal CLI capability router that wraps 4,000+ CLI tools, AP
 
 ### Quality Metrics
 - Plugin quality score: 92.1% (up from 91.2%)
-- 1,174 plugins still have short descriptions (< 30 chars)
+- 807 plugins still have short descriptions (< 30 chars)
 - 31 source URLs already fixed (generic → specific repos)
 - 13 tags added for improved discoverability
 
@@ -121,9 +121,9 @@ Both implementations share `~/.supercli/plugins/plugins.lock.json`. The Zig CLI 
 ### Summary
 | Metric | Value |
 |--------|-------|
-| Total plugin directories | 5,047 |
-| With plugin.json | 5,047 (100%) |
-| With meta.json | 5,047 (100%) |
+| Total plugin directories | 5,046 |
+| With plugin.json | 5,046 (100%) |
+| With meta.json | 5,046 (100%) |
 | With install-guidance.json | 4,021 (99.97%) |
 | With skills/quickstart/SKILL.md | 3,142 (78.1%) |
 | With README.md | 75 (2.2%) |
@@ -176,5 +176,5 @@ Both implementations share `~/.supercli/plugins/plugins.lock.json`. The Zig CLI 
 - **CI workflows**: 90 Jest test files, 36 smoke test scripts
 
 ### Notes
-- Total plugin dirs: 5,047
+- Total plugin dirs: 5,046
 - install-guidance.json coverage near-perfect at 99.97%

--- a/PLUGIN_STANDARDS.md
+++ b/PLUGIN_STANDARDS.md
@@ -1,7 +1,7 @@
 # SuperCLI Plugin Standards
 
 ## Overview
-This document defines quality standards for plugins in the SuperCLI collection. These standards ensure consistency, discoverability, and usability across 1,179+ plugins.
+This document defines quality standards for plugins in the SuperCLI collection. These standards ensure consistency, discoverability, and usability across 5,000+ plugins.
 
 ## Description Quality
 

--- a/QUALITY_REPORT.md
+++ b/QUALITY_REPORT.md
@@ -15,7 +15,7 @@ Automated quality improvements applied to SuperCLI plugin collection across mult
 - **Short descriptions remaining:** 923 (down from 1,262)
 - **DESCRIPTIONS map entries:** 416 tools (need ~400+ more)
 - **Install-guidance.json created:** 22 plugins
-- **Plugins scanned:** 5,047
+- **Plugins scanned:** 5,046
 
 ### Before vs After (Cumulative)
 
@@ -29,7 +29,7 @@ Automated quality improvements applied to SuperCLI plugin collection across mult
 
 ### Process Used
 
-1. **Analysis** - Scanned all 5,047 plugins for short descriptions (< 30 chars)
+1. **Analysis** - Scanned all 5,046 plugins for short descriptions (< 30 chars)
 2. **Generation** - `batch-enhance-descriptions.ts` mapped 1,262 short-description plugins to suggestions
 3. **Auto-apply** - 54 high-confidence (>=85%) suggestions applied to plugin files
 4. **Install guidance** - 22 missing `install-guidance.json` files created from existing `plugin.json` data

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,7 @@ subtitle: "From OSS Swiss Army Knife → Cloud AI Layer → French Unicorn"
 
 # SuperCLI Roadmap 2026–2028
 
-**Current state (mid-2026):** 1 269 plugins, 5 553 commands, 130k+ LOC. A config-driven, AI-friendly dynamic CLI — the largest open-source CLI ecosystem in the world.
+**Current state (mid-2026):** 5,000+ plugins, 8,000+ commands, 130k+ LOC. A config-driven, AI-friendly dynamic CLI — the largest open-source CLI ecosystem in the world.
 
 SuperCLI has already won the *distribution* game. Every tool an agent needs is one `sc <namespace>` away. The roadmap below turns that distribution monopoly into a platform, a network, and eventually a generational company.
 
@@ -20,7 +20,7 @@ SuperCLI has already won the *distribution* game. Every tool an agent needs is o
 | Initiative | Why | Expected Impact |
 |---|---|---|
 | **SuperCLI Agent SDK** — Node/Python/Rust SDK to call any plugin programmatically | Agents embed `sc` calls natively instead of shelling out | 10× agent adoption |
-| **Plugin scoring & curation** — Community-voted "verified" plugins | Quality signal for 1.3K+ plugins | Better discovery |
+| **Plugin scoring & curation** — Community-voted "verified" plugins | Quality signal for 5,000+ plugins | Better discovery |
 | **`sc diagnose`** — Built-in health check + debugger for agent workflows | Reduce agent frustration with broken commands | Lower churn |
 | **Plugin bundles** — Curated groups (security-bundle, cloud-bundle, etc.) | One-command install for vertical use-cases | Faster onboarding |
 | **Otel-native logging** — Every command emits structured traces | Agents can audit their own execution | Debuggability |
@@ -33,7 +33,7 @@ SuperCLI has already won the *distribution* game. Every tool an agent needs is o
 |---|---|---|
 | **`sc plan` / `sc act` / `sc review`** — High-level agentic workflows built on top of plugin chains | Agents don't call individual tools — they declare intent | 100× productivity leap |
 | **Plugin dependency graphs** — Resolve toolchains automatically (e.g., `sc deploy` → triggers build + test + push + notify) | Eliminate multi-step agent loops | Fewer context window overflows |
-| **MCP-native runtime** — SuperCLI as an MCP server itself (not just consuming MCP) | Any MCP client gets all 1.3K+ tools for free | Network effects |
+| **MCP-native runtime** — SuperCLI as an MCP server itself (not just consuming MCP) | Any MCP client gets all 5,000+ tools for free | Network effects |
 | **`sc store`** — Community plugin marketplace (like VS Code extensions but for CLI) | Third-party authors publish without PRs | Scale beyond core team |
 | **Local LLM integration** — `sc explain`, `sc suggest` powered by local models | Agents get inline help without phoning home | Offline-first credibility |
 
@@ -174,6 +174,6 @@ SuperCLI has already won the *distribution* game. Every tool an agent needs is o
 |------|------------|
 | AI agents become "good enough" without plugins | SuperCLI as the universal execution layer — agents use tools, not guess |
 | OpenAI/Anthropic build their own tool registries | Plugin portability + MCP-native runtime = no lock-in |
-| Open-source clone emerges | Network effects (1.3K+ plugins, 5.5K+ commands), cloud layer, team features |
+| Open-source clone emerges | Network effects (5,000+ plugins, 8,000+ commands), cloud layer, team features |
 | Enterprise sales cycle too long | Self-serve freemium → land & expand → enterprise |
 | European scaling slower than US | Lean team + remote-first until Series A |


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Improve supercli static documentation: README, CONTRIBUTING, or docs/ files. Make ONE atomic commit with clear summary explaining what documentation was improved and WHY. Use fix:/docs: prefix. Keep it focused and reviewable.

**Branch:** `am/am-f17c27-tg5nrm`

```
AGENTS.md            |  4 ++--
 ARCHITECTURE_PLAN.md | 14 +++++++-------
 PLUGIN_STANDARDS.md  |  2 +-
 QUALITY_REPORT.md    |  4 ++--
 docs/ROADMAP.md      |  8 ++++----
 5 files changed, 16 insertions(+), 16 deletions(-)
```
