### PR TITLE
fix(jq): restore source URL and split malformed tags

### DIFF
--- a/plugins/amtool/meta.json
+++ b/plugins/amtool/meta.json
@@ -2,7 +2,9 @@
   "description": "amtool — Alertmanager admin tool",
   "tags": [
     "amtool",
-    "//prometheus.io:alerts,notification,monitoring"
+    "alerts",
+    "notification",
+    "monitoring"
   ],
   "has_learn": true
 }

--- a/plugins/amtool/plugin.json
+++ b/plugins/amtool/plugin.json
@@ -2,7 +2,7 @@
   "name": "amtool",
   "version": "0.1.0",
   "description": "amtool — Alertmanager admin tool",
-  "source": "https",
+  "source": "https://prometheus.io",
   "checks": [
     {
       "type": "binary",

--- a/plugins/htop/meta.json
+++ b/plugins/htop/meta.json
@@ -1,5 +1,5 @@
 {
   "description": "Interactive process viewer and system monitor",
-  "tags": ["htop", "//github.com/htop-dev/htop:system,process,monitor"],
+  "tags": ["htop", "system", "process", "monitor"],
   "has_learn": true
 }

--- a/plugins/htop/plugin.json
+++ b/plugins/htop/plugin.json
@@ -2,7 +2,7 @@
   "name": "htop",
   "version": "0.1.0",
   "description": "Interactive process viewer and system monitor",
-  "source": "https",
+  "source": "https://github.com/htop-dev/htop",
   "checks": [{"type": "binary", "name": "htop"}],
   "install_guidance": {
     "plugin": "htop",

--- a/plugins/jq/meta.json
+++ b/plugins/jq/meta.json
@@ -2,7 +2,9 @@
   "description": "jq — command-line JSON processor and query tool",
   "tags": [
     "jq",
-    "//jqlang.github.io/jq:json,processor,query"
+    "json",
+    "processor",
+    "query"
   ],
   "has_learn": true
 }

--- a/plugins/jq/plugin.json
+++ b/plugins/jq/plugin.json
@@ -2,7 +2,7 @@
   "name": "jq",
   "version": "0.1.0",
   "description": "jq — command-line JSON processor and query tool",
-  "source": "https",
+  "source": "https://jqlang.github.io/jq",
   "checks": [
     {
       "type": "binary",


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** test

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #268 (am/am-f17c27-tgxpuu): fix(cargo-nextest): correct source URL and expand tags
    touches: plugins/cargo-nextest/meta.json, plugins/cargo-nextest/plugin.json, plugins/cargo-test/plugin.json, plugins/gotestsum/meta.json, plugins/gotestsum/plugin.json


**Branch:** `am/am-f17c27-tgzo7c`

## Summary

Fix malformed source URLs and tags in three plugin manifests (jq, htop, amtool). Each had its `source` field truncated to the bare string "https" while the real project URL plus tag list were accidentally mashed into a single malformed tag entry (e.g. "//jqlang.github.io/jq:json,processor,query"). This restores the proper source URL in plugin.json and splits the tag string into discrete, searchable tags in meta.json, improving plugin discoverability and catalog correctness. Fixes are data-driven from the embedded values, so no URLs were guessed.

**Diff:**
```
plugins/amtool/meta.json   | 4 +++-
 plugins/amtool/plugin.json | 2 +-
 plugins/htop/meta.json     | 2 +-
 plugins/htop/plugin.json   | 2 +-
 plugins/jq/meta.json       | 4 +++-
 plugins/jq/plugin.json     | 2 +-
 6 files changed, 10 insertions(+), 6 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected and fully specified source URLs for amtool, htop, and jq plugins, linking to official repositories and documentation
  * Reorganized and standardized plugin tags for improved categorization and discoverability
  * Enhanced plugin metadata completeness and accuracy across multiple plugins

<!-- end of auto-generated comment: release notes by coderabbit.ai -->