### PR TITLE
feat: add 5 new plugins

### DIFF
--- a/plugins/frawk/install-guidance.json
+++ b/plugins/frawk/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "frawk",
+  "binary": "frawk",
+  "check": "which frawk",
+  "install_steps": [
+    "cargo install frawk",
+    "Verify: frawk --version",
+    "supercli plugins install ./plugins/frawk --on-conflict replace --json"
+  ],
+  "note": "Build features vary; see https://github.com/ezrosent/frawk for LLVM-backed vs. cranelift install options."
+}

--- a/plugins/frawk/meta.json
+++ b/plugins/frawk/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "frawk — a fast, AWK-like programming language for processing text, CSV, and TSV data. Supports parallel execution and column-aware parsing for large datasets.",
+  "tags": ["frawk", "awk", "text", "csv", "tsv", "data", "processing", "rust"],
+  "has_learn": false
+}

--- a/plugins/frawk/plugin.json
+++ b/plugins/frawk/plugin.json
@@ -1,0 +1,63 @@
+{
+  "name": "frawk",
+  "version": "0.1.0",
+  "description": "frawk — fast AWK-like language for processing text and CSV/TSV data with parallel execution",
+  "source": "https://github.com/ezrosent/frawk",
+  "checks": [
+    { "type": "binary", "name": "frawk" }
+  ],
+  "install_guidance": {
+    "plugin": "frawk",
+    "binary": "frawk",
+    "check": "which frawk",
+    "install_steps": [
+      "cargo install frawk",
+      "Verify: frawk --version",
+      "supercli plugins install ./plugins/frawk --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "frawk",
+      "resource": "self",
+      "action": "version",
+      "description": "Print frawk version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "frawk",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install frawk: cargo install frawk"
+      },
+      "args": []
+    },
+    {
+      "namespace": "frawk",
+      "resource": "program",
+      "action": "run",
+      "description": "Run a frawk program against input files",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "frawk",
+        "passthrough": true,
+        "missingDependencyHelp": "Install frawk: cargo install frawk"
+      },
+      "args": [
+        { "name": "program", "type": "string", "required": true, "description": "frawk program text" },
+        { "name": "files", "type": "string", "required": false, "description": "Input files to process" }
+      ]
+    },
+    {
+      "namespace": "frawk",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to frawk CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "frawk",
+        "passthrough": true,
+        "missingDependencyHelp": "Install frawk: cargo install frawk"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/slumber/install-guidance.json
+++ b/plugins/slumber/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "slumber",
+  "binary": "slumber",
+  "check": "which slumber",
+  "install_steps": [
+    "cargo install slumber",
+    "Verify: slumber --version",
+    "supercli plugins install ./plugins/slumber --on-conflict replace --json"
+  ],
+  "note": "Also available via brew: brew install slumber. Pre-built binaries at https://github.com/LucasPickering/slumber/releases."
+}

--- a/plugins/slumber/meta.json
+++ b/plugins/slumber/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "slumber — terminal-based HTTP/REST API client with a TUI, file-based request collections, response history, and templating. A lightweight, git-friendly alternative to Postman.",
+  "tags": ["slumber", "http", "rest", "api", "client", "tui", "terminal", "rust"],
+  "has_learn": false
+}

--- a/plugins/slumber/plugin.json
+++ b/plugins/slumber/plugin.json
@@ -1,0 +1,63 @@
+{
+  "name": "slumber",
+  "version": "0.1.0",
+  "description": "slumber — terminal-based HTTP/REST API client with TUI, request collections, and templating",
+  "source": "https://github.com/LucasPickering/slumber",
+  "checks": [
+    { "type": "binary", "name": "slumber" }
+  ],
+  "install_guidance": {
+    "plugin": "slumber",
+    "binary": "slumber",
+    "check": "which slumber",
+    "install_steps": [
+      "cargo install slumber",
+      "Verify: slumber --version",
+      "supercli plugins install ./plugins/slumber --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "slumber",
+      "resource": "self",
+      "action": "version",
+      "description": "Print slumber version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "slumber",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install slumber: cargo install slumber"
+      },
+      "args": []
+    },
+    {
+      "namespace": "slumber",
+      "resource": "request",
+      "action": "run",
+      "description": "Send a request from a collection without the TUI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "slumber",
+        "baseArgs": ["request"],
+        "passthrough": true,
+        "missingDependencyHelp": "Install slumber: cargo install slumber"
+      },
+      "args": [
+        { "name": "id", "type": "string", "required": false, "description": "Recipe/request ID to send" }
+      ]
+    },
+    {
+      "namespace": "slumber",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to slumber CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "slumber",
+        "passthrough": true,
+        "missingDependencyHelp": "Install slumber: cargo install slumber"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/vgrep/install-guidance.json
+++ b/plugins/vgrep/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "vgrep",
+  "binary": "vgrep",
+  "check": "which vgrep",
+  "install_steps": [
+    "go install github.com/vrothberg/vgrep@latest",
+    "Verify: vgrep --version",
+    "supercli plugins install ./plugins/vgrep --on-conflict replace --json"
+  ],
+  "note": "Also packaged for some distros (e.g. dnf install vgrep). Requires grep/git-grep available on PATH."
+}

