### PR TITLE
refactor: remove unused BUNDLED_PLUGINS and validateNodeHook import

### DIFF
--- a/cli/plugins-manifest.js
+++ b/cli/plugins-manifest.js
@@ -5,16 +5,13 @@ const path = require("path");
 const os = require("os");
 const { spawnSync } = require("child_process");
 const { getRegistryPlugin } = require("./plugins-registry");
-const { validateNodeHook } = require("./plugins-hooks");
-
-const BUNDLED_PLUGINS = {};
 
 function commandKey(cmd) {
   return `${cmd.namespace}.${cmd.resource}.${cmd.action}`;
 }
 
 function resolveManifestPath(ref) {
-  const base = BUNDLED_PLUGINS[ref] || path.resolve(ref);
+  const base = path.resolve(ref);
   if (!fs.existsSync(base)) return null;
   const st = fs.statSync(base);
   if (st.isDirectory()) return path.join(base, "plugin.json");
@@ -187,7 +184,6 @@ function loadPluginManifest(ref, options = {}) {
 }
 
 module.exports = {
-  validateNodeHook,
   commandKey,
   resolveManifestPath,
   parseManifestFile,


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 1) Open cli/plugins-manifest.js 2) Remove const BUNDLED_PLUGINS = {} (only used in resolveManifestPath which always falls through) 3) Remove unused require('./plugins-hooks') 4) Remove validateNodeHook from module.exports 5) Run npm ci && npm run test:unit to confirm no breakage 6) Commit with message 'refactor: remove unused BUNDLED_PLUGINS and validateNodeHook import'

**Branch:** `am/am-f17c27-tgfv07`

## Summary

refactor: remove unused BUNDLED_PLUGINS object (always empty) and re-export of validateNodeHook from cli/plugins-manifest.js — both were dead code with no functional impact

**Diff:**
```
cli/plugins-manifest.js | 6 +-----
 1 file changed, 1 insertion(+), 5 deletions(-)
```
