### PR TITLE
feat: add static-web-server plugin — fast async static file server

### DIFF
--- a/plugins/static-web-server/install-guidance.json
+++ b/plugins/static-web-server/install-guidance.json
@@ -1,0 +1,9 @@
+{
+  "plugin": "static-web-server",
+  "binary": "static-web-server",
+  "check": "which static-web-server",
+  "install_steps": [
+    "cargo install static-web-server",
+    "Binary download: https://github.com/static-web-server/static-web-server/releases"
+  ]
+}

--- a/plugins/static-web-server/meta.json
+++ b/plugins/static-web-server/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "static-web-server — fast asynchronous static file server (Rust)",
+  "tags": ["rust", "web", "http", "network", "filesystem", "cli"],
+  "has_learn": true
+}

--- a/plugins/static-web-server/plugin.json
+++ b/plugins/static-web-server/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "static-web-server",
+  "version": "0.1.0",
+  "description": "static-web-server — fast asynchronous static file server (Rust)",
+  "source": "https://github.com/static-web-server/static-web-server",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "static-web-server"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "static-web-server",
+    "binary": "static-web-server",
+    "check": "which static-web-server",
+    "install_steps": [
+      "cargo install static-web-server",
+      "Binary download: https://github.com/static-web-server/static-web-server/releases"
+    ],
+    "note": "High-performance async static file server written in Rust."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "static-web-server",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to static-web-server",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "static-web-server",
+        "passthrough": true,
+        "missingDependencyHelp": "Install static-web-server: cargo install static-web-server"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/static-web-server/skills/quickstart/SKILL.md
+++ b/plugins/static-web-server/skills/quickstart/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: static-web-server
+description: static-web-server — fast asynchronous static file server (Rust)
+---
+# static-web-server Plugin
+
+static-web-server is a high-performance, asynchronous web server for serving static files, written in Rust.
+
+## Usage
+
+Start a server serving files from the `./public` directory on port `8080`:
+
+```bash
+supercli static-web-server --port 8080 --root ./public
+```
+
+### Common Flags
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--host` | `-a` | Host address to bind | `::` (all interfaces) |
+| `--port` | `-p` | Port to listen on | `80` |
+| `--root` | `-d` | Root directory for static files | `./public` |
+| `--log-level` | `-g` | Log level (error, warn, info, debug, trace) | `error` |
+| `--grace-period` | `-q` | Grace period in seconds before shutdown | `0` |
+| `--compression` | `-x` | Enable compression (gzip/deflate/brotli/zstd) | `true` |
+| `--directory-listing` | `-z` | Enable directory listing | `false` |
+| `--cors-allow-origins` | `-j` | CORS allowed origins (comma-separated) | (none) |
+| `--basic-auth` | | Basic auth credentials (user:password, bcrypt) | (none) |
+| `--version` | `-V` | Print version and exit | |
+
+### Examples
+
+Serve files from current directory on port 3000:
+
+```bash
+supercli static-web-server --port 3000 --root .
+```
+
+Enable verbose logging and directory listing:
+
+```bash
+supercli static-web-server --port 8080 --root ./public --log-level info --directory-listing
+```
+
+## Install
+
+### From source (Cargo)
+
+```bash
+cargo install static-web-server
+```
+
+### Binary download
+
+Download the latest release for your platform from:
+https://github.com/static-web-server/static-web-server/releases


### PR DESCRIPTION
## Summary

Add a new supercli plugin for **static-web-server** — a high-performance, asynchronous static file server written in Rust ([github.com/static-web-server/static-web-server](https://github.com/static-web-server/static-web-server)).

## What changed

- **`plugins/static-web-server/plugin.json`** — manifest with binary check, install guidance, and a default passthrough command (`supercli static-web-server --port 8080 --root ./public`)
- **`plugins/static-web-server/meta.json`** — registry metadata with description, tags `[rust, web, http, network, filesystem, cli]`, and `has_learn: true`
- **`plugins/static-web-server/install-guidance.json`** — standalone install steps (cargo install + GitHub releases binary download)
- **`plugins/static-web-server/skills/quickstart/SKILL.md`** — agent quickstart guide with usage examples and common CLI flags

## Why

This plugin enables supercli users to discover, install, and run `static-web-server` seamlessly. The default passthrough command lets users serve static files with familiar flags (`--port`, `--root`, `--host`) confirmed from the tool's actual source code.

## How it was verified

- All JSON files validate as well-formed
- Tags checked against `TAG_VOCABULARY.md` — all 6 tags exist in the controlled vocabulary
- Description meets PLUGIN_STANDARDS.md (30-150 chars, format `[name] — [purpose]`)
- CLI flags (`--host`, `--port`, `--root`) verified against `static-web-server` source (`src/settings/cli.rs`)
- New plugin directory follows the isolated convention (no shared-file edits)

Closes #293  _(mago task #293)_