--- a/plugins/vgrep/meta.json
+++ b/plugins/vgrep/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "vgrep — a user-friendly pager for grep and git-grep results. Browse matches interactively and jump straight into your editor at the selected line.",
+  "tags": ["vgrep", "grep", "search", "pager", "git-grep", "cli", "terminal", "go"],
+  "has_learn": false
+}

--- a/plugins/vgrep/plugin.json
+++ b/plugins/vgrep/plugin.json
@@ -1,0 +1,64 @@
+{
+  "name": "vgrep",
+  "version": "0.1.0",
+  "description": "vgrep — user-friendly pager for grep/git-grep results with interactive navigation to matches",
+  "source": "https://github.com/vrothberg/vgrep",
+  "checks": [
+    { "type": "binary", "name": "vgrep" }
+  ],
+  "install_guidance": {
+    "plugin": "vgrep",
+    "binary": "vgrep",
+    "check": "which vgrep",
+    "install_steps": [
+      "go install github.com/vrothberg/vgrep@latest",
+      "Verify: vgrep --version",
+      "supercli plugins install ./plugins/vgrep --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "vgrep",
+      "resource": "self",
+      "action": "version",
+      "description": "Print vgrep version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "vgrep",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install vgrep: go install github.com/vrothberg/vgrep@latest"
+      },
+      "args": []
+    },
+    {
+      "namespace": "vgrep",
+      "resource": "search",
+      "action": "run",
+      "description": "Search for a pattern and browse results interactively",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "vgrep",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "missingDependencyHelp": "Install vgrep: go install github.com/vrothberg/vgrep@latest"
+      },
+      "args": [
+        { "name": "pattern", "type": "string", "required": false, "description": "Pattern to search for" }
+      ]
+    },
+    {
+      "namespace": "vgrep",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to vgrep CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "vgrep",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "missingDependencyHelp": "Install vgrep: go install github.com/vrothberg/vgrep@latest"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/xplr/install-guidance.json
+++ b/plugins/xplr/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "xplr",
+  "binary": "xplr",
+  "check": "which xplr",
+  "install_steps": [
+    "cargo install xplr",
+    "Verify: xplr --version",
+    "supercli plugins install ./plugins/xplr --on-conflict replace --json"
+  ],
+  "note": "Also available via brew (brew install xplr) and other package managers; see https://xplr.dev/en/install."
+}

--- a/plugins/xplr/meta.json
+++ b/plugins/xplr/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "xplr — a hackable, minimal, and fast TUI file explorer with Lua-based configuration. Designed to be embedded as a file picker in shell workflows and other tools.",
+  "tags": ["xplr", "file", "explorer", "manager", "tui", "terminal", "lua", "rust"],
+  "has_learn": false
+}

--- a/plugins/xplr/plugin.json
+++ b/plugins/xplr/plugin.json
@@ -1,0 +1,64 @@
+{
+  "name": "xplr",
+  "version": "0.1.0",
+  "description": "xplr — hackable, minimal, fast TUI file explorer with Lua-based configuration",
+  "source": "https://github.com/sayanarijit/xplr",
+  "checks": [
+    { "type": "binary", "name": "xplr" }
+  ],
+  "install_guidance": {
+    "plugin": "xplr",
+    "binary": "xplr",
+    "check": "which xplr",
+    "install_steps": [
+      "cargo install xplr",
+      "Verify: xplr --version",
+      "supercli plugins install ./plugins/xplr --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "xplr",
+      "resource": "self",
+      "action": "version",
+      "description": "Print xplr version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "xplr",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install xplr: cargo install xplr"
+      },
+      "args": []
+    },
+    {
+      "namespace": "xplr",
+      "resource": "explorer",
+      "action": "open",
+      "description": "Open the xplr file explorer at a path",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "xplr",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "missingDependencyHelp": "Install xplr: cargo install xplr"
+      },
+      "args": [
+        { "name": "path", "type": "string", "required": false, "description": "Directory to open" }
+      ]
+    },
+    {
+      "namespace": "xplr",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to xplr CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "xplr",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "missingDependencyHelp": "Install xplr: cargo install xplr"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/zenith/install-guidance.json
+++ b/plugins/zenith/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "zenith",
+  "binary": "zenith",
+  "check": "which zenith",
+  "install_steps": [
+    "cargo install zenith",
+    "Verify: zenith --version",
+    "supercli plugins install ./plugins/zenith --on-conflict replace --json"
+  ],
+  "note": "Also available via brew and pre-built packages; see https://github.com/bvaisvil/zenith/releases. NVIDIA GPU stats require the nvidia feature build."
+}

--- a/plugins/zenith/meta.json
+++ b/plugins/zenith/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "zenith — terminal system resource monitor with zoomable charts for CPU, memory, network, and disk usage, plus a process table. A feature-rich top/htop alternative written in Rust.",
+  "tags": ["zenith", "monitor", "system", "cpu", "memory", "process", "tui", "rust"],
+  "has_learn": false
+}

