### PR TITLE
 docs: fix stale plugin counts in README Capability Sources and Tech Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ supercli replaces tool-specific syntax with a **queryable, executable capability
 
 ## 📦 Capability Sources
 
-supercli draws capabilities from **bundled plugins** (200+, immediate), **plugin registry** (3,100+, `plugins install <name>`), **MCP servers** (`mcp add <name>`), and **HTTP APIs** (`api add <name>`). Every capability includes description, tags, argument schemas, and checksum-verified metadata.
+supercli draws capabilities from **bundled plugins** (5,000+, auto-discovered), **MCP servers** (`mcp add <name>`), and **HTTP APIs** (`api add <name>`). Every capability includes description, tags, argument schemas, and checksum-verified metadata.
 
 ---
 
@@ -371,7 +371,7 @@ For detailed debugging: `supercli` returns the full schema (JSON by default). Us
 |-------|-----------|
 | Runtime | Node.js (sc), Zig (sc-zig) — co-exist, share plugin state |
 | Router | Custom capability graph with sub-millisecond cache |
-| Plugins | 4,999 bundled — each `plugin.json` + `meta.json` |
+| Plugins | 5,000+ bundled — each `plugin.json` + `meta.json` |
 | MCP | Built-in MCP server adapter (`supercli mcp add <name>`) |
 | HTTP | HTTP adapter for REST endpoints as capabilities |
 | Registry | `plugins/catalog.json` — checksum-verified updates |


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Improve supercli static documentation: README, CONTRIBUTING, or docs/ files. Make ONE atomic commit with clear summary explaining what documentation was improved and WHY. Use fix:/docs: prefix. Keep it focused and reviewable.

**Branch:** `am/am-f17c27-tg5o14`

```
README.md | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated capability sources documentation to reflect 5,000+ bundled plugins and auto-discovery capabilities.
  * Updated technical stack details to reflect current plugin bundle count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->