### PR TITLE
 docs: add missing azd-uipath-plugins feature to index

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -16,6 +16,7 @@ Detailed documentation for supercli's core features and capabilities.
 | [Workflows](workflows.md) | Multi-step workflow execution with data piping | [Read →](workflows.md) |
 | [Config Sync](config-sync.md) | Configuration synchronization between client and server | [Read →](config-sync.md) |
 | [Execution Plans](execution-plans.md) | Planning and execution of command sequences | [Read →](execution-plans.md) |
+| [Azure DevOps & UiPath Plugins](azd-uipath-plugins.md) | Azure Developer CLI and UiPath automation harnesses | [Read →](azd-uipath-plugins.md) |
 
 ## Quick Navigation
 


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Improve supercli static documentation: README, CONTRIBUTING, or docs/ files. Make ONE atomic commit with clear summary explaining what documentation was improved and WHY. Use fix:/docs: prefix. Keep it focused and reviewable.

**Branch:** `am/am-f17c27-tg5o6k`

```
docs/features/README.md | 1 +
 1 file changed, 1 insertion(+)
```
