### PR TITLE
feat: add 2 new plugins

### DIFF
--- a/plugins/atuin/install-guidance.json
+++ b/plugins/atuin/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "atuin",
+  "binary": "atuin",
+  "check": "which atuin",
+  "install_steps": [
+    "cargo install atuin",
+    "Verify: atuin --version",
+    "supercli plugins install ./plugins/atuin --on-conflict replace --json"
+  ],
+  "note": "Also available via: brew, pacman, nix, or the official install script. Replaces shell history with a searchable SQLite database, optional end-to-end encrypted sync, and usage stats."
+}

--- a/plugins/atuin/meta.json
+++ b/plugins/atuin/meta.json
@@ -1,0 +1,10 @@
+{
+  "description": "atuin — magical shell history with search, sync and stats",
+  "tags": [
+    "atuin",
+    "shell",
+    "history",
+    "search"
+  ],
+  "has_learn": true
+}

--- a/plugins/atuin/plugin.json
+++ b/plugins/atuin/plugin.json
@@ -1,0 +1,50 @@
+{
+  "name": "atuin",
+  "version": "0.1.0",
+  "description": "atuin — magical shell history with search, sync and stats",
+  "source": "https://github.com/atuinsh/atuin",
+  "checks": [
+    { "type": "binary", "name": "atuin" }
+  ],
+  "install_guidance": {
+    "plugin": "atuin",
+    "binary": "atuin",
+    "check": "which atuin",
+    "install_steps": [
+      "cargo install atuin",
+      "Verify: atuin --version",
+      "supercli plugins install ./plugins/atuin --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "atuin",
+      "resource": "self",
+      "action": "version",
+      "description": "Print atuin version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "atuin",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install atuin: cargo install atuin"
+      },
+      "args": []
+    },
+    {
+      "namespace": "atuin",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to atuin CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "atuin",
+        "passthrough": true,
+        "missingDependencyHelp": "Install atuin: cargo install atuin"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/atuin/skills/quickstart/SKILL.md
+++ b/plugins/atuin/skills/quickstart/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: atuin
+description: Use this skill when the user wants better shell history — full-text search, sync across machines, or usage stats — replacing the default history with a searchable database.
+---
+
+# atuin Plugin
+
+Magical shell history: stores your command history in a searchable SQLite database
+with optional end-to-end encrypted sync across machines.
+
+## Commands
+
+### Self
+- `atuin self version` — Print atuin version
+
+### Passthrough
+- `atuin _ _` — Run any atuin command (search, import, sync, stats, ...)
+
+## Usage Examples
+- "Search my shell history for the last docker command"
+- "Import my existing bash/zsh history into atuin"
+- "Show stats about my most-used commands"
+
+## Notes
+After install, run `atuin import auto` then add the shell init to your rc file.
+Install with `cargo install atuin` (also available via brew, pacman, nix, or the official script).

--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generated_at": "2026-06-22T13:01:19.400Z",
-  "count": 9999,
+  "generated_at": "2026-06-22T13:12:11.212Z",
+  "count": 10001,
   "plugins": [
     {
       "name": "100-exercises-to-learn-rust",
@@ -1810,6 +1810,10 @@
     {
       "name": "attempt-cli",
       "checksum": "82371924bd1a3fef"
+    },
+    {
+      "name": "atuin",
+      "checksum": "e99ae66cb5ea74fd"
     },
     {
       "name": "aud-convert",
@@ -14842,6 +14846,10 @@
     {
       "name": "gitu",
       "checksum": "ee5830eb14423435"
+    },
+    {
+      "name": "gitui",
+      "checksum": "6384500a36024273"
     },
     {
       "name": "gitup",

--- a/plugins/gitui/install-guidance.json
+++ b/plugins/gitui/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "gitui",
+  "binary": "gitui",
+  "check": "which gitui",
+  "install_steps": [
+    "cargo install gitui",
+    "Verify: gitui --version",
+    "supercli plugins install ./plugins/gitui --on-conflict replace --json"
+  ],
+  "note": "Also available via: brew, pacman, scoop, winget, nix. Fast keyboard-driven git TUI for staging, committing, branching and diffing."
+}

--- a/plugins/gitui/meta.json
+++ b/plugins/gitui/meta.json
@@ -1,0 +1,10 @@
+{
+  "description": "gitui — blazing-fast terminal UI for git",
+  "tags": [
+    "gitui",
+    "git",
+    "tui",
+    "version-control"
+  ],
+  "has_learn": true
+}

--- a/plugins/gitui/plugin.json
+++ b/plugins/gitui/plugin.json
@@ -1,0 +1,50 @@
+{
+  "name": "gitui",
+  "version": "0.1.0",
+  "description": "gitui — blazing-fast terminal UI for git",
+  "source": "https://github.com/extrawurst/gitui",
+  "checks": [
+    { "type": "binary", "name": "gitui" }
+  ],
+  "install_guidance": {
+    "plugin": "gitui",
+    "binary": "gitui",
+    "check": "which gitui",
+    "install_steps": [
+      "cargo install gitui",
+      "Verify: gitui --version",
+      "supercli plugins install ./plugins/gitui --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "gitui",
+      "resource": "self",
+      "action": "version",
+      "description": "Print gitui version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "gitui",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install gitui: cargo install gitui"
+      },
+      "args": []
+    },
+    {
+      "namespace": "gitui",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to gitui CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "gitui",
+        "passthrough": true,
+        "missingDependencyHelp": "Install gitui: cargo install gitui"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/gitui/skills/quickstart/SKILL.md
+++ b/plugins/gitui/skills/quickstart/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: gitui
+description: Use this skill when the user wants a fast terminal UI for git — to stage, commit, branch, stash, or review diffs without leaving the keyboard.
+---
+
+# gitui Plugin
+
+A blazing-fast terminal UI for git, written in Rust.
+
+## Commands
+
+### Self
+- `gitui self version` — Print gitui version
+
+### Passthrough
+- `gitui _ _` — Run any gitui command or launch the interactive TUI
+
+## Usage Examples
+- "Open a terminal UI for this git repo"
+- "Stage and commit changes interactively"
+- "Browse branches and diffs without the mouse"
+
+## Notes
+Launch `gitui` inside any git repository to open the interactive interface.
+Install with `cargo install gitui` (also available via brew, pacman, scoop, winget, nix).


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** Add exactly 2 NEW plugins to the supercli catalog. Each is a new directory under plugins/<name>/ with plugin.json, meta.json and install-guidance.json matching the existing schema (inspect an existing plugins/*/plugin.json first). Pick 2 distinct, real, useful CLI tools NOT already present and NOT already in flight in an open PR. Strictly additive; single PR titled "feat: add 2 new plugins".

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #281 (am/am-f17c27-th02lm): fix(k0s,k3s): set canonical source URLs
    touches: plugins/k0s/plugin.json, plugins/k3s/plugin.json, plugins/okteto-cli/plugin.json, plugins/oracle-cloud/plugin.json, plugins/up/plugin.json
- PR #280 (am/am-f17c27-th029w): feat: add fzf-make plugin — fuzzy-find and run make/just/npm targets
    touches: plugins/fzf-make/install-guidance.json, plugins/fzf-make/meta.json, plugins/fzf-make/plugin.json
- PR #272 (am/am-f17c27-tgzta5): feat: add 5 new plugins
    touches: plugins/frawk/install-guidance.json, plugins/frawk/meta.json, plugins/frawk/plugin.json, plugins/slumber/install-guidance.json, plugins/slumber/meta.json, plugins/slumber/plugin.json, plugins/vgrep/install-guidance.json, plugins/vgrep/meta.json, plugins/vgrep/plugin.json, plugins/xplr/install-guidance.json, plugins/xplr/meta.json, plugins/xplr/plugin.json (+3 more)
- PR #271 (am/am-f17c27-tgzsui): fix(aws): expand description and tags for discoverability
    touches: plugins/aws/meta.json, plugins/aws/plugin.json, plugins/delta/meta.json, plugins/delta/plugin.json, plugins/rg/meta.json, plugins/rg/plugin.json
- PR #270 (am/am-f17c27-tgzr9t): fix(7zip): set canonical source URL
    touches: plugins/7zip/plugin.json, plugins/ack/plugin.json, plugins/ant/plugin.json
- PR #269 (am/am-f17c27-tgzo7c): fix(jq): restore source URL and split malformed tags
    touches: plugins/amtool/meta.json, plugins/amtool/plugin.json, plugins/htop/meta.json, plugins/htop/plugin.json, plugins/jq/meta.json, plugins/jq/plugin.json
- PR #268 (am/am-f17c27-tgxpuu): fix(cargo-nextest): correct source URL and expand tags
    touches: plugins/cargo-nextest/meta.json, plugins/cargo-nextest/plugin.json, plugins/cargo-test/plugin.json, plugins/gotestsum/meta.json, plugins/gotestsum/plugin.json


**Branch:** `am/am-f17c27-th1b8g`

## Summary

Added two new plugins to the supercli catalog: gitui (a blazing-fast keyboard-driven terminal UI for git) and atuin (magical shell history with full-text search, optional encrypted sync, and usage stats). Each new plugin directory includes plugin.json, meta.json, install-guidance.json, and a quickstart SKILL.md matching the existing schema, and plugins/catalog.json was regenerated. Strictly additive — both are real, popular Rust CLI tools not already present and not in any open PR.

**Diff:**
```
plugins/atuin/install-guidance.json      | 11 +++++++
 plugins/atuin/meta.json                  | 10 +++++++
 plugins/atuin/plugin.json                | 50 ++++++++++++++++++++++++++++++++
 plugins/atuin/skills/quickstart/SKILL.md | 26 +++++++++++++++++
 plugins/catalog.json                     | 12 ++++++--
 plugins/gitui/install-guidance.json      | 11 +++++++
 plugins/gitui/meta.json                  | 10 +++++++
 plugins/gitui/plugin.json                | 50 ++++++++++++++++++++++++++++++++
 plugins/gitui/skills/quickstart/SKILL.md | 25 ++++++++++++++++
 9 files changed, 203 insertions(+), 2 deletions(-)
```
