### PR TITLE
automaintainer: Improve supercli static documentation: README, CONTRIBUTING…

### DIFF
--- a/docs/features/observability.md
+++ b/docs/features/observability.md
@@ -1,22 +1,101 @@
 # Observability & Traceability
 
-supercli maintains a rich audit trail to monitor tool utilization natively, eliminating CLI tooling "blind spots".
+supercli maintains a rich audit trail to monitor tool utilization natively, eliminating CLI tooling "blind spots". Every command execution is recorded as a job, enabling historical analysis, agent behavior auditing, and performance monitoring.
 
 ## Key Features
 
-- **Job Tracing API (`/api/jobs`)**: Every time the CLI executes a command, it fires an asynchronous job tracking payload via `fetch` to the backend server with its execution parameters (command called, user arguments, duration, risk classification, outcome code).
-- **Historical Analysis**: Administrators can review which endpoints are failing at the network adapter layer, identify slow execution patterns, or audit AI agent behaviors natively.
-- **Dashboard Interface**: The built-in Express `.ejs` UI ships a dedicated `Jobs` dashboard that dynamically visualizes job history and computes basic high-level stats (e.g., success rate).
+- **Job Tracing API (`/api/jobs`)**: Every CLI execution fires an asynchronous job tracking payload to the backend server with execution parameters (command, arguments, duration, status, error details).
+- **Historical Analysis**: Review which endpoints are failing, identify slow execution patterns, or audit AI agent behaviors over time.
+- **Dashboard Interface**: The built-in Express UI ships a dedicated Jobs page that visualizes execution history with stats (total, success, failed, failure rate).
+- **Aggregate Statistics**: `/api/jobs/stats` computes top commands by frequency and average latency across all recorded executions.
+- **Pruning**: Old jobs can be pruned by age to manage storage (`DELETE /api/jobs?older_than=7`).
+
+## Job Record Schema
+
+Each job execution produces a record with the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_id` | string | Unique job identifier (`job:<timestamp>_<random>`) |
+| `command` | string | Full command string (e.g., `aws.cfn.deploy`) |
+| `args` | object | Arguments passed to the command |
+| `status` | string | `success`, `failed`, or `unknown` |
+| `duration_ms` | number | Execution time in milliseconds |
+| `timestamp` | string | ISO 8601 timestamp of execution |
+| `plan_id` | string | Execution plan ID if command was plan-gated (nullable) |
+| `error` | object | Error details if status is `failed` (nullable) |
+| `client_id` | string | Client identifier for multi-agent environments (nullable) |
 
 ## Usage
 
-Observability is enabled entirely passively. The CLI client naturally logs its outcome up to the server.
+Observability is enabled passively — the CLI automatically records each execution trace.
 
 ```bash
-# The CLI automatically records this execution trace
+# Execution is automatically traced
 SUPERCLI_SERVER=http://127.0.0.1:3000 supercli github issues list
 
-# The traces can be consumed locally or via REST
+# Open the dashboard in a browser
 open http://localhost:3000/jobs
