### PR TITLE
docs: add JSDoc comments to generate-catalog.js

### DIFF
--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-06-09T14:25:57.528Z",
+  "generated_at": "2026-06-10T23:50:01.270Z",
   "count": 5058,
   "plugins": [
     {

--- a/scripts/generate-catalog.js
+++ b/scripts/generate-catalog.js
@@ -1,6 +1,15 @@
 #!/usr/bin/env node
 "use strict"
 
+/**
+ * Generate plugins/catalog.json from git-tracked plugins.
+ *
+ * Scans all git-tracked directories under plugins/, reads each plugin's
+ * plugin.json and meta.json, computes a short SHA256 checksum of their
+ * combined content, and writes the result to plugins/catalog.json.
+ * The checksum is used by the CLI to detect plugin updates.
+ */
+
 const fs = require("fs")
 const path = require("path")
 const crypto = require("crypto")
@@ -8,6 +17,16 @@ const crypto = require("crypto")
 const PLUGINS_DIR = path.join(__dirname, "..", "plugins")
 const OUTPUT_FILE = path.join(PLUGINS_DIR, "catalog.json")
 
+/**
+ * Compute a short checksum for a plugin directory.
+ *
+ * Reads plugin.json and meta.json (if they exist), concatenates their
+ * content, and returns the first 16 hex characters of the SHA256 digest.
+ * Returns null if neither file exists.
+ *
+ * @param {string} pluginDir - Absolute path to the plugin directory
+ * @returns {string|null} Hex checksum (first 16 chars) or null if no manifest files
+ */
 function pluginChecksum(pluginDir) {
   const manifestPath = path.join(pluginDir, "plugin.json")
   const metaPath = path.join(pluginDir, "meta.json")
@@ -23,6 +42,15 @@ function pluginChecksum(pluginDir) {
   return crypto.createHash("sha256").update(parts.join("\n")).digest("hex").slice(0, 16)
 }
 
+/**
+ * Discover git-tracked plugin directory names.
+ *
+ * Runs `git ls-files -- plugins/` to find only directories under plugins/
+ * that are tracked by git. This skips gitignored or generated directories.
+ * Falls back to null (meaning "scan everything") if git is unavailable.
+ *
+ * @returns {Set<string>|null} Set of tracked plugin names, or null on git failure
+ */
 function trackedPluginNames() {
   // Use git ls-files to find only git-tracked plugin dirs (skips gitignored dirs)
   const { spawnSync } = require("child_process")
@@ -40,6 +68,15 @@ function trackedPluginNames() {
   return names
 }
 
+/**
+ * Discover all valid bundled plugins and compute their checksums.
+ *
+ * Reads the plugins/ directory, filters to git-tracked directories
+ * that contain a plugin.json, computes a checksum from each plugin's
+ * manifest files, and returns the list sorted by name.
+ *
+ * @returns {Array<{name: string, checksum: string}>} Sorted array of plugin entries
+ */
 function discoverPlugins() {
   let entries
   try {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 1) Open scripts/generate-catalog.js 2) Add JSDoc block to pluginChecksum() describing its purpose, param, and return 3) Add JSDoc to trackedPluginNames() 4) Add JSDoc to discoverPlugins() 5) Optionally add module-level doc 6) Verify with node scripts/generate-catalog.js 7) Commit with message 'docs: add JSDoc comments to generate-catalog.js'

**Branch:** `am/am-f17c27-tgfwuv`

## Summary

Add JSDoc documentation to the three main functions in scripts/generate-catalog.js (pluginChecksum, trackedPluginNames, discoverPlugins) plus a module-level doc describing the script's purpose. This improves code readability for developers maintaining the catalog generation pipeline.

**Diff:**
```
plugins/catalog.json        |  2 +-
 scripts/generate-catalog.js | 37 +++++++++++++++++++++++++++++++++++++
 2 files changed, 38 insertions(+), 1 deletion(-)
```
