### PR TITLE
fix(7zip): set canonical source URL

### DIFF
--- a/plugins/7zip/plugin.json
+++ b/plugins/7zip/plugin.json
@@ -2,7 +2,7 @@
   "name": "7zip",
   "version": "0.1.0",
   "description": "7zip — high-ratio file archiver supporting 7z, ZIP, and RAR formats",
-  "source": "https",
+  "source": "https://www.7-zip.org",
   "checks": [
     {
       "type": "binary",

--- a/plugins/ack/plugin.json
+++ b/plugins/ack/plugin.json
@@ -2,7 +2,7 @@
   "name": "ack",
   "version": "0.1.0",
   "description": "Ack — grep-like source code search tool",
-  "source": "https",
+  "source": "https://beyondgrep.com",
   "checks": [
     {
       "type": "binary",

--- a/plugins/ant/plugin.json
+++ b/plugins/ant/plugin.json
@@ -2,7 +2,7 @@
   "name": "ant",
   "version": "0.1.0",
   "description": "Apache Ant — Java library and command-line build tool",
-  "source": "https",
+  "source": "https://ant.apache.org",
   "checks": [
     {
       "type": "binary",


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** test

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #269 (am/am-f17c27-tgzo7c): fix(jq): restore source URL and split malformed tags
    touches: plugins/amtool/meta.json, plugins/amtool/plugin.json, plugins/htop/meta.json, plugins/htop/plugin.json, plugins/jq/meta.json, plugins/jq/plugin.json
- PR #268 (am/am-f17c27-tgxpuu): fix(cargo-nextest): correct source URL and expand tags
    touches: plugins/cargo-nextest/meta.json, plugins/cargo-nextest/plugin.json, plugins/cargo-test/plugin.json, plugins/gotestsum/meta.json, plugins/gotestsum/plugin.json


**Branch:** `am/am-f17c27-tgzr9t`

## Summary

Fix truncated source URLs in three plugin manifests (7zip, ack, ant) where the "source" field had been cut to the literal string "https" instead of a real URL. Each now points to the tool's canonical official homepage (7-zip.org, beyondgrep.com, ant.apache.org). This improves catalog metadata accuracy without touching any files in open PRs #268/#269. JSON validity verified for all three.

**Diff:**
```
plugins/7zip/plugin.json | 2 +-
 plugins/ack/plugin.json  | 2 +-
 plugins/ant/plugin.json  | 2 +-
 3 files changed, 3 insertions(+), 3 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed incomplete source URLs for 7zip, ack, and ant plugins to display accurate website references in plugin information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->