### PR TITLE
feat: add spyql plugin — SQL-like queries over CSV/JSON/text data

### DIFF
--- a/plugins/spyql/install-guidance.json
+++ b/plugins/spyql/install-guidance.json
@@ -1,0 +1,9 @@
+{
+  "plugin": "spyql",
+  "binary": "spyql",
+  "check": "which spyql",
+  "install_steps": [
+    "pip install spyql",
+    "Verify: spyql --version"
+  ]
+}

--- a/plugins/spyql/meta.json
+++ b/plugins/spyql/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "spyql — query CSV, JSON, and text data using SQL-like syntax with JSON output support",
+  "tags": ["cli", "python", "data", "sql", "json", "text-processing", "filter"],
+  "has_learn": false
+}

--- a/plugins/spyql/plugin.json
+++ b/plugins/spyql/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "spyql",
+  "version": "0.1.0",
+  "description": "spyql — query CSV, JSON, and text data using SQL-like syntax with JSON output support",
+  "source": "https://github.com/dcmoura/spyql",
+  "checks": [{ "type": "binary", "name": "spyql" }],
+  "commands": [{
+    "namespace": "spyql",
+    "resource": "_",
+    "action": "_",
+    "description": "Passthrough to spyql CLI",
+    "adapter": "process",
+    "adapterConfig": {
+      "command": "spyql",
+      "passthrough": true,
+      "missingDependencyHelp": "Install spyql: pip install spyql"
+    },
+    "args": []
+  }]
+}


### PR DESCRIPTION
Adds the spyql plugin to supercli.

SpyQL is a Python CLI tool that enables SQL-like queries over CSV, JSON, and text data with JSON output support.

## Files added
- `plugins/spyql/plugin.json` — passthrough manifest
- `plugins/spyql/meta.json` — registry metadata with tags: cli, python, data, sql, json, text-processing, filter
- `plugins/spyql/install-guidance.json` — pip install guidance