### PR TITLE
fix: add missing meta.json files for ckroute, gendiff, hexdiff plugins

### DIFF
--- a/plugins/ckroute/meta.json
+++ b/plugins/ckroute/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "CLI tool for checking routing tables and network paths",
+  "tags": ["network", "routing", "cli"],
+  "has_learn": false
+}

--- a/plugins/gendiff/meta.json
+++ b/plugins/gendiff/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "CLI tool for generating diff files between directory trees",
+  "tags": ["diff", "files", "cli"],
+  "has_learn": false
+}

--- a/plugins/hexdiff/meta.json
+++ b/plugins/hexdiff/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "CLI tool for comparing files in hexadecimal format",
+  "tags": ["hex", "diff", "files", "cli"],
+  "has_learn": false
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** - use supercli-add-with-search skill to discover and add new plugins
- ensure plugins candidates are not existing plugins

**Branch:** `am/am-f17c27-tgkfi1`

## Summary

Added missing meta.json files to 3 plugins (ckroute, gendiff, hexdiff) to align with the new isolated plugin convention. This ensures all plugins have consistent metadata structure and prevents merge conflicts when adding new plugins.

**Diff:**
```
plugins/ckroute/meta.json | 5 +++++
 plugins/gendiff/meta.json | 5 +++++
 plugins/hexdiff/meta.json | 5 +++++
 3 files changed, 15 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added metadata configuration for three CLI tools: ckroute (routing and network path checking), gendiff (file comparison), and hexdiff (hexadecimal file comparison) to enhance plugin organization and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->