### PR TITLE
automaintainer: Improve supercli static documentation: README, CONTRIBUTING…

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,8 +360,10 @@ Both versions co-exist and share plugin storage at `~/.supercli/plugins/plugins.
 | `command not found: supercli` | Not installed | Run `npx supercli` (no install needed) or `npm install -g superacli` |
 | Plugin not found | Not in registry | Run `supercli plugins explore --name <query>` to find it |
 | Output is not JSON | Tool may not support JSON output | Use `supercli inspect <ns> <res> <act>` to check if the command supports JSON |
-| MCP server not connecting | Server not running | Ensure the MCP server process is active and accessible |
+| MCP server not connecting | Server not running or wrong URL | See MCP diagnosis steps below |
 | Zig binary not found | Wrong platform binary | Use `npx supercli` (Node.js) as fallback — both share plugin state |
+| `ask` not available | LLM env vars not set | Set `OPENAI_BASE_URL`, `OPENAI_MODEL`, `OPENAI_API_KEY` — see [ask docs](docs/features/ask.md) |
+| Arguments rejected | Wrong arg names or types | Run `supercli inspect <ns> <res> <act>` to see the expected argument schema |
 
 **Quick diagnosis flowchart:**
 
@@ -370,10 +372,38 @@ Problem?
   ├─ "command not found" → Run `npx supercli` (zero-install) or `npm install -g superacli`
   ├─ "plugin not found"  → `supercli plugins explore --name <query>` to search registry
   ├─ Output not JSON     → Verify tool supports JSON; use `supercli inspect` to check adapter config
-  ├─ MCP not connecting  → Check server process is running + `SUPERCLI_SERVER` env is set
+  ├─ MCP not connecting  → Follow MCP diagnosis steps below
+  ├─ "ask" not available → Set OPENAI_BASE_URL, OPENAI_MODEL, OPENAI_API_KEY env vars
   ├─ Zig binary missing  → Use `npx supercli` (Node.js fallback, shares plugin state)
   └─ Arguments rejected  → `supercli inspect <ns> <res> <act>` to see expected schema
 ```
+
+### MCP Server Diagnosis
+
+If an MCP adapter command fails to connect:
+
+```bash
+# 1. Check if the MCP server is registered
+supercli mcp list
+
+# 2. Verify the server URL is correct
+#    For HTTP/SSE: ensure the URL is reachable
+curl -s <server-url>  # Should return a response, not connection refused
+
+# 3. For stdio servers, check the binary exists
+which <command-from-adapterConfig>
+
+# 4. Inspect the command to see the adapter config
+supercli inspect <ns> <res> <act>
+
+# 5. Run with verbose output for debugging
+supercli <ns> <res> <act> --verbose
+```
+
+Common MCP issues:
+- **Connection refused**: Server process not running. Start it first.
+- **Timeout**: Server is slow. Increase `timeout_ms` in `adapterConfig`.
+- **Tool not found**: The `tool` name in `adapterConfig` doesn't match the server's tool list. Check with `supercli inspect`.
 
 For detailed debugging: `supercli` returns the full schema (JSON by default). Use `supercli inspect <ns> <res> <act>` to validate arguments before execution.
 

--- a/docs/features/ask.md
+++ b/docs/features/ask.md
@@ -1,32 +1,187 @@
-# Natural Language execution ("ask")
+# Natural Language Execution ("ask")
 
-supercli seamlessly translates natural language intents into execution steps in your infrastructure by mapping user queries directly to your established command capability graph.
+supercli translates natural language intents into execution steps by mapping user queries to the configured command capability graph. Instead of learning command syntax, you describe what you want and supercli builds and runs the workflow.
 
 ## Key Features
 
