### PR TITLE
feat(plugins): add difft plugin — structural syntax-aware diff CLI

### DIFF
--- a/plugins/difft/install-guidance.json
+++ b/plugins/difft/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "difft",
+  "binary": "difft",
+  "check": "which difft",
+  "install_steps": ["cargo install difftastic"]
+}

--- a/plugins/difft/meta.json
+++ b/plugins/difft/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "difft — structural syntax-aware diff tool comparing code by AST",
+  "tags": ["difft", "rust", "cli", "text-processing", "development"],
+  "has_learn": true
+}

--- a/plugins/difft/plugin.json
+++ b/plugins/difft/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "difft",
+  "version": "0.1.0",
+  "description": "difft — structural syntax-aware diff tool comparing code by AST",
+  "source": "https://github.com/Wilfred/difftastic",
+  "checks": [
+    { "type": "binary", "name": "difft" }
+  ],
+  "install_guidance": {
+    "plugin": "difft",
+    "binary": "difft",
+    "check": "which difft",
+    "install_steps": ["cargo install difftastic"],
+    "note": "System utility."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "difft",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to difft CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "difft",
+        "passthrough": true,
+        "missingDependencyHelp": "Install difftastic: cargo install difftastic"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/difft/skills/quickstart/SKILL.md
+++ b/plugins/difft/skills/quickstart/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: difft
+description: difft — structural syntax-aware diff tool comparing code by AST
+---
+# difft Plugin
+
+Difftastic is a syntax-aware diff tool that compares code by AST rather than line-by-line, producing clearer diffs across 30+ languages.
+
+## Quickstart
+
+```bash
+# Compare two files
+difft old.js new.js
+
+# Side-by-side display
+difft --display side-by-side old.py new.py
+
+# Compare entire directories
+difft dir1/ dir2/
+
+# Inline display mode
+difft --display inline old.rs new.rs
+
+# Ignore comments when diffing
+difft --ignore-comments old.java new.java
+```


### PR DESCRIPTION
## Summary

Adds `plugins/difft/` — a new supercli plugin for the difft CLI (Difftastic), a structural syntax-aware diff tool that compares code by AST across 30+ languages.

## Changes

- **plugin.json**: Name `difft`, version `0.1.0`, description in required em-dash format, source URL pointing to the official GitHub repo (Wilfred/difftastic), binary check for `difft`, install guidance with cargo, learn section pointing to SKILL.md, and passthrough command.
- **meta.json**: Description, tags (`difft`, `rust`, `cli`, `text-processing`, `development`) — 5 tags from the controlled vocabulary, `has_learn: true`.
- **install-guidance.json**: Plugin, binary, check, and install steps (`cargo install difftastic`).
- **skills/quickstart/SKILL.md**: Frontmatter with name/description + quickstart examples showing file comparison, side-by-side display, directory diff, inline mode, and ignore-comments.

## Verification

- All JSON files validate with `python3 -m json.tool`
- Structure mirrors `plugins/rg/` exactly as specified
- No edits to `plugins/plugins.json` or any other files outside `plugins/difft/`

Closes #288  _(mago task #28)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Difft plugin now available with installation guidance and quickstart documentation
  * Supports syntax-aware file and directory comparison with multiple display modes (side-by-side and inline)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->