-curl http://127.0.0.1:3000/api/jobs/stats
+
+# Query stats via API
+curl -s http://127.0.0.1:3000/api/jobs/stats | jq
+
+# List recent jobs (JSON)
+curl -s "http://127.0.0.1:3000/api/jobs?limit=10&format=json" | jq
+
+# Filter jobs by command
+curl -s "http://127.0.0.1:3000/api/jobs?command=aws.cfn.deploy&format=json" | jq
+
+# Get a specific job by ID
+curl -s "http://127.0.0.1:3000/api/jobs/job:1717849200000_abc1234" | jq
+
+# Prune jobs older than 30 days
+curl -s -X DELETE "http://127.0.0.1:3000/api/jobs?older_than=30" | jq
 ```
+
+## Stats Response
+
+The `/api/jobs/stats` endpoint returns aggregate metrics:
+
+```json
+{
+  "total": 1247,
+  "success": 1189,
+  "failed": 58,
+  "failure_rate": "4.7%",
+  "top_commands": [
+    { "command": "github.issue.list", "count": 312, "avg_ms": 245 },
+    { "command": "aws.cfn.deploy", "count": 87, "avg_ms": 14200 },
+    { "command": "ai.text.summarize", "count": 64, "avg_ms": 3100 }
+  ]
+}
+```
+
+**Key fields:**
+- `failure_rate`: Percentage of jobs with `status: "failed"`
+- `top_commands`: Top 10 most-executed commands with average latency
+- `avg_ms`: Average duration — useful for identifying slow commands
+
+## Interpreting Job Status
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `success` | Command completed with exit code 0 | No action needed |
+| `failed` | Command returned non-zero exit code | Check `error` field for details |
+| `unknown` | Status was not reported (e.g., crash, timeout) | Investigate client logs |
+
+### Common Failure Patterns
+
+- **High failure rate on a specific command**: Likely a configuration issue or missing dependency. Check the `error` field in individual job records.
+- **Spike in `unknown` status**: Client may be crashing before reporting status. Check client connectivity and server logs.
+- **High `avg_ms` for a command**: Consider adding `timeout_ms` to `adapterConfig` or caching results.
+
+## Dashboard
+
+The Jobs dashboard at `/jobs` provides:
+
+- **Stats panel**: Click "Stats" to see total/success/failed/failure rate
+- **Job table**: Sortable list with command, status badge (green/red), duration, relative timestamp, and client ID
+- **Filtering**: Use `?command=<name>` query parameter to filter by command
+
+The dashboard renders server-side (EJS) and loads stats client-side (Vue.js). No additional setup required beyond running the server with `SUPERCLI_SERVER` configured.

--- a/docs/features/storage.md
+++ b/docs/features/storage.md
@@ -1,25 +1,157 @@
 # Pluggable Storage
 
-By default, the backend of supercli is incredibly lightweight. However, for scaled enterprise deployments, its datastore is fully pluggable.
+supercli's backend uses a pluggable key-value storage layer. By default it writes JSON files locally, with an option to switch to MongoDB for production deployments. All server data — jobs, plugins, settings — flows through this single abstraction.
 
 ## Key Features
 
-- **Key-Value Abstraction Layer**: Rather than tying the application to a specific database driver (e.g., MongoDB), supercli operates strictly against a generic `delete`, `set`, `get`, and `listKeys` interface.
-- **Natural Entity Keys**: Data records internally utilize human-readable string IDs (like `command:namespace.resource.action`) rather than opaque ObjectIDs to improve portability.
-- **Zero-Dependency Native Backend (`FileAdapter`)**: Without MongoDB configured, supercli defaults to reading and writing `.json` files in a local directory (`./supercli_storage`). This makes local testing completely frictionless and allows backing up configurations natively into Git if desired.
-- **Enterprise Scale (`MongoAdapter`)**: Toggling an environment variable enables MongoDB persistence for shared, concurrent, high-availability deployments.
+- **Key-Value Abstraction Layer**: A four-method interface (`get`, `set`, `delete`, `listKeys`) that all server features use. Swapping backends requires zero changes to application code.
+- **Natural Entity Keys**: Data records use human-readable string IDs (e.g., `command:aws.cfn.deploy`, `job:1717849200000_abc1234`) instead of opaque ObjectIDs, making debugging and backup straightforward.
+- **Zero-Dependency Default (`FileAdapter`)**: Without MongoDB configured, supercli writes `.json` files to a local directory. This makes local development and testing frictionless, and the files are human-readable for debugging.
+- **Production Scale (`MongoAdapter`)**: Setting `SUPERCLI_USE_MONGO=true` enables MongoDB persistence for concurrent, high-availability deployments with proper indexing.
+
+## Key-Value Interface
+
+Both adapters implement the same four methods:
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `get` | `get(key) → object \| null` | Retrieve a record by key. Returns `null` if not found. |
+| `set` | `set(key, value) → void` | Create or update a record. Upserts by default. |
+| `delete` | `delete(key) → void` | Remove a record. No-op if key doesn't exist. |
+| `listKeys` | `listKeys(prefix) → string[]` | List all keys matching a prefix. Empty array if none. |
+
+**Key naming convention:** Keys follow a `type:identifier` pattern:
+- `job:<timestamp>_<random>` — execution trace records
+- `command:<namespace>.<resource>.<action>` — command registrations
+- `plugin:<name>` — plugin metadata
+- `setting:<key>` — server settings
+
+## Configuration
+
+The storage adapter is selected by environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SUPERCLI_USE_MONGO` | `false` | Set to `true` to use MongoDB |
+| `MONGO_URL` | `mongodb://localhost:27017` | MongoDB connection URI |
+| `SUPERCLI_DB` | `supercli` | MongoDB database name |
+| `SUPERCLI_STORAGE_DIR` | `./supercli_storage` | Local directory for FileAdapter |
 
 ## Usage
 
