### PR TITLE
fix(k0s,k3s): set canonical source URLs

### DIFF
--- a/plugins/k0s/plugin.json
+++ b/plugins/k0s/plugin.json
@@ -2,7 +2,7 @@
   "name": "k0s",
   "version": "0.1.0",
   "description": "Zero-friction Kubernetes distribution",
-  "source": "//get.k0s.sh | sh",
+  "source": "https://github.com/k0sproject/k0s",
   "checks": [{"type": "binary", "name": "k0s"}],
   "install_guidance": {
     "plugin": "k0s",

--- a/plugins/k3s/plugin.json
+++ b/plugins/k3s/plugin.json
@@ -2,7 +2,7 @@
   "name": "k3s",
   "version": "0.1.0",
   "description": "Lightweight Kubernetes distribution",
-  "source": "//get.k3s.io | sh",
+  "source": "https://github.com/k3s-io/k3s",
   "checks": [{"type": "binary", "name": "k3s"}],
   "install_guidance": {
     "plugin": "k3s",

--- a/plugins/okteto-cli/plugin.json
+++ b/plugins/okteto-cli/plugin.json
@@ -2,7 +2,7 @@
   "name": "okteto-cli",
   "version": "0.1.0",
   "description": "Cloud-native development environments CLI for Kubernetes",
-  "source": " sh",
+  "source": "https://github.com/okteto/okteto",
   "checks": [{ "type": "binary", "name": "okteto-cli" }],
   "install_guidance": {
     "plugin": "okteto-cli",

--- a/plugins/oracle-cloud/plugin.json
+++ b/plugins/oracle-cloud/plugin.json
@@ -2,7 +2,7 @@
   "name": "oracle-cloud",
   "version": "1.0.0",
   "description": "oci — Oracle Cloud Infrastructure CLI. Manage OCI compute, networking, storage, and database services.",
-  "source": "",
+  "source": "https://github.com/oracle/oci-cli",
   "checks": [
     { "type": "binary", "name": "oci" }
   ],

--- a/plugins/up/plugin.json
+++ b/plugins/up/plugin.json
@@ -2,7 +2,7 @@
   "name": "up",
   "version": "0.1.0",
   "description": "Deploy serverless applications to AWS with minimal configuration",
-  "source": " sh",
+  "source": "https://github.com/apex/up",
   "checks": [{ "type": "binary", "name": "up" }],
   "install_guidance": {
     "plugin": "up",


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Add a plugin for the tool frawk (a fast AWK-like language for CSV/TSV text processing). Create plugins/frawk/plugin.json, plugins/frawk/meta.json and plugins/frawk/install-guidance.json following the existing plugin schema (inspect an existing plugins/*/plugin.json to match it). Single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #280 (am/am-f17c27-th029w): feat: add fzf-make plugin — fuzzy-find and run make/just/npm targets
    touches: plugins/fzf-make/install-guidance.json, plugins/fzf-make/meta.json, plugins/fzf-make/plugin.json
- PR #272 (am/am-f17c27-tgzta5): feat: add 5 new plugins
    touches: plugins/frawk/install-guidance.json, plugins/frawk/meta.json, plugins/frawk/plugin.json, plugins/slumber/install-guidance.json, plugins/slumber/meta.json, plugins/slumber/plugin.json, plugins/vgrep/install-guidance.json, plugins/vgrep/meta.json, plugins/vgrep/plugin.json, plugins/xplr/install-guidance.json, plugins/xplr/meta.json, plugins/xplr/plugin.json (+3 more)
- PR #271 (am/am-f17c27-tgzsui): fix(aws): expand description and tags for discoverability
    touches: plugins/aws/meta.json, plugins/aws/plugin.json, plugins/delta/meta.json, plugins/delta/plugin.json, plugins/rg/meta.json, plugins/rg/plugin.json
- PR #270 (am/am-f17c27-tgzr9t): fix(7zip): set canonical source URL
    touches: plugins/7zip/plugin.json, plugins/ack/plugin.json, plugins/ant/plugin.json
- PR #269 (am/am-f17c27-tgzo7c): fix(jq): restore source URL and split malformed tags
    touches: plugins/amtool/meta.json, plugins/amtool/plugin.json, plugins/htop/meta.json, plugins/htop/plugin.json, plugins/jq/meta.json, plugins/jq/plugin.json
- PR #268 (am/am-f17c27-tgxpuu): fix(cargo-nextest): correct source URL and expand tags
    touches: plugins/cargo-nextest/meta.json, plugins/cargo-nextest/plugin.json, plugins/cargo-test/plugin.json, plugins/gotestsum/meta.json, plugins/gotestsum/plugin.json


**Branch:** `am/am-f17c27-th02lm`

## Summary

The assigned frawk plugin already exists in-tree (merged in b12699d5) and its files are claimed by open PR #272, so re-creating it would conflict. Instead, this PR fixes five plugins whose `source` field held a mangled curl-install fragment (e.g. "//get.k0s.sh | sh", " sh", or empty) instead of a repository URL. k0s, k3s, okteto-cli, up, and oracle-cloud now point at their canonical GitHub repos, restoring correct provenance and discoverability. Changes are limited to the `source` field; all JSON validated.

**Diff:**
```
plugins/k0s/plugin.json          | 2 +-
 plugins/k3s/plugin.json          | 2 +-
 plugins/okteto-cli/plugin.json   | 2 +-
 plugins/oracle-cloud/plugin.json | 2 +-
 plugins/up/plugin.json           | 2 +-
 5 files changed, 5 insertions(+), 5 deletions(-)
```
