### PR TITLE
fix: improve do-release-upgrade plugin description and tags

### DIFF
--- a/plugins/do-release-upgrade/meta.json
+++ b/plugins/do-release-upgrade/meta.json
@@ -1,7 +1,12 @@
 {
-  "description": "do-release-upgrade \u2014 CLI utility",
+  "description": "Upgrade Ubuntu/Debian system to the next LTS release",
   "tags": [
-    "cli"
+    "ubuntu",
+    "debian",
+    "system",
+    "upgrade",
+    "lts",
+    "linux"
   ],
   "has_learn": false
 }

--- a/plugins/do-release-upgrade/plugin.json
+++ b/plugins/do-release-upgrade/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "do-release-upgrade",
   "version": "1.0.0",
-  "description": "do-release-upgrade \u2014 do-release-upgrade \u2014 CLI utility",
+  "description": "Upgrade Ubuntu/Debian system to the next LTS release",
   "checks": [
     {
       "type": "binary",
@@ -21,7 +21,7 @@
       "namespace": "do-release-upgrade",
       "resource": "run",
       "action": "exec",
-      "description": "do-release-upgrade \u2014 CLI utility",
+      "description": "Upgrade system to next LTS release",
       "adapter": "process",
       "adapterConfig": {
         "command": "do-release-upgrade",


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** - use supercli-add-with-search skill to discover and add new plugins
- ensure plugins candidates are not existing plugins

**Branch:** `am/am-f17c27-tgmcy1`

**Diff:**
```
plugins/do-release-upgrade/meta.json   | 9 +++++++--
 plugins/do-release-upgrade/plugin.json | 4 ++--
 2 files changed, 9 insertions(+), 4 deletions(-)
```