-The storage adapter is entirely determined by your environment variables in `.env` or process spawn.
-
 ```bash
-# Default behavior (uses FileAdapter producing ./supercli_storage/*.json files)
+# Default: FileAdapter — writes to ./supercli_storage/*.json
 npm start
 
-# Enable MongoDB Mode
+# Production: MongoDB adapter
 export SUPERCLI_USE_MONGO=true
 export MONGO_URL=mongodb://127.0.0.1:27017
 export SUPERCLI_DB=supercli
 npm start
 ```
+
+## FileAdapter Details
+
+The FileAdapter stores each record as a separate JSON file:
+
+```
+supercli_storage/
+├── command:aws.cfn.deploy.json
+├── job:1717849200000_abc1234.json
+├── job:1717849201000_def5678.json
+├── plugin:github.json
+└── setting:max_zip_mb.json
+```
+
+**Character sanitization:** Keys containing characters outside `[a-zA-Z0-9_.-]` are replaced with `_` in filenames. This is transparent — `get`/`set` work with the original key.
+
+**Backup:** Since files are plain JSON, backing up FileAdapter data is as simple as copying the directory:
+
+```bash
+# Backup
+cp -r ./supercli_storage ./supercli_storage_backup_$(date +%Y%m%d)
+
+# Restore
+cp -r ./supercli_storage_backup_20260608 ./supercli_storage
+```
+
+The storage directory is also Git-friendly — you can commit it for version-controlled configurations.
+
+## MongoAdapter Details
+
+The MongoDB adapter stores all records in a single `storage` collection:
+
+```json
+{ "_id": "job:1717849200000_abc1234", "value": { "command": "aws.cfn.deploy", ... } }
+{ "_id": "setting:max_zip_mb", "value": 10 }
+```
+
+**Indexing:** The `_id` field is automatically indexed by MongoDB, providing efficient key lookups and prefix queries via regex.
+
+**Connection pooling:** The adapter connects lazily on first use and reuses the connection for subsequent operations.
+
+## Migration: File → MongoDB
+
+To migrate from FileAdapter to MongoDB:
+
+```bash
+# 1. Ensure MongoDB is running and accessible
+mongosh --eval "db.stats()"
+
+# 2. Set environment variables
+export SUPERCLI_USE_MONGO=true
+export MONGO_URL=mongodb://127.0.0.1:27017
+export SUPERCLI_DB=supercli
+
+# 3. Import existing data (one-time script)
+node -e "
+const fs = require('fs');
+const path = require('path');
+const { MongoClient } = require('mongodb');
+
+async function migrate() {
+  const client = new MongoClient(process.env.MONGO_URL);
+  await client.connect();
+  const db = client.db(process.env.SUPERCLI_DB);
+  const col = db.collection('storage');
+  
+  const dir = './supercli_storage';
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.json'));
+  
+  for (const file of files) {
+    const key = file.replace('.json', '');
+    const data = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf-8'));
+    await col.updateOne({ _id: key }, { \$set: { value: data } }, { upsert: true });
+    console.log('Migrated:', key);
+  }
+  
+  await client.close();
+  console.log('Migration complete:', files.length, 'records');
+}
+migrate().catch(console.error);
+"
+
+# 4. Restart the server — it will now use MongoDB
+npm start
+```
+
+**Verification:**
+
+```bash
+# Check record count in MongoDB
+mongosh supercli --eval "db.storage.countDocuments()"
+
+# Compare with file count
+ls ./supercli_storage/*.json | wc -l
+```
+
+## When to Use Each Adapter
+
+| Scenario | Recommended Adapter |
+|----------|-------------------|
+| Local development | FileAdapter (default) |
+| Single-user deployment | FileAdapter |
+| CI/CD testing | FileAdapter |
+| Multi-user team server | MongoAdapter |
+| High-availability production | MongoAdapter |
+| Air-gapped / offline | FileAdapter |

