### PR TITLE
test: add unit test for commandKey()

### DIFF
--- a/__tests__/plugins-manifest.test.js
+++ b/__tests__/plugins-manifest.test.js
@@ -1,0 +1,15 @@
+const { commandKey } = require("../cli/plugins-manifest");
+
+describe("commandKey", () => {
+  test("formats namespace, resource, action as ns.res.act", () => {
+    expect(commandKey({ namespace: "git", resource: "branch", action: "list" })).toBe("git.branch.list");
+  });
+
+  test("formats namespace, resource, action with dots in namespace", () => {
+    expect(commandKey({ namespace: "github.cli", resource: "issue", action: "create" })).toBe("github.cli.issue.create");
+  });
+
+  test("handles single-character values", () => {
+    expect(commandKey({ namespace: "a", resource: "b", action: "c" })).toBe("a.b.c");
+  });
+});


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 1) Create __tests__/plugins-manifest.test.js 2) Import { commandKey } from ../cli/plugins-manifest 3) Test it formats namespaces as 'ns.res.act' 4) Verify with npm ci && npm run test:unit 5) Commit with message 'test: add unit test for commandKey()'

**Branch:** `am/am-f17c27-tgdh77`

## Summary

Added unit test for commandKey() in plugins-manifest.js. The function joins namespace, resource, and action with dots (e.g., 'git.branch.list'). Three test cases cover: basic formatting, namespace with dots, and single-character values. All 626 tests pass.

**Diff:**
```
__tests__/plugins-manifest.test.js | 15 +++++++++++++++
 1 file changed, 15 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for command key formatting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->