--- a/plugins/zenith/plugin.json
+++ b/plugins/zenith/plugin.json
@@ -1,0 +1,64 @@
+{
+  "name": "zenith",
+  "version": "0.1.0",
+  "description": "zenith — terminal system resource monitor with zoomable charts for CPU, memory, network, and disk",
+  "source": "https://github.com/bvaisvil/zenith",
+  "checks": [
+    { "type": "binary", "name": "zenith" }
+  ],
+  "install_guidance": {
+    "plugin": "zenith",
+    "binary": "zenith",
+    "check": "which zenith",
+    "install_steps": [
+      "cargo install zenith",
+      "Verify: zenith --version",
+      "supercli plugins install ./plugins/zenith --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "zenith",
+      "resource": "self",
+      "action": "version",
+      "description": "Print zenith version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "zenith",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install zenith: cargo install zenith"
+      },
+      "args": []
+    },
+    {
+      "namespace": "zenith",
+      "resource": "monitor",
+      "action": "run",
+      "description": "Launch the zenith system monitor TUI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "zenith",
+        "passthrough": true,
+        "missingDependencyHelp": "Install zenith: cargo install zenith"
+      },
+      "args": [
+        { "name": "--disk-height", "type": "string", "required": false, "description": "Height of the disk chart" },
+        { "name": "--cpu-height", "type": "string", "required": false, "description": "Height of the CPU chart" },
+        { "name": "--refresh-rate", "type": "string", "required": false, "description": "Refresh rate in milliseconds" }
+      ]
+    },
+    {
+      "namespace": "zenith",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to zenith CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "zenith",
+        "passthrough": true,
+        "missingDependencyHelp": "Install zenith: cargo install zenith"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: Add exactly 5 NEW plugins to the supercli plugin catalog.

Each plugin is a NEW directory under `plugins/<plugin-name>/` containing a `plugin.json` that follows the EXACT schema of existing plugins. Inspect any existing `plugins/*/plugin.json` first to match the format precisely (fields: name, version, description, source, checks, install_guidance, commands). Also add `meta.json` and `install-guidance.json` matching the existing convention used by neighboring plugins.

Pick 5 distinct, real, useful CLI tools that are NOT already present under `plugins/` — verify each target directory does NOT already exist before creating it (there are ~7364 existing plugins, so choose genuinely new ones). Do NOT modify or delete any existing plugin; keep the change strictly additive (only the 5 new plugin directories).

Deliver as a single PR titled "feat: add 5 new plugins". Keep the diff limited to the 5 new plugin directories.


----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #271 (am/am-f17c27-tgzsui): fix(aws): expand description and tags for discoverability
    touches: plugins/aws/meta.json, plugins/aws/plugin.json, plugins/delta/meta.json, plugins/delta/plugin.json, plugins/rg/meta.json, plugins/rg/plugin.json
- PR #270 (am/am-f17c27-tgzr9t): fix(7zip): set canonical source URL
    touches: plugins/7zip/plugin.json, plugins/ack/plugin.json, plugins/ant/plugin.json
- PR #269 (am/am-f17c27-tgzo7c): fix(jq): restore source URL and split malformed tags
    touches: plugins/amtool/meta.json, plugins/amtool/plugin.json, plugins/htop/meta.json, plugins/htop/plugin.json, plugins/jq/meta.json, plugins/jq/plugin.json
- PR #268 (am/am-f17c27-tgxpuu): fix(cargo-nextest): correct source URL and expand tags
    touches: plugins/cargo-nextest/meta.json, plugins/cargo-nextest/plugin.json, plugins/cargo-test/plugin.json, plugins/gotestsum/meta.json, plugins/gotestsum/plugin.json


**Branch:** `am/am-f17c27-tgzta5`

## Summary

feat: add 5 new plugins (slumber, frawk, zenith, xplr, vgrep) to the supercli catalog. Each new plugins/<name>/ directory contains plugin.json, meta.json, and install-guidance.json matching the existing convention. Strictly additive — no existing plugin is modified.

**Diff:**
```
plugins/frawk/install-guidance.json   | 11 ++++++
 plugins/frawk/meta.json               |  5 +++
 plugins/frawk/plugin.json             | 63 ++++++++++++++++++++++++++++++++++
 plugins/slumber/install-guidance.json | 11 ++++++
 plugins/slumber/meta.json             |  5 +++
 plugins/slumber/plugin.json           | 63 ++++++++++++++++++++++++++++++++++
 plugins/vgrep/install-guidance.json   | 11 ++++++
 plugins/vgrep/meta.json               |  5 +++
 plugins/vgrep/plugin.json             | 64 +++++++++++++++++++++++++++++++++++
 plugins/xplr/install-guidance.json    | 11 ++++++
 plugins/xplr/meta.json                |  5 +++
 plugins/xplr/plugin.json              | 64 +++++++++++++++++++++++++++++++++++
 plugins/zenith/install-guidance.json  | 11 ++++++
 plugins/zenith/meta.json              |  5 +++
 plugins/zenith/plugin.json            | 64 +++++++++++++++++++++++++++++++++++
 15 files changed, 398 insertions(+)
```