--- a/docs/features/workflows.md
+++ b/docs/features/workflows.md
@@ -1,16 +1,17 @@
 # Multi-Step Workflows
 
-supercli handles command chaining inherently via Workflow Commands without forcing agents or developers to write complicated shell orchestration.
+supercli handles command chaining via Workflow Commands without forcing agents or developers to write complicated shell orchestration. A workflow is a single command that orchestrates multiple steps, passing data between them automatically.
 
 ## Key Features
 
-- **Workflow Adapter Definition**: supercli represents compound multi-step processes as just another single command in its capability tree (`type: workflow`).
-- **Data Piping (Context Mapping)**: When a workflow command executes, the `stdout` JSON result of step 1 can automatically be injected into the arguments of step 2. This creates clean API mapping layers (e.g., extract an ID from one endpoint, pass it to another).
-- **Atomic Abstraction**: A complex graph of actions is compacted into one deterministic interface that agents discover seamlessly.
+- **Workflow Adapter Definition**: Compound multi-step processes appear as a single command in the capability tree (`type: workflow`). Agents discover and invoke them exactly like any other command.
+- **Data Piping (Context Mapping)**: The `stdout` JSON result of step N is automatically injected into the arguments of step N+1 via template expressions. This creates clean API mapping layers (e.g., extract an ID from one endpoint, pass it to another).
+- **Atomic Abstraction**: A complex graph of actions is compacted into one deterministic interface with a single JSON envelope output.
+- **Sequential Execution**: Steps run in order. If any step fails, the workflow halts and returns a structured error with the failing step index.
 
-## Usage
+## Workflow Definition
 
-A workflow is stored as a standard command in the registry, composed of references to other commands:
+A workflow is stored as a standard command in the registry:
 
 ```json
 {
@@ -27,7 +28,132 @@ A workflow is stored as a standard command in the registry, composed of referenc
 }
 ```
 
+### Template Expressions
+
+Template expressions reference data from previous steps or the original invocation arguments:
+
+| Expression | Resolves To |
+|-----------|-------------|
+| `{{args.id}}` | The `--id` flag passed to the workflow command |
+| `{{step.0.data.status}}` | The `status` field from step 0's JSON output |
+| `{{step.1.data.id}}` | The `id` field from step 1's JSON output |
+| `{{step.N.data.field}}` | Any field from step N's output (0-indexed) |
+
+**Important:** Template expressions only resolve against JSON output. If a step returns non-JSON (e.g., raw text), downstream templates that reference its data will resolve to `null`.
+
+## Usage
+
 ```bash
-# Executing the workflow command feels completely standard
+# Execute a workflow — same interface as any other command
 supercli aws instances restart_and_log --id i-0123456789
+
+# Output is a standard JSON envelope containing all step results
 ```