-- **Decentralized Execution (`SUPERCLI_SERVER` vs Local)**: supercli can generate natural language execution workflows on the backend server to share API keys across teams, or directly on the individual developer's machine locally using `OPENAI_BASE_URL`.
-- **Automatic Fallback Execution**: The translation produces a DAG workflow JSON. supercli takes this JSON and runs it sequentially via the standard workflow planner mechanism.
-- **Dynamic Context**: The LLM context is strictly limited to the definitions and JSON schemas of the actual configured commands.
+- **Natural Language → Execution Plan**: Describe your intent in plain English; supercli generates a DAG workflow from available capabilities.
+- **Decentralized Execution**: Run on the backend server (`SUPERCLI_SERVER`) to share API keys across teams, or locally on your machine using `OPENAI_BASE_URL`.
+- **Automatic Fallback Execution**: The translation produces a DAG workflow JSON that runs sequentially via the standard workflow planner.
+- **Dynamic Context**: The LLM context is strictly limited to the definitions and JSON schemas of the actual configured commands — no hallucinated tools.
 
 ## Setup
 
-Set environment variables on either the local machine (for purely local mode) or the backend server (`server/app.js`):
+### Local Mode
+
+Run the translation directly on your machine:
 
 ```bash
 export OPENAI_BASE_URL=https://api.openai.com/v1
 export OPENAI_MODEL=gpt-4
 export OPENAI_API_KEY=sk-...
+
+# Now ask is available
+supercli ask "list my recent commits"
 ```
+
+### Server Mode
+
+Run the translation on the supercli server to share API keys and models across a team:
+
+```bash
+# On the server (server/app.js), set:
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_MODEL=gpt-4
+OPENAI_API_KEY=sk-...
+
+# On the client, point to the server:
+export SUPERCLI_SERVER=http://localhost:3001
+supercli ask "list my recent commits"
+```
+
+### Configuration Reference
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `OPENAI_BASE_URL` | Yes | — | OpenAI-compatible API endpoint |
+| `OPENAI_MODEL` | No | `gpt-4` | Model to use for translation |
+| `OPENAI_API_KEY` | Yes | — | API key for the LLM provider |
+| `SUPERCLI_SERVER` | No | — | Server URL for server-side execution |
+
+Any OpenAI-compatible provider works (OpenAI, Azure OpenAI, local LLMs via llama.cpp, Ollama, etc.). Set `OPENAI_BASE_URL` to your provider's endpoint.
 
 ## Usage
 
-If the feature is enabled (either server-side or locally), it becomes visible in `supercli help`.
+### Basic Invocation
 
 ```bash
-# Query the system to build and execute a workflow
+# Describe what you want in natural language
 supercli ask "list the posts and summarize them"
 
-# Output will stream the execution steps
-# 1. jsonplaceholder posts list 
-# 2. ai text summarize --text="{{step.0.data.summary}}"
+# The system:
+# 1. Searches capabilities for relevant commands
+# 2. Generates a DAG workflow
+# 3. Executes each step sequentially
+# 4. Returns the combined result
 ```
