### PR TITLE
feat: add outline-cli plugin with full API coverage

### DIFF
--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generated_at": "2026-06-22T14:57:47.854Z",
-  "count": 10005,
+  "generated_at": "2026-06-22T20:03:26.357Z",
+  "count": 10007,
   "plugins": [
     {
       "name": "100-exercises-to-learn-rust",
@@ -6406,6 +6406,10 @@
     {
       "name": "courier",
       "checksum": "3253a73ae99f789b"
+    },
+    {
+      "name": "coverage",
+      "checksum": "ec4447bbbf118fe7"
     },
     {
       "name": "coverage-3.10",
@@ -25930,6 +25934,10 @@
     {
       "name": "ouch",
       "checksum": "ddca0dcf75dd28fe"
+    },
+    {
+      "name": "outline-cli",
+      "checksum": "ff048850de583654"
     },
     {
       "name": "outocp",

--- a/plugins/outline-cli/install-guidance.json
+++ b/plugins/outline-cli/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "outline-cli",
+  "binary": "ol",
+  "check": "ol --version",
+  "install_steps": [
+    "npm install -g @doist/outline-cli",
+    "Verify: ol --version",
+    "Authenticate: ol auth login (opens browser for OAuth)",
+    "Alternative: ol auth token --base-url <url> <token>",
+    "supercli plugins install ./plugins/outline-cli --on-conflict replace --json"
+  ],
+  "note": "Requires Node.js 18+. OAuth authentication opens browser for first-time setup. API token authentication available for headless environments."
+}

--- a/plugins/outline-cli/meta.json
+++ b/plugins/outline-cli/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Official CLI for the Outline wiki/knowledge base API with full API coverage, OAuth authentication, and AI-friendly JSON output",
+  "tags": ["wiki", "knowledge-base", "documentation", "api", "cli", "productivity"],
+  "has_learn": true
+}

--- a/plugins/outline-cli/plugin.json
+++ b/plugins/outline-cli/plugin.json
@@ -1,0 +1,261 @@
+{
+  "name": "outline-cli",
+  "version": "0.1.0",
+  "description": "Outline CLI — official CLI for the Outline wiki/knowledge base API. Full API coverage for documents, collections, search, authentication with OAuth and OS keyring integration. Terminal-friendly markdown rendering, multi-user support, and AI-friendly JSON output.",
+  "source": "https://github.com/Doist/outline-cli",
+  "checks": [
+    { "type": "binary", "name": "ol" }
+  ],
+  "install_guidance": {
+    "plugin": "outline-cli",
+    "binary": "ol",
+    "check": "ol --version",
+    "install_steps": [
+      "npm install -g @doist/outline-cli",
+      "Verify: ol --version",
+      "Authenticate: ol auth login (opens browser for OAuth)",
+      "Alternative: ol auth token --base-url <url> <token>",
+      "supercli plugins install ./plugins/outline-cli --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "outline",
+      "resource": "self",
+      "action": "version",
+      "description": "Print outline-cli version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install outline-cli: npm install -g @doist/outline-cli"
+      },
+      "args": []
+    },
+    {
+      "namespace": "outline",
+      "resource": "auth",
+      "action": "status",
+      "description": "Check Outline authentication status",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["auth", "status"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install outline-cli and authenticate: ol auth login"
+      },
+      "args": []
+    },
+    {
+      "namespace": "outline",
+      "resource": "auth",
+      "action": "login",
+      "description": "Authenticate with Outline via OAuth (opens browser)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["auth", "login"],
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install outline-cli: npm install -g @doist/outline-cli"
+      },
+      "args": []
+    },
+    {
+      "namespace": "outline",
+      "resource": "auth",
+      "action": "token",
+      "description": "Save Outline API token for CLI auth",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["auth", "token"],
+        "passthrough": true,
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "Install outline-cli: npm install -g @doist/outline-cli"
+      },
+      "args": [
+        { "name": "--base-url", "type": "string", "required": true, "description": "Outline base URL" },
+        { "name": "token", "type": "string", "required": true, "description": "Outline API token (ol_api_...)" }
+      ]
+    },
+    {
+      "namespace": "outline",
+      "resource": "search",
+      "action": "run",
+      "description": "Search Outline documents by query string",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["search"],
+        "positionalArgs": ["query"],
+        "passthrough": true,
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install outline-cli and authenticate"
+      },
+      "args": [
+        { "name": "query", "type": "string", "required": true, "description": "Search query text" },
+        { "name": "--limit", "type": "number", "required": false, "description": "Limit results (default 10)" },
+        { "name": "--collection", "type": "string", "required": false, "description": "Filter by collection ID" }
+      ]
+    },
+    {
+      "namespace": "outline",
+      "resource": "document",
+      "action": "list",
+      "description": "List documents in a collection",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["document", "list"],
+        "passthrough": true,
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install outline-cli and authenticate"
+      },
+      "args": [
+        { "name": "--collection", "type": "string", "required": false, "description": "Collection ID to filter" },
+        { "name": "--limit", "type": "number", "required": false, "description": "Limit results" },
+        { "name": "--sort", "type": "string", "required": false, "description": "Sort field (e.g., updatedAt)" }
+      ]
+    },
+    {
+      "namespace": "outline",
+      "resource": "document",
+      "action": "get",
+      "description": "Get document details or content",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["document", "get"],
+        "positionalArgs": ["documentId"],
+        "passthrough": true,
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install outline-cli and authenticate"
+      },
+      "args": [
+        { "name": "documentId", "type": "string", "required": true, "description": "Document URL ID or full URL" },
+        { "name": "--raw", "type": "boolean", "required": false, "description": "Output raw markdown" }
+      ]
+    },
+    {
+      "namespace": "outline",
+      "resource": "document",
+      "action": "create",
+      "description": "Create a new document",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["document", "create"],
+        "passthrough": true,
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install outline-cli and authenticate"
+      },
+      "args": [
+        { "name": "--title", "type": "string", "required": true, "description": "Document title" },
+        { "name": "--collection", "type": "string", "required": true, "description": "Collection ID" },
+        { "name": "--file", "type": "string", "required": false, "description": "Markdown file to import" },
+        { "name": "--publish", "type": "boolean", "required": false, "description": "Publish immediately" }
+      ]
+    },
+    {
+      "namespace": "outline",
+      "resource": "document",
+      "action": "update",
+      "description": "Update an existing document",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["document", "update"],
+        "positionalArgs": ["documentId"],
+        "passthrough": true,
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install outline-cli and authenticate"
+      },
+      "args": [
+        { "name": "documentId", "type": "string", "required": true, "description": "Document URL ID" },
+        { "name": "--file", "type": "string", "required": false, "description": "Markdown file with updated content" }
+      ]
+    },
+    {
+      "namespace": "outline",
+      "resource": "document",
+      "action": "open",
+      "description": "Open document in browser",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["document", "open"],
+        "positionalArgs": ["documentId"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install outline-cli and authenticate"
+      },
+      "args": [
+        { "name": "documentId", "type": "string", "required": true, "description": "Document URL ID" }
+      ]
+    },
+    {
+      "namespace": "outline",
+      "resource": "collection",
+      "action": "list",
+      "description": "List all collections",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["collection", "list"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install outline-cli and authenticate"
+      },
+      "args": []
+    },
+    {
+      "namespace": "outline",
+      "resource": "collection",
+      "action": "get",
+      "description": "Get collection details",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["collection", "get"],
+        "positionalArgs": ["collectionId"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install outline-cli and authenticate"
+      },
+      "args": [
+        { "name": "collectionId", "type": "string", "required": true, "description": "Collection ID" }
+      ]
+    },
+    {
+      "namespace": "outline",
+      "resource": "collection",
+      "action": "create",
+      "description": "Create a new collection",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "baseArgs": ["collection", "create"],
+        "passthrough": true,
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install outline-cli and authenticate"
+      },
+      "args": [
+        { "name": "--name", "type": "string", "required": true, "description": "Collection name" },
+        { "name": "--color", "type": "string", "required": false, "description": "Collection color (hex)" }
+      ]
+    },
+    {
+      "namespace": "outline",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to outline CLI for any command",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ol",
+        "passthrough": true,
+        "missingDependencyHelp": "Install outline-cli: npm install -g @doist/outline-cli. Authenticate: ol auth login"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/outline-cli/skills/quickstart/SKILL.md
+++ b/plugins/outline-cli/skills/quickstart/SKILL.md
@@ -1,0 +1,163 @@
+# Outline CLI Skill
+
+Official CLI for the Outline wiki/knowledge base API. Full API coverage for documents, collections, search, and authentication with OAuth and OS keyring integration.
+
+## Installation
+
+```bash
+npm install -g @doist/outline-cli
+```
+
+## Authentication
+
+### OAuth (Recommended for Interactive Use)
+```bash
+ol auth login
+# Opens browser for OAuth flow
+# Token stored securely in OS keyring
+```
+
+### API Token (Headless/CI)
+```bash
+ol auth token --base-url <url> <token>
+# Example: ol auth token --base-url https://outline.example.com ol_api_xxxxx
+```
+
+**Important**: The `--base-url` must match exactly the URL the token was generated for. Authentication verification will fail if URLs don't match.
+
+### Check Authentication Status
+```bash
+ol auth status
+```
+
+## Common Workflows
+
+### List Collections
+```bash
+ol collection list
+ol collection list --json  # AI-friendly output
+```
+
+### Search Documents
+```bash
+ol search "query"
+ol search "query" --limit 20 --collection <id>
+```
+
+### List Documents in Collection
+```bash
+ol document list --collection <id>
+ol document list --collection <id> --sort updatedAt --limit 10
+```
+
+### Get Document Content
+```bash
+ol document get <documentId>          # Terminal rendering
+ol document get <documentId> --raw    # Raw markdown
+ol document get <documentId> --json  # JSON metadata
+```
+
+### Create Document
+```bash
+ol document create --title "Title" --collection <id> --file doc.md --publish
+```
+
+### Update Document
+```bash
+ol document update <documentId> --file updated.md
+```
+
+### Open in Browser
+```bash
+ol document open <documentId>
+```
+
+## AI Agent Integration
+
+### JSON Output
+Always use `--json` flag for machine-readable output:
+```bash
+ol collection list --json
+ol document get <id> --json
+ol search "query" --json
+```
+
+### Common Patterns for Agents
+```bash
+# Search and get content
+ol search "topic" --json | jq -r '.[].urlId' | xargs -I {} ol document get {} --raw
+
+# List documents in specific collection
+ol document list --collection <id> --json
+
+# Get document metadata only
+ol document get <id> --json
+```
+
+## Caveats and Gotchas
+
+### Base URL Matching
+- API tokens are tied to specific base URLs
+- Authentication verification fails if `--base-url` doesn't match exactly
+- Common issue: Including or excluding trailing slashes
+- Example: `https://outline.example.com` vs `https://outline.example.com/`
+
+### Authentication Verification
+- First authentication requires network access to Outline instance
+- Token verification happens on save
+- If verification fails, check:
+  - Token validity
+  - Base URL exact match
+  - Network connectivity to Outline instance
+
+### Document IDs vs URLs
+- Commands accept either document URL IDs (short) or full URLs
+- URL IDs look like: `LuW3bpbs3H`
+- Full URLs: `https://outline.example.com/doc/title-LuW3bpbs3H`
+- Use URL IDs for cleaner commands
+
+### Collection IDs
+- Collection IDs are UUIDs: `5bffa199-ab84-4bab-a2d3-8c926e6b17d4`
+- Get IDs from `ol collection list --json`
+
+### JSON Output Variations
+- `--json` provides structured data but fields vary by command
+- Use `jq` or similar tools for parsing
+- Some commands have `--full` flag for additional fields
+
+### OAuth Token Refresh
+- OAuth tokens refresh automatically when expired
+- API tokens don't auto-refresh and may need manual updates
+- `ol auth status` shows current authentication state
+
+## Key Commands Reference
+
+| Command | Description |
+|---------|-------------|
+| `ol auth login` | OAuth authentication (browser) |
+| `ol auth token --base-url <url> <token>` | API token authentication |
+| `ol auth status` | Check authentication state |
+| `ol collection list` | List all collections |
+| `ol collection get <id>` | Get collection details |
+| `ol search <query>` | Search documents |
+| `ol document list --collection <id>` | List documents in collection |
+| `ol document get <id>` | Get document content/metadata |
+| `ol document create --title <t> --collection <id>` | Create new document |
+| `ol document update <id> --file <file>` | Update document |
+| `ol document open <id>` | Open in browser |
+
+## Use Cases
+
+- **Documentation workflow automation**: Script document creation and updates
+- **Knowledge base management**: Bulk operations on collections and documents
+- **CI/CD integration**: Automated documentation updates from code
+- **AI agent integration**: Programmatic access to knowledge base for RAG systems
+- **Content migration**: Import/export documents between systems
+
+## Notes
+
+- Requires Node.js 18+
+- Tokens stored securely in OS keyring (OAuth) or secure-store (API tokens)
+- Multi-user support via `--user` flag for account switching
+- Terminal-friendly markdown rendering for human consumption
+- JSON output optimized for AI agent integration


### PR DESCRIPTION
## Summary
Add official Outline CLI plugin for wiki/knowledge base API management with full API coverage, OAuth authentication, and AI-friendly JSON output.

## Features
- **Full Outline API coverage**: Documents, collections, search, authentication
- **Dual authentication methods**: OAuth (browser) and API token (headless/CI)
- **AI-friendly**: JSON output optimized for agent integration
- **Terminal-friendly**: Markdown rendering for human consumption
- **Multi-user support**: Account switching via `--user` flag
- **OS keyring integration**: Secure token storage

## Plugin Structure
Follows isolated `meta.json` convention for conflict-free parallel plugin development:
- `plugin.json` - Manifest with commands and metadata
- `meta.json` - Registry metadata (description, tags, has_learn)
- `install-guidance.json` - Installation steps
- `skills/quickstart/SKILL.md` - Comprehensive agent guide with caveats

## Key Commands
- `ol auth login` - OAuth authentication
- `ol auth token --base-url <url> <token>` - API token auth
- `ol collection list` - List collections
- `ol search <query>` - Search documents
- `ol document get <id>` - Get document content
- `ol document create --title <t> --collection <id>` - Create document

## Skill Content
Comprehensive quickstart skill covering:
- Installation and authentication (OAuth + API token)
- Common workflows (collections, search, documents)
- AI agent integration patterns
- **Caveats and gotchas**: Base URL matching, auth verification, ID formats, JSON output variations

## Testing
Verified with live Outline instance:
- OAuth authentication flow
- API token authentication
- Collection listing and document operations
- Search functionality
- JSON output parsing

Generated with [Devin](https://devin.ai)