+
+The output envelope includes step-by-step results:
+
+```json
+{
+  "version": "1.0",
+  "command": "aws.instances.restart_and_log",
+  "duration_ms": 3420,
+  "data": {
+    "steps": [
+      { "step": 0, "command": "aws.instances.restart", "status": "ok", "data": { "status": "restarting" } },
+      { "step": 1, "command": "logging.events.publish", "status": "ok", "data": { "published": true } }
+    ],
+    "final": { "published": true }
+  }
+}
+```
+
+## Error Handling
+
+When a step fails, the workflow halts immediately and returns a structured error:
+
+```json
+{
+  "version": "1.0",
+  "command": "aws.instances.restart_and_log",
+  "duration_ms": 1205,
+  "error": {
+    "code": 105,
+    "type": "workflow_step_failed",
+    "message": "Step 1 failed: aws.instances.restart returned exit code 105",
+    "details": {
+      "failed_step": 1,
+      "failed_command": "aws.instances.restart",
+      "step_exit_code": 105,
+      "completed_steps": [0]
+    }
+  }
+}
+```
+
+**Agent retry logic:**
+- Exit code `0` from a step: proceed to next step
+- Exit code `80-89` (validation): do not retry, fix input
+- Exit code `100-109` (integration): retry the failed step with backoff
+- Exit code `110-119` (internal): report bug, do not retry
+
+## Common Patterns
+
+### Fan-Out / Aggregate
+
+Run multiple independent queries, then combine results:
+
+```json
+{
+  "namespace": "report",
+  "resource": "daily",
+  "action": "generate",
+  "type": "workflow",
+  "adapterConfig": {
+    "steps": [
+      { "command": "metrics.requests.list", "args": { "date": "{{args.date}}" } },
+      { "command": "metrics.errors.list", "args": { "date": "{{args.date}}" } },
+      { "command": "ai.text.summarize", "args": { "text": "Requests: {{step.0.data.count}}, Errors: {{step.1.data.count}}" } }
+    ]
+  }
+}
+```
+
+### Conditional Steps
+
+Use the `condition` field to skip steps based on previous output:
+
+```json
+{
+  "steps": [
+    { "command": "deploy.status.check", "args": { "env": "{{args.env}}" } },
+    { "command": "deploy.approve", "args": { "env": "{{args.env}}" }, "condition": "{{step.0.data.status}} == pending" },
+    { "command": "deploy.execute", "args": { "env": "{{args.env}}" } }
+  ]
+}
+```
+
+Conditions use a simple expression syntax: `{{step.N.field}} <operator> <value>`.
+
+### Retry-Aware Workflows
+
+For steps that may experience transient failures, the workflow engine retries steps that return recoverable error codes:
+
+```json
+{
+  "steps": [
+    { "command": "api.data.fetch", "args": { "url": "{{args.url}}" }, "retry": { "max_attempts": 3, "backoff_ms": 1000 } }
+  ]
+}
+```
+
+## Workflow vs `ask`
+
+| Aspect | Workflow | `supercli ask` |
+|--------|----------|----------------|
+| Definition | Declared in `plugin.json`, version-controlled | Generated at runtime from natural language |
+| Execution | Deterministic, same steps every time | May vary based on LLM interpretation |
+| Discoverability | Shows in `supercli skills search` | Not discoverable — it creates its own plan |
+| Use case | Known, repeatable multi-step processes | One-shot tasks, exploratory queries |
+| Error handling | Structured, predictable | Depends on LLM recovery strategy |
+
+**Rule of thumb:** If you'll run the same multi-step process more than once, define it as a workflow. For one-off tasks, use `ask`.


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Improve supercli static documentation: README, CONTRIBUTING, or docs/ files. Make ONE atomic commit with clear summary explaining what documentation was improved and WHY. Use fix:/docs: prefix. Keep it focused and reviewable.

**Branch:** `am/am-f17c27-tgalda`

## Summary

Expanded three sparse feature docs that were 22-33 lines each with no practical guidance. workflows.md now covers template syntax, error handling patterns, and retry configuration. observability.md documents the job record schema, stats API, and failure interpretation. storage.md explains the KV interface, key naming conventions, and provides a step-by-step File-to-MongoDB migration script. All three were self-evidently incomplete — operators had to read source code to understand these features.

**Diff:**
```
docs/features/observability.md |  95 +++++++++++++++++++++++---
 docs/features/storage.md       | 150 ++++++++++++++++++++++++++++++++++++++---
 docs/features/workflows.md     | 140 ++++++++++++++++++++++++++++++++++++--
 3 files changed, 361 insertions(+), 24 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded observability documentation with clearer Job Tracing API reference, dashboard visualization details, and failure pattern guidance.
  * Enhanced storage documentation with configuration tables, backend comparison, and step-by-step migration instructions.
  * Updated workflows documentation with template expressions reference, error handling examples, and common patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->