+
+### Output Format
+
+`ask` returns a standard JSON envelope with the workflow execution results:
+
+```json
+{
+  "version": "1.0",
+  "command": "ask",
+  "duration_ms": 4520,
+  "data": {
+    "query": "list the posts and summarize them",
+    "steps": [
+      {
+        "step": 0,
+        "command": "jsonplaceholder.posts.list",
+        "status": "ok",
+        "data": { "posts": [...], "count": 10 }
+      },
+      {
+        "step": 1,
+        "command": "ai.text.summarize",
+        "status": "ok",
+        "data": { "summary": "The posts cover..." }
+      }
+    ],
+    "final": { "summary": "The posts cover..." }
+  }
+}
+```
+
+### What the LLM Sees
+
+The LLM context is strictly limited to your configured commands. It does not hallucinate tools — it only references capabilities that exist in your registry. This means:
+
+- If you only have `github` and `aws` plugins, the LLM can only compose those tools
+- Unknown requests fail gracefully with a structured error (exit code 82)
+- No API keys or secrets leak into the LLM context
+
+## Examples
+
+### Multi-Tool Composition
+
+```bash
+# Combine data from multiple sources
+supercli ask "show me open GitHub issues and recent deploy logs"
+
+# The system finds:
+# 1. gh issue list --state open
+# 2. aws cloudwatch logs ...
+# And chains them automatically
+```
+
+### Data Transformation
+
+```bash
+# Ask for analysis of existing data
+supercli ask "list my database tables and suggest indexes"
+
+# Steps:
+# 1. database.tables.list
+# 2. ai.text.analyze with table schemas as context
+```
+
+### Reporting
+
+```bash
+# Generate a report from multiple commands
+supercli ask "create a summary of this week's commits and failed builds"
+
+# Steps:
+# 1. git.log --since "1 week ago"
+# 2. ci.builds.list --status failed
+# 3. ai.text.summarize combining both outputs
+```
+
+## Error Handling
+
+| Scenario | Exit Code | Behavior |
+|----------|-----------|----------|
+| No matching capabilities found | 82 | Returns error: no relevant commands in registry |
+| LLM API failure | 105 | Returns error with provider details |
+| Step execution failure | 105 | Workflow halts, returns failed step details |
+| Invalid/malicious input | 82 | Input validation rejects the request |
+
+### Common Issues
+
+```bash
+# "ask" not showing in help
+# → LLM environment variables not set. Run:
+echo $OPENAI_BASE_URL  # Should be set
+echo $OPENAI_API_KEY   # Should be set
+
+# "No matching capabilities"
+# → Install relevant plugins first:
+supercli plugins explore --name <tool>
+supercli plugins install <plugin-name>
+
+# Timeout on complex queries
+# → The LLM translation may take time for complex intents.
+# → Retry or simplify the query.
+```
+
+## Workflow vs `ask`
+
+| Aspect | Workflow (defined in plugin.json) | `ask` (natural language) |
+|--------|-----------------------------------|--------------------------|
+| Definition | Declared in `plugin.json`, version-controlled | Generated at runtime from natural language |
+| Execution | Deterministic, same steps every time | May vary based on LLM interpretation |
+| Discoverability | Shows in `supercli skills search` | Not discoverable — it creates its own plan |
+| Use case | Known, repeatable multi-step processes | One-shot tasks, exploratory queries |
+| Error handling | Structured, predictable | Depends on LLM recovery strategy |
+
+**Rule of thumb:** If you'll run the same multi-step process more than once, define it as a [workflow](workflows.md). For one-off tasks, use `ask`.
+
+## Related Documentation
+
+- [Workflows](workflows.md) — declarative multi-step execution with data piping
+- [Execution Plans](execution-plans.md) — dry-run and plan-gated execution
+- [Skill Documents](skills.md) — teaching agents about available capabilities
+- [Adapters](adapters.md) — the adapter types that back each capability

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -1,29 +1,202 @@
 # Skill Documents (SKILL.md)
 
-supercli includes a SKILL.md teaching/catalog system for local LLMs and agents.
+supercli includes a SKILL.md teaching/catalog system for local LLMs and agents. Skill documents are instruction artifacts that teach AI agents how to use specific tools or the supercli system as a whole.
 
-Terminology:
+**Terminology:**
 - **Capability**: executable command endpoint (commands, MCP tool bindings, OpenAPI-backed operations, workflows).
-- **Skill document**: instruction artifact returned by `supercli skills ...` commands.
+- **Skill document**: instruction artifact returned by `supercli skills ...` commands. These are Markdown files compatible with Anthropic/OpenAI instruction formats.
 
 ## Key Features
 
 - **Bootstrapping Skill Docs (`teach`)**: Emits a meta-skill document (Markdown compatible with Anthropic/OpenAI instructions) describing SuperCLI and available namespaces/resources.
 - **Capability Doc Extraction (`get <cmd>`)**: Pulls one command capability and formats it as a self-contained agent instruction document.
 - **Embedded DAG Planning**: Optionally injects execution plan information (`--show-dag`) into the generated skill document to teach dry-run-first workflows.
