### PR TITLE
feat: add frawk plugin — fast AWK-like CLI for CSV/TSV/text processing

### DIFF
--- a/plugins/frawk/install-guidance.json
+++ b/plugins/frawk/install-guidance.json
@@ -1,0 +1,9 @@
+{
+  "plugin": "frawk",
+  "binary": "frawk",
+  "check": "which frawk",
+  "install_steps": [
+    "cargo install frawk",
+    "Verify: frawk --version"
+  ]
+}

--- a/plugins/frawk/meta.json
+++ b/plugins/frawk/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "frawk — fast AWK-like CLI for processing CSV/TSV/text with structured JSON output",
+  "tags": ["cli", "rust", "data", "text-processing", "filter", "search"],
+  "has_learn": false
+}

--- a/plugins/frawk/plugin.json
+++ b/plugins/frawk/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "frawk",
+  "version": "0.1.0",
+  "description": "frawk — fast AWK-like CLI for processing CSV/TSV/text with structured JSON output",
+  "source": "https://github.com/ezrosent/frawk",
+  "checks": [{ "type": "binary", "name": "frawk" }],
+  "commands": [{
+    "namespace": "frawk",
+    "resource": "_",
+    "action": "_",
+    "description": "Passthrough to frawk CLI",
+    "adapter": "process",
+    "adapterConfig": {
+      "command": "frawk",
+      "passthrough": true,
+      "missingDependencyHelp": "Install frawk: cargo install frawk"
+    },
+    "args": []
+  }]
+}


### PR DESCRIPTION
Adds a supercli plugin for **frawk** — a fast AWK-like CLI tool for processing CSV, TSV, and structured text data with JSON output support.

## Files added
- `plugins/frawk/plugin.json` — passthrough manifest with `frawk` binary
- `plugins/frawk/meta.json` — registry metadata (tags: cli, rust, data, text-processing, filter, search)
- `plugins/frawk/install-guidance.json` — install instructions via `cargo install frawk`

## Verification
- [x] Valid JSON in all files
- [x] Description is 81 chars (within 30–150), starts with `frawk`
- [x] Catalog generation succeeds (7010 plugins)
- [x] No changes to `plugins/catalog.json` committed

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the frawk plugin, enabling integration with the frawk CLI tool. Includes automated dependency checking and installation guidance for seamless setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->