### PR TITLE
docs: add JSDoc comments to enrich-meta-plugins.js

### DIFF
--- a/scripts/enrich-meta-plugins.js
+++ b/scripts/enrich-meta-plugins.js
@@ -1,3 +1,16 @@
+/**
+ * Reads plugin-scores.csv and enriches docs/meta-plugins.json with score metadata.
+ *
+ * The CSV file contains per-plugin scores and attributes (language, interactivity,
+ * auth requirements, etc.). This script merges that data into the meta-plugins JSON
+ * under a "score" property on each plugin object, then writes the enriched result
+ * back to disk.
+ *
+ * Usage: node scripts/enrich-meta-plugins.js
+ *
+ * @module enrich-meta-plugins
+ */
+
 "use strict";
 
 const fs = require('fs');
@@ -6,6 +19,16 @@ const path = require('path');
 const SCORES_CSV = path.join(__dirname, '..', 'plugin-scores.csv');
 const META_PLUGINS = path.join(__dirname, '..', 'docs', 'meta-plugins.json');
 
+/**
+ * Parse a CSV file and return an object mapping plugin names to their score rows.
+ *
+ * The first line is treated as a header row; subsequent lines are parsed into
+ * objects keyed by those headers. The result is keyed by the "name" column.
+ *
+ * @param {string} filePath - Absolute or relative path to the CSV file.
+ * @returns {Object<string, Object>} Object where keys are plugin names and values
+ *   are row objects with the CSV headers as property names.
+ */
 function parseCSV(filePath) {
   const content = fs.readFileSync(filePath, 'utf8');
   const lines = content.trim().split('\n');
@@ -25,6 +48,24 @@ function parseCSV(filePath) {
   return scores;
 }
 
+/**
+ * Read plugin-scores.csv, enrich docs/meta-plugins.json, and write back.
+ *
+ * Flow:
+ * 1. Parse the CSV file with {@link parseCSV} to get a map of scores by plugin name.
+ * 2. Read and parse the existing docs/meta-plugins.json.
+ * 3. Map over every plugin: if a matching score row exists, attach a structured
+ *    `score` object (value, no_interactive, go_rust_nodejs, language, cli, tui,
+ *    auth_required, complexity, binary, json_support, install).
+ * 4. Wrap the result in a top-level object with a `generated` timestamp and count.
+ * 5. Write the enriched JSON back to the same file.
+ *
+ * Side effects:
+ * - Reads plugin-scores.csv (throws if not found).
+ * - Reads docs/meta-plugins.json (throws if not found or malformed).
+ * - Overwrites docs/meta-plugins.json with the enriched data.
+ * - Logs progress messages to the console.
+ */
 function enrichMetaPlugins() {
   const scores = parseCSV(SCORES_CSV);
   const metaPlugins = JSON.parse(fs.readFileSync(META_PLUGINS, 'utf8'));


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 1) Open scripts/enrich-meta-plugins.js 2) Add a module-level JSDoc block describing the script's purpose (reads plugin-scores.csv, enriches docs/meta-plugins.json with score metadata) 3) Add JSDoc to parseCSV() describing param (filePath) and return (object mapping names to score rows) 4) Add JSDoc to enrichMetaPlugins() documenting the read-enrich-write flow and side effects 5) Verify with: node scripts/enrich-meta-plugins.js 6) Commit with message 'docs: add JSDoc comments to enrich-meta-plugins.js'

**Branch:** `am/am-f17c27-tgg2vj`

## Summary

Added comprehensive JSDoc documentation to scripts/enrich-meta-plugins.js: module-level description explaining the CSV-to-JSON enrichment pipeline, typed parameter/return docs for parseCSV(), and full read-enrich-write flow documentation for enrichMetaPlugins() including side effects.

**Diff:**
```
scripts/enrich-meta-plugins.js | 41 +++++++++++++++++++++++++++++++++++++++++
 1 file changed, 41 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for internal plugin metadata enrichment processes with comprehensive descriptions of utility functions and operational workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->