### PR TITLE
feat: add install-guidance.json for ckroute, gendiff, hexdiff plugins

### DIFF
--- a/plugins/ckroute/install-guidance.json
+++ b/plugins/ckroute/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "ckroute",
+  "binary": "ckroute",
+  "check": "which ckroute",
+  "install_steps": [
+    "which ckroute",
+    "Verify: ckroute --version",
+    "supercli plugins install ./plugins/ckroute --on-conflict replace --json"
+  ]
+}

--- a/plugins/gendiff/install-guidance.json
+++ b/plugins/gendiff/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "gendiff",
+  "binary": "gendiff",
+  "check": "which gendiff",
+  "install_steps": [
+    "which gendiff",
+    "Verify: gendiff --version",
+    "supercli plugins install ./plugins/gendiff --on-conflict replace --json"
+  ]
+}

--- a/plugins/hexdiff/install-guidance.json
+++ b/plugins/hexdiff/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "hexdiff",
+  "binary": "hexdiff",
+  "check": "which hexdiff",
+  "install_steps": [
+    "which hexdiff",
+    "Verify: hexdiff --version",
+    "supercli plugins install ./plugins/hexdiff --on-conflict replace --json"
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** - use supercli-add-with-search skill to discover and add new plugins
- ensure plugins candidates are not existing plugins

**Branch:** `am/am-f17c27-tgkk4p`

**Diff:**
```
plugins/ckroute/install-guidance.json | 10 ++++++++++
 plugins/gendiff/install-guidance.json | 10 ++++++++++
 plugins/hexdiff/install-guidance.json | 10 ++++++++++
 3 files changed, 30 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Installation guidance added for ckroute, gendiff, and hexdiff plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->