### PR TITLE
docs: add JSDoc to loadJson and writeJson in apply-enhancements-and-install-guidance.js

### DIFF
--- a/scripts/apply-enhancements-and-install-guidance.js
+++ b/scripts/apply-enhancements-and-install-guidance.js
@@ -9,11 +9,22 @@ import { join } from "path";
 const PLUGINS_DIR = join(import.meta.dirname, "..", "plugins");
 const ENHANCEMENTS_PATH = join(import.meta.dirname, "..", "description-enhancements.json");
 
+/**
+ * Load and parse a JSON file.
+ * @param {string} p - Path to the JSON file.
+ * @returns {object|null} Parsed JSON object, or null if the file does not exist.
+ */
 function loadJson(p) {
   if (!existsSync(p)) return null;
   return JSON.parse(readFileSync(p, "utf-8"));
 }
 
+/**
+ * Serialize an object to JSON and write it to a file.
+ * @param {string} p - Path to the output file.
+ * @param {object} data - Data to serialize.
+ * @returns {void}
+ */
 function writeJson(p, data) {
   writeFileSync(p, JSON.stringify(data, null, 2) + "\n");
 }


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 1) Open scripts/apply-enhancements-and-install-guidance.js 2) Add JSDoc to loadJson() describing its file-read-and-parse behavior, @param, and @return 3) Add JSDoc to writeJson() describing its serialize-and-write behavior, @param, and @return 4) Verify with: node scripts/apply-enhancements-and-install-guidance.js 5) Commit with 'docs: add JSDoc to loadJson and writeJson in apply-enhancements-and-install-guidance.js'

**Branch:** `am/am-f17c27-tgg10v`

## Summary

Add JSDoc comments to loadJson and writeJson utility functions in apply-enhancements-and-install-guidance.js, clarifying their file-read-and-parse and serialize-and-write behaviors, with explicit @param and @return annotations. Verified script still runs successfully.

**Diff:**
```
scripts/apply-enhancements-and-install-guidance.js | 11 +++++++++++
 1 file changed, 11 insertions(+)
```
