### PR TITLE
automaintainer: Improve supercli static documentation: README, CONTRIBUTING…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,18 +198,31 @@ docs(readme): update installation instructions
 
 ### Where to Find Documentation
 
-- `/docs/` - Main documentation directory
-- `/docs/plugins-how-to.md` - Plugin development guide
-- `/docs/skills-catalog.md` - Skill document catalog and provider management
-- `/README.md` - Project overview and quick start
+- `/README.md` — Project overview and quick start
+- `/CONTRIBUTING.md` — This file
+- `/PLUGIN_STANDARDS.md` — Plugin quality standards (descriptions, tags, source URLs)
+- `/TAG_VOCABULARY.md` — Controlled vocabulary for plugin tags
+- `/ARCHITECTURE_PLAN.md` — Architecture plan and design decisions
+- `/docs/` — Main documentation directory
+  - `/docs/plugins-how-to.md` — Plugin development guide
+  - `/docs/skills-catalog.md` — Skill document catalog and provider management
+  - `/docs/server-plugins-usage-guide.md` — Server plugin usage and testing guide
+  - `/docs/AGENTS_FRIENDLY_TOOLS.md` — Agent-friendly CLI design principles
+  - `/docs/ROADMAP.md` — Project roadmap (2026–2028)
+  - `/docs/feature-gaps.md` — Feature gap analysis vs. capability-mesh vision
+  - `/docs/plugins-available.md` — Available plugins listing
+  - `/docs/plugins-examples.md` — Plugin examples
+  - `/docs/features/` — Feature-specific documentation (adapters, skills, workflows, etc.)
 - Plugin-specific docs in `/plugins/*/README.md`
 
 ### Documentation Style
 
 - Use clear, concise language
-- Include practical examples
-- Keep code snippets up to date
-- Use consistent formatting
+- Include practical examples with copy-pasteable commands
+- Keep code snippets up to date with current CLI syntax
+- Use consistent formatting: `backticks` for commands, **bold** for key concepts
+- Reference other docs files when relevant (e.g., "see [PLUGIN_STANDARDS.md](PLUGIN_STANDARDS.md)")
+- Plugin documentation must reflect the isolated file convention (never reference legacy shared files)
 
 ### Contributing Plugin Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <p align="center">
   <img src="https://img.shields.io/npm/v/superacli" alt="npm">
-  <img src="https://img.shields.io/badge/release-2026--05--14-blue" alt="Latest Release">
+  <img src="https://img.shields.io/badge/release-2026--06--07-blue" alt="Latest Release">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
+  <img src="https://img.shields.io/badge/plugins-5000+-blueviolet" alt="Plugins">
   <img src="https://img.shields.io/github/stars/javimosch/supercli?style=social" alt="Stars">
 </p>
 

--- a/docs/plugins-how-to.md
+++ b/docs/plugins-how-to.md
@@ -111,12 +111,16 @@ Every plugin harness consists of:
 
 ### Minimal Plugin Structure
 
+Use the isolated plugin structure described at the top of this guide. Every file
+must live inside `plugins/<name>/` — never at the top level or in shared directories.
+
 ```
-my-plugin/
-├── plugin.json          # Required: manifest
-├── README.md            # Optional: plugin documentation
-└── examples/            # Optional: example usage
-    └── example.sh
+plugins/my-plugin/
+├── plugin.json              # Required: manifest with commands
+├── meta.json                # Required: description, tags, has_learn
+├── install-guidance.json    # Optional: install steps
+├── skills/quickstart/SKILL.md  # Optional: agent guide
+└── README.md                # Optional: human docs
 ```
 
 ## plugin.json Manifest
@@ -157,9 +161,9 @@ The `plugin.json` file is the core of your harness. It describes:
 {
   "name": "beads",              // Unique plugin identifier
   "version": "0.1.0",           // Semantic versioning
-  "description": "...",         // Short description
+  "description": "...",         // Short description (30-150 chars, see PLUGIN_STANDARDS.md)
   "source": "https://...",      // Link to upstream CLI
-  "tags": ["task", "automation"], // Optional: discovery tags
+  "tags": ["task", "automation"], // Optional: discovery tags (3-8 tags, see TAG_VOCABULARY.md)
   "author": "Your Name"         // Optional: plugin author
 }
 ```
@@ -433,8 +437,10 @@ Once your plugin is tested and working:
 2. **Structure it properly**:
    ```
    my-plugin-harness/
-   ├── plugin.json
-   ├── meta.json
+   ├── plugin.json              # Required: manifest with commands
+   ├── meta.json                # Required: description, tags, has_learn
+   ├── install-guidance.json    # Optional: install steps
+   ├── skills/quickstart/SKILL.md  # Optional: agent guide
    ├── README.md
    ├── LICENSE
    └── examples/


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Improve supercli static documentation: README, CONTRIBUTING, or docs/ files. Make ONE atomic commit with clear summary explaining what documentation was improved and WHY. Use fix:/docs: prefix. Keep it focused and reviewable.

**Branch:** `am/am-f17c27-tgabna`

## Summary

Fixed documentation inconsistencies across three static docs files. plugins-how-to.md had a "Minimal Plugin Structure" section showing a flat layout that contradicted the isolated plugin convention documented 100 lines earlier — replaced with the correct directory layout and added cross-references to PLUGIN_STANDARDS.md and TAG_VOCABULARY.md. CONTRIBUTING.md's documentation index only listed 3 of ~15 docs files, making it impossible for contributors to discover ROADMAP.md, PLUGIN_STANDARDS.md, server-plugins-usage-guide.md, and others without browsing the filesystem. README.md had a stale release badge (2026-05-14) and lacked a plugin count badge for at-a-glance context.

**Diff:**
```
CONTRIBUTING.md        | 27 ++++++++++++++++++++-------
 README.md              |  3 ++-
 docs/plugins-how-to.md | 24 +++++++++++++++---------
 3 files changed, 37 insertions(+), 17 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced contribution guidelines with clearer documentation structure and stricter plugin documentation requirements.
  * Updated README badges, including new "5000+ Plugins" milestone indicator.
  * Improved plugin creation guide with explicit folder structure requirements and expanded metadata documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->