### PR TITLE
feat: add recsel plugin — GNU recutils selector for recfiles

### DIFF
--- a/plugins/recsel/install-guidance.json
+++ b/plugins/recsel/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "recsel",
+  "binary": "recsel",
+  "check": "which recsel",
+  "install_steps": [
+    "Debian/Ubuntu: sudo apt-get update && sudo apt-get install -y recutils",
+    "macOS: brew install recutils",
+    "Arch Linux: sudo pacman -S recutils",
+    "Build from source: git clone https://git.savannah.gnu.org/git/recutils.git && cd recutils && ./configure && make && sudo make install",
+    "Verify: recsel --version"
+  ]
+}

--- a/plugins/recsel/meta.json
+++ b/plugins/recsel/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "recsel — GNU recutils selector: query, filter, and transform records from recfiles with structured output",
+  "tags": ["cli", "data", "database", "filter", "search", "text-processing", "c"],
+  "has_learn": false
+}

--- a/plugins/recsel/plugin.json
+++ b/plugins/recsel/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "recsel",
+  "version": "0.1.0",
+  "description": "recsel — GNU recutils selector: query, filter, and transform records from recfiles with structured output",
+  "source": "https://www.gnu.org/software/recutils/",
+  "checks": [{ "type": "binary", "name": "recsel" }],
+  "commands": [{
+    "namespace": "recsel",
+    "resource": "_",
+    "action": "_",
+    "description": "Passthrough to recsel CLI",
+    "adapter": "process",
+    "adapterConfig": {
+      "command": "recsel",
+      "passthrough": true,
+      "missingDependencyHelp": "Install recutils: sudo apt-get install recutils (Debian/Ubuntu) or brew install recutils (macOS)"
+    },
+    "args": []
+  }]
+}


### PR DESCRIPTION
Adds a new supercli plugin for `recsel` (GNU recutils), a tool to query, filter, and transform records from recfiles.

- `plugins/recsel/plugin.json` — manifest with passthrough to `recsel` binary
- `plugins/recsel/meta.json` — registry metadata with 7 tags (cli, data, database, filter, search, text-processing, c)
- `plugins/recsel/install-guidance.json` — installation instructions for Debian/Ubuntu, macOS, Arch Linux, and from source

✅ Validated JSON, description length (105 chars, within 30-150), and catalog generation succeeds.