### PR TITLE
test: add unit test for outputHumanTable()

### DIFF
--- a/__tests__/output.test.js
+++ b/__tests__/output.test.js
@@ -1,4 +1,4 @@
-const { compactKeys } = require("../cli/output");
+const { compactKeys, outputHumanTable } = require("../cli/output");
 
 describe("compactKeys", () => {
   test("returns primitives as-is", () => {
@@ -87,5 +87,91 @@ describe("compactKeys", () => {
 
   test("handles arrays of primitives", () => {
     expect(compactKeys([1, "two", true])).toEqual([1, "two", true]);
+  });
+});
+
+describe("outputHumanTable", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("prints a table with headers and rows", () => {
+    const spy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const rows = [
+      { name: "Alice", role: "Developer" },
+      { name: "Bob", role: "Designer" },
+    ];
+    const columns = [
+      { key: "name", label: "Name" },
+      { key: "role", label: "Role" },
+    ];
+
+    outputHumanTable(rows, columns);
+
+    expect(spy).toHaveBeenCalledTimes(4);
+    const calls = spy.mock.calls.map(([msg]) => msg);
+    // widths: name=5 (max of "Name"=4, "Alice"=5, "Bob"=3), role=9 (max of "Role"=4, "Developer"=9, "Designer"=8)
+    expect(calls[0]).toBe("  Name   Role     ");
+    expect(calls[1]).toBe("  ────────────────");
+    expect(calls[2]).toBe("  Alice  Developer");
+    expect(calls[3]).toBe("  Bob    Designer ");
+
+    spy.mockRestore();
+  });
+
+  test("returns true when rows are printed", () => {
+    const spy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const result = outputHumanTable([{ x: "1" }], [{ key: "x", label: "X" }]);
+    expect(result).toBe(true);
+
+    spy.mockRestore();
+  });
+
+  test("handles empty rows by printing a placeholder", () => {
+    const spy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const result = outputHumanTable([], [{ key: "n", label: "N" }]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("  (empty)");
+    expect(result).toBe(true);
+
+    spy.mockRestore();
+  });
+
+  test("handles null/undefined rows by printing a placeholder", () => {
+    const spy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    expect(outputHumanTable(null, [{ key: "n", label: "N" }])).toBe(true);
+    expect(outputHumanTable(undefined, [{ key: "n", label: "N" }])).toBe(true);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith("  (empty)");
+
+    spy.mockRestore();
+  });
+
+  test("pads columns to match the widest value", () => {
+    const spy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const rows = [
+      { short: "a", long: "very long value here" },
+    ];
+    const columns = [
+      { key: "short", label: "Short" },
+      { key: "long", label: "Long" },
+    ];
+
+    outputHumanTable(rows, columns);
+
+    const calls = spy.mock.calls.map(([msg]) => msg);
+    // widths: short=5 (max of "Short"=5, "a"=1), long=19 (max of "Long"=4, "very long value here"=19)
+    expect(calls[0]).toBe("  Short  Long                ");
+    expect(calls[1]).toBe("  ───────────────────────────");
+    expect(calls[2]).toBe("  a      very long value here");
+
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 1) Open __tests__/output.test.js 2) Import { outputHumanTable } from ../cli/output 3) Write a test that captures console.log output with jest.spyOn 4) Test that a table is printed with headers and rows 5) Test empty-rows edge case 6) Run npm ci && npm run test:unit 7) Commit with message 'test: add unit test for outputHumanTable()'

**Branch:** `am/am-f17c27-tgdk6p`

## Summary

Add unit tests for outputHumanTable() in cli/output.js — covers table rendering with headers/rows, column padding that accommodates the widest value, empty-rows edge case, null/undefined input, and return value verification. These tests use jest.spyOn to capture console.log output, closing a gap in test coverage for human-readable table formatting.

**Diff:**
```
__tests__/output.test.js | 88 +++++++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 87 insertions(+), 1 deletion(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for table output functionality, including validation of formatting, column padding, and edge case handling for empty or missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->