### PR TITLE
feat: add rare plugin — regex extract-and-aggregate over logs/text with summary output

### DIFF
--- a/plugins/rare/install-guidance.json
+++ b/plugins/rare/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "rare",
+  "binary": "rare",
+  "check": "which rare",
+  "install_steps": [
+    "cargo install rare",
+    "Homebrew: brew install zix99/tap/rare",
+    "Verify: rare --version"
+  ]
+}

--- a/plugins/rare/meta.json
+++ b/plugins/rare/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "rare — regex extract-and-aggregate over logs/text with summary output, supports JSON output",
+  "tags": ["cli", "rust", "data", "text-processing", "search", "filter", "logging"],
+  "has_learn": false
+}

--- a/plugins/rare/plugin.json
+++ b/plugins/rare/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "rare",
+  "version": "0.1.0",
+  "description": "rare — regex extract-and-aggregate over logs/text with summary output, supports JSON output",
+  "source": "https://github.com/zix99/rare",
+  "checks": [{ "type": "binary", "name": "rare" }],
+  "commands": [{
+    "namespace": "rare",
+    "resource": "_",
+    "action": "_",
+    "description": "Passthrough to rare CLI — regex-based extraction and aggregation from logs or text files",
+    "adapter": "process",
+    "adapterConfig": {
+      "command": "rare",
+      "passthrough": true,
+      "missingDependencyHelp": "Install rare: cargo install rare"
+    },
+    "args": []
+  }]
+}


### PR DESCRIPTION
Adds a supercli plugin for **rare** — a fast regex-based extract-and-aggregate CLI tool for log files and text data with summary output and JSON support.

## Files created

- `plugins/rare/plugin.json` — passthrough manifest (binary: `rare`)
- `plugins/rare/meta.json` — registry metadata with tags: cli, rust, data, text-processing, search, filter, logging
- `plugins/rare/install-guidance.json` — install instructions (cargo, homebrew)

## Verification

- All JSON files are valid
- Description is 91 chars (within 30-150 range, starts with 'rare')
- Catalog generation succeeds (7,010 plugins)

Closes task #7.