+- **Skill Catalog**: Discover and query skill documents from multiple providers (local filesystem, remote repos, plugin bundles).
 
-## Usage
+## Quick Start
+
+### Teach an Agent About supercli
+
+The `teach` command generates a bootstrap document that teaches any LLM or agent how supercli works:
 
 ```bash
-# List all available capabilities briefly as an index
-supercli skills list --json
-
-# Extract the global knowledge required to teach an agent how supercli works
+# Generate the full bootstrap skill document (stdout, Markdown)
 supercli skills teach
 
-# Generate a hyper-specific instruction for an AI agent on how to call a command
-supercli skills get oapi.todos.list
-
-# Same as above, but instruct the AI on execution planning
-supercli skills get oapi.todos.list --show-dag
+# JSON output for programmatic consumption
+supercli skills teach --json
 ```
+
+The output covers:
+- Available namespaces and resources
+- Command routing pattern (`<namespace> <resource> <action>`)
+- Output envelope format and exit codes
+- How to discover, inspect, and execute commands
+
+### Generate a Command-Specific Skill Document
+
+The `get` command extracts a single capability and formats it as a self-contained instruction:
+
+```bash
+# Basic: get skill doc for a specific command
+supercli skills get beads.issue.create
+
+# With DAG planning info (teaches dry-run-first workflow)
+supercli skills get beads.issue.create --show-dag
+
+# JSON output
+supercli skills get beads.issue.create --json
+```
+
+### List Available Capabilities
+
+```bash
+# Brief index of all capabilities (JSON by default)
+supercli skills list --json
+
+# Search by keyword
+supercli skills search --query "deploy" --json
+
+# Get full details for a specific capability
+supercli skills get aws.cfn.deploy
+```
+
+## Workflow: Teaching an Agent a New Tool
+
+A typical workflow for onboarding an agent to a new tool:
+
+```bash
+# 1. Discover what's available
+supercli skills search "database" --json
+
+# 2. Inspect a specific command before using it
+supercli inspect postgres query
+
+# 3. Generate a skill document for the agent
+supercli skills get postgres.query --json
+
+# 4. Execute the command
+supercli postgres query --sql "SELECT count(*) FROM users"
+```
+
+For agents, the recommended pattern is:
+
+```
+1. Run `supercli` (no args) → full capability graph schema (JSON)
+2. Run `supercli skills search <query>` → narrow down tools
+3. Run `supercli skills get <ns.res.act>` → get usage instructions
+4. Run `supercli <ns> <res> <action>` → execute
+```
+
+## Skill Document Output Format
+
+When you run `supercli skills get <command>`, the output is a self-contained Markdown document with:
+
+- **Command signature**: exact invocation syntax
+- **Argument schema**: all arguments with types, required/optional, defaults
+- **Output format**: expected JSON envelope structure
+- **Examples**: copy-pasteable usage patterns
+- **Error codes**: exit codes and what they mean
+- **DAG plan** (with `--show-dag`): step-by-step execution plan for dry-run validation
+
+Example output structure:
+
+```markdown
+# supercli beads.issue.create
+
+## Signature
+supercli beads.issue create --title <string> [--priority <integer>] [--description <string>]
+
+## Arguments
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| title | string | yes | — | Issue title |
+| priority | integer | no | 0 | Priority level (0-4) |
+| description | string | no | — | Issue description |
+
+## Output
+Returns JSON envelope with created issue details.
+
+## Exit Codes
+- 0: Success
+- 82: Validation error (missing required args)
+- 105: Integration error (beads_rust not installed)
+
+## Example
+supercli beads issue create --title "Fix auth bug" --priority 2
+```
+
+## Skill Catalog System
+
+supercli can discover SKILL.md files from multiple providers and expose them with stable `provider:id` identifiers. See [skills-catalog.md](../skills-catalog.md) for the full catalog system documentation.
+
+### Provider Commands
+
+```bash
+# List configured providers
+supercli skills providers list --json
+
+# Add a local filesystem provider
+supercli skills providers add --name mykb --type local_fs --roots /path/to/skills
+
+# Sync catalog from all providers
+supercli skills sync --json
+
+# Query catalog skill documents
+supercli skills list --catalog --json
+supercli skills search --query "planning" --json
+supercli skills get opencode:plan-changes
+```
+
+### Built-in vs External Skill Documents
+
+| Source | How to Access | Examples |
+|--------|--------------|----------|
+| Built-in capabilities | `supercli skills get <ns.res.act>` | `beads.issue.create`, `aws.cfn.deploy` |
+| Built-in meta-skills | `supercli skills teach` | Bootstrap document for agent onboarding |
+| Catalog providers | `supercli skills get <provider:id>` | `opencode:plan-changes`, `nullclaw:root.agents` |
+| Plugin-bundled skills | Via plugin's `skills/quickstart/SKILL.md` | Plugin-specific agent guides |
+
+## Writing Your Own Skill Documents
+
+If you're creating a plugin with a `skills/quickstart/SKILL.md`, follow these conventions:
+
+1. **Start with the tool name** as the document title
+2. **Include the command signature** with all arguments
+3. **Show at least one complete example** with expected output
+4. **Document error codes** and recovery steps
+5. **Keep it concise** — agents are token-constrained
+
+### Template
+
+```markdown
+# <Tool Name> — <one-line purpose>
+
+## Commands
+### <namespace> <resource> <action>
+<description>
+
+**Usage:**
+supercli <ns> <res> <action> --arg value
+
+**Arguments:**
+- `--arg` (string, required): description
+
+**Output:**
+```json
+{ "status": "ok", "data": { ... } }
+```
+
+**Errors:**
+- Exit 82: validation error
+- Exit 105: integration error (tool not installed)
+```
+
+Set `has_learn: true` in your plugin's `meta.json` to register the skill document with the catalog system.
+
+## Related Documentation
+
+- [Skill Documents Catalog](../skills-catalog.md) — provider system and remote skill discovery
+- [Agent-Friendly Tooling](agent-friendly.md) — design principles for machine-consumable output
+- [Natural Language Execution](ask.md) — AI-driven capability composition
+- [Plugin Development Guide](../plugins-how-to.md) — creating plugins with bundled skill documents


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Improve supercli static documentation: README, CONTRIBUTING, or docs/ files. Make ONE atomic commit with clear summary explaining what documentation was improved and WHY. Use fix:/docs: prefix. Keep it focused and reviewable.

**Branch:** `am/am-f17c27-tgav3a`

## Summary

Expanded three sparse documentation files that were blocking contributor onboarding. skills.md went from 29 lines (just command flags) to a full guide with teach/get workflow, skill document format, catalog system, and authoring templates. ask.md went from 32 lines (no output examples) to a reference with DAG output format, error handling table, env config, and workflow comparison. README troubleshooting replaced the vague 'ensure MCP server is active' entry with actionable diagnosis commands (supercli mcp list, curl checks, inspect, verbose mode) and added missing entries for ask availability and argument rejection.

**Diff:**
```
README.md               |  34 ++++++++-
 docs/features/ask.md    | 177 ++++++++++++++++++++++++++++++++++++++++---
 docs/features/skills.md | 195 +++++++++++++++++++++++++++++++++++++++++++++---
 3 files changed, 382 insertions(+), 24 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded troubleshooting guidance in README with MCP connectivity diagnostics, ask availability setup, and step-by-step diagnosis flows
  * Comprehensive ask feature documentation with setup instructions, usage examples, JSON output format, and error handling guidance
  * Complete skills documentation guide with quick start, skill document format reference, and catalog system documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->