### PR TITLE
docs: add CHANGELOG.md summarizing recent plugin additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- **posting** — TUI HTTP client plugin (#199)
+- **cli-printing-press** — print-formatted file linter/formatter (#198)
+- **doxx** — markdown documentation generator (#198)
+- **fallow** — file watcher/auto-command runner (#198)
+- **gws** — git workspace manager (#198)
+- **open-claw-skills** — 4,957 bundled OpenClaw skills
+- **last** — login history display
+- **git-stash** — git stash management
+- **gh-pr** — GitHub Pull Request management via gh CLI
+- **vmstat** — virtual memory and system statistics
+- **visudo** — safe sudoers file editing
+- **networkctl** — systemd networking subsystem control
+- **loginctl** — systemd login manager control
+- **skim** + **mods** — fuzzy finding and AI-assisted CLI
+- **charm** + **watchman** — Charm ecosystem and file watcher (#176)
+- **proto** + **scarb** — polyglot toolchain manager + Cairo toolchain (#175)
+- **op** + **talisman** — 1Password CLI + secrets scanner (#174)
+- **at** + **crontab** — job scheduling plugins (#173)
+- **gunicorn** + **localstack** — WSGI server + local cloud emulator (#172)
+- **tqdm** + **uvicorn** — progress bars + ASGI server (#171)
+- **sha512sum** + **touch** — file hashing and timestamp tools (#170)
+- **readelf** + **scriptreplay** — ELF analysis and terminal recorder (#169)
+- **apropos** + **whatis** — man page search tools (#168)


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Create a CHANGELOG.md at the repo ROOT (if missing) summarizing recent plugin additions. Keep it short (Keep a Changelog style, <40 lines). Do not touch plugins/ or tests. Commit it. Do not over-explore; commit by ~your 8th tool call.

**Branch:** `am/am-f17c27-tgdcqs`

## Summary

Created CHANGELOG.md at repo root summarizing ~20 recent plugin additions (Keep a Changelog style, <40 lines). Covers plugins added in PRs #168-#199.

**Diff:**
```
CHANGELOG.md | 31 +++++++++++++++++++++++++++++++
 1 file changed, 31 insertions(+)
```
