### PR TITLE
feat(plugins): add atuin, gitui, rustic, repgrep, pre-commit

### DIFF
--- a/plugins/atuin/install-guidance.json
+++ b/plugins/atuin/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "atuin",
+  "binary": "atuin",
+  "check": "which atuin",
+  "install_steps": ["cargo install atuin"]
+}

--- a/plugins/atuin/meta.json
+++ b/plugins/atuin/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "atuin — magical shell history with sync, search, and stats",
+  "tags": ["atuin", "rust", "cli", "shell", "history"],
+  "has_learn": true
+}

--- a/plugins/atuin/plugin.json
+++ b/plugins/atuin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "atuin",
+  "version": "0.1.0",
+  "description": "atuin — magical shell history with sync, search, and stats",
+  "source": "https://github.com/atuinsh/atuin",
+  "checks": [
+    { "type": "binary", "name": "atuin" }
+  ],
+  "install_guidance": {
+    "plugin": "atuin",
+    "binary": "atuin",
+    "check": "which atuin",
+    "install_steps": ["cargo install atuin"],
+    "note": "System utility."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "atuin",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to atuin CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "atuin",
+        "passthrough": true,
+        "missingDependencyHelp": "Install atuin: cargo install atuin"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/atuin/skills/quickstart/SKILL.md
+++ b/plugins/atuin/skills/quickstart/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: atuin
+description: atuin — magical shell history with sync, search, and stats
+---
+# atuin Plugin
+
+Atuin replaces your shell history with a searchable, encrypted SQLite database, adding context (exit code, duration, directory) and optional end-to-end encrypted sync across machines.
+
+## Quickstart
+
+```bash
+# Import existing shell history
+atuin import auto
+
+# Interactive fuzzy search of history (also bound to Ctrl-R)
+atuin search --interactive
+
+# Search non-interactively for a command
+atuin search "git push"
+
+# Show usage stats
+atuin stats
+
+# Register and sync history across machines
+atuin register -u <username> -e <email>
+atuin sync
+```

--- a/plugins/gitui/install-guidance.json
+++ b/plugins/gitui/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "gitui",
+  "binary": "gitui",
+  "check": "which gitui",
+  "install_steps": ["cargo install gitui"]
+}

--- a/plugins/gitui/meta.json
+++ b/plugins/gitui/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "gitui — blazing fast terminal UI for git",
+  "tags": ["gitui", "rust", "cli", "git", "tui"],
+  "has_learn": true
+}

--- a/plugins/gitui/plugin.json
+++ b/plugins/gitui/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "gitui",
+  "version": "0.1.0",
+  "description": "gitui — blazing fast terminal UI for git",
+  "source": "https://github.com/extrawurst/gitui",
+  "checks": [
+    { "type": "binary", "name": "gitui" }
+  ],
+  "install_guidance": {
+    "plugin": "gitui",
+    "binary": "gitui",
+    "check": "which gitui",
+    "install_steps": ["cargo install gitui"],
+    "note": "System utility."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "gitui",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to gitui CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "gitui",
+        "passthrough": true,
+        "missingDependencyHelp": "Install gitui: cargo install gitui"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/gitui/skills/quickstart/SKILL.md
+++ b/plugins/gitui/skills/quickstart/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: gitui
+description: gitui — blazing fast terminal UI for git
+---
+# gitui Plugin
+
+GitUI is a fast, keyboard-driven terminal interface for git, letting you stage hunks, commit, browse logs, manage branches, and resolve conflicts without leaving the terminal.
+
+## Quickstart
+
+```bash
+# Launch gitui in the current repository
+gitui
+
+# Open gitui for a specific repo path
+gitui -d /path/to/repo
+
+# Use a specific theme file
+gitui -t my-theme.ron
+
+# Show key bindings reference
+gitui --help
+```
+
+Inside the TUI: press `1`-`5` to switch tabs (Status, Log, Files, Stashing, Branches), `Space` to stage, `c` to commit, and `?` for the help overlay.

--- a/plugins/pre-commit/install-guidance.json
+++ b/plugins/pre-commit/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "pre-commit",
+  "binary": "pre-commit",
+  "check": "which pre-commit",
+  "install_steps": ["pipx install pre-commit"]
+}

--- a/plugins/pre-commit/meta.json
+++ b/plugins/pre-commit/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "pre-commit — framework for managing multi-language git pre-commit hooks",
+  "tags": ["pre-commit", "python", "cli", "git", "development"],
+  "has_learn": true
+}

--- a/plugins/pre-commit/plugin.json
+++ b/plugins/pre-commit/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "pre-commit",
+  "version": "0.1.0",
+  "description": "pre-commit — framework for managing multi-language git pre-commit hooks",
+  "source": "https://github.com/pre-commit/pre-commit",
+  "checks": [
+    { "type": "binary", "name": "pre-commit" }
+  ],
+  "install_guidance": {
+    "plugin": "pre-commit",
+    "binary": "pre-commit",
+    "check": "which pre-commit",
+    "install_steps": ["pipx install pre-commit"],
+    "note": "System utility. Requires Python."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "pre-commit",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to pre-commit CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pre-commit",
+        "passthrough": true,
+        "missingDependencyHelp": "Install pre-commit: pipx install pre-commit"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pre-commit/skills/quickstart/SKILL.md
+++ b/plugins/pre-commit/skills/quickstart/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: pre-commit
+description: pre-commit — framework for managing multi-language git pre-commit hooks
+---
+# pre-commit Plugin
+
+pre-commit is a framework for managing and running git hooks. You declare the linters, formatters, and checks you want in a `.pre-commit-config.yaml`, and pre-commit installs and runs them automatically on each commit across many languages.
+
+## Quickstart
+
+```bash
+# Install the git hook into the current repo
+pre-commit install
+
+# Run all configured hooks against all files
+pre-commit run --all-files
+
+# Run a single hook by id
+pre-commit run black --all-files
+
+# Update hook versions to the latest released revs
+pre-commit autoupdate
+
+# Generate a sample config to start from
+pre-commit sample-config > .pre-commit-config.yaml
+```

--- a/plugins/repgrep/install-guidance.json
+++ b/plugins/repgrep/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "repgrep",
+  "binary": "rgr",
+  "check": "which rgr",
+  "install_steps": ["cargo install repgrep"]
+}

--- a/plugins/repgrep/meta.json
+++ b/plugins/repgrep/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "repgrep — interactive terminal UI for ripgrep search and replace",
+  "tags": ["repgrep", "rust", "cli", "search", "text-processing"],
+  "has_learn": true
+}

--- a/plugins/repgrep/plugin.json
+++ b/plugins/repgrep/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "repgrep",
+  "version": "0.1.0",
+  "description": "repgrep — interactive terminal UI for ripgrep search and replace",
+  "source": "https://github.com/acheronfail/repgrep",
+  "checks": [
+    { "type": "binary", "name": "rgr" }
+  ],
+  "install_guidance": {
+    "plugin": "repgrep",
+    "binary": "rgr",
+    "check": "which rgr",
+    "install_steps": ["cargo install repgrep"],
+    "note": "System utility. Requires ripgrep (rg) to be installed."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "repgrep",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to repgrep (rgr) CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "rgr",
+        "passthrough": true,
+        "missingDependencyHelp": "Install repgrep: cargo install repgrep"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/repgrep/skills/quickstart/SKILL.md
+++ b/plugins/repgrep/skills/quickstart/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: repgrep
+description: repgrep — interactive terminal UI for ripgrep search and replace
+---
+# repgrep Plugin
+
+repgrep (`rgr`) is an interactive terminal companion to ripgrep. It runs a ripgrep search, lets you review matches in a TUI, deselect any you want to skip, and then applies a replacement across all selected matches.
+
+## Quickstart
+
+```bash
+# Search for a pattern, then interactively replace
+rgr 'foo'
+
+# Restrict the search to a file type
+rgr --type rust 'old_name'
+
+# Case-insensitive search
+rgr -i 'todo'
+
+# Search including hidden files
+rgr --hidden 'secret'
+```
+
+In the TUI: navigate matches, press `Space` to toggle a match, enter your replacement text, and confirm to write the changes to disk. Requires ripgrep (`rg`) on PATH.

--- a/plugins/rustic/install-guidance.json
+++ b/plugins/rustic/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "rustic",
+  "binary": "rustic",
+  "check": "which rustic",
+  "install_steps": ["cargo install rustic-rs"]
+}

--- a/plugins/rustic/meta.json
+++ b/plugins/rustic/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "rustic — fast encrypted deduplicated backup tool (restic-compatible)",
+  "tags": ["rustic", "rust", "cli", "backup", "encryption"],
+  "has_learn": true
+}

--- a/plugins/rustic/plugin.json
+++ b/plugins/rustic/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "rustic",
+  "version": "0.1.0",
+  "description": "rustic — fast encrypted deduplicated backup tool (restic-compatible)",
+  "source": "https://github.com/rustic-rs/rustic",
+  "checks": [
+    { "type": "binary", "name": "rustic" }
+  ],
+  "install_guidance": {
+    "plugin": "rustic",
+    "binary": "rustic",
+    "check": "which rustic",
+    "install_steps": ["cargo install rustic-rs"],
+    "note": "System utility."
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "rustic",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to rustic CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "rustic",
+        "passthrough": true,
+        "missingDependencyHelp": "Install rustic: cargo install rustic-rs"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/rustic/skills/quickstart/SKILL.md
+++ b/plugins/rustic/skills/quickstart/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: rustic
+description: rustic — fast encrypted deduplicated backup tool (restic-compatible)
+---
+# rustic Plugin
+
+Rustic is a fast, encrypted, deduplicated backup tool written in Rust. It is compatible with the restic repository format and can back up to local disks, SFTP, S3, and other cloud storage.
+
+## Quickstart
+
+```bash
+# Initialize a new backup repository
+rustic init -r /backups/my-repo
+
+# Back up a directory
+rustic backup ~/Documents -r /backups/my-repo
+
+# List snapshots
+rustic snapshots -r /backups/my-repo
+
+# Restore a snapshot to a target directory
+rustic restore latest:/ /tmp/restored -r /backups/my-repo
+
+# Remove old snapshots by retention policy
+rustic forget --keep-daily 7 --keep-weekly 4 -r /backups/my-repo
+```


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #281 (am/am-f17c27-th02lm): fix(k0s,k3s): set canonical source URLs
    touches: plugins/k0s/plugin.json, plugins/k3s/plugin.json, plugins/okteto-cli/plugin.json, plugins/oracle-cloud/plugin.json, plugins/up/plugin.json
- PR #280 (am/am-f17c27-th029w): feat: add fzf-make plugin — fuzzy-find and run make/just/npm targets
    touches: plugins/fzf-make/install-guidance.json, plugins/fzf-make/meta.json, plugins/fzf-make/plugin.json
- PR #272 (am/am-f17c27-tgzta5): feat: add 5 new plugins
    touches: plugins/frawk/install-guidance.json, plugins/frawk/meta.json, plugins/frawk/plugin.json, plugins/slumber/install-guidance.json, plugins/slumber/meta.json, plugins/slumber/plugin.json, plugins/vgrep/install-guidance.json, plugins/vgrep/meta.json, plugins/vgrep/plugin.json, plugins/xplr/install-guidance.json, plugins/xplr/meta.json, plugins/xplr/plugin.json (+3 more)
- PR #271 (am/am-f17c27-tgzsui): fix(aws): expand description and tags for discoverability
    touches: plugins/aws/meta.json, plugins/aws/plugin.json, plugins/delta/meta.json, plugins/delta/plugin.json, plugins/rg/meta.json, plugins/rg/plugin.json
- PR #270 (am/am-f17c27-tgzr9t): fix(7zip): set canonical source URL
    touches: plugins/7zip/plugin.json, plugins/ack/plugin.json, plugins/ant/plugin.json
- PR #269 (am/am-f17c27-tgzo7c): fix(jq): restore source URL and split malformed tags
    touches: plugins/amtool/meta.json, plugins/amtool/plugin.json, plugins/htop/meta.json, plugins/htop/plugin.json, plugins/jq/meta.json, plugins/jq/plugin.json
- PR #268 (am/am-f17c27-tgxpuu): fix(cargo-nextest): correct source URL and expand tags
    touches: plugins/cargo-nextest/meta.json, plugins/cargo-nextest/plugin.json, plugins/cargo-test/plugin.json, plugins/gotestsum/meta.json, plugins/gotestsum/plugin.json


**Branch:** `am/am-f17c27-th2yw9`

## Summary

Added 5 new CLI tool plugins (atuin, gitui, rustic, repgrep, pre-commit) to grow the catalog. Each ships plugin.json, meta.json, install-guidance.json, and a quickstart SKILL.md matching the existing plugin schema. The change is strictly additive — no existing plugins were modified — and covers shell-history, git TUI, encrypted backup, search-and-replace, and git-hook tooling.

**Diff:**
```
plugins/atuin/install-guidance.json           |  6 +++++
 plugins/atuin/meta.json                       |  5 ++++
 plugins/atuin/plugin.json                     | 34 +++++++++++++++++++++++++++
 plugins/atuin/skills/quickstart/SKILL.md      | 27 +++++++++++++++++++++
 plugins/gitui/install-guidance.json           |  6 +++++
 plugins/gitui/meta.json                       |  5 ++++
 plugins/gitui/plugin.json                     | 34 +++++++++++++++++++++++++++
 plugins/gitui/skills/quickstart/SKILL.md      | 25 ++++++++++++++++++++
 plugins/pre-commit/install-guidance.json      |  6 +++++
 plugins/pre-commit/meta.json                  |  5 ++++
 plugins/pre-commit/plugin.json                | 34 +++++++++++++++++++++++++++
 plugins/pre-commit/skills/quickstart/SKILL.md | 26 ++++++++++++++++++++
 plugins/repgrep/install-guidance.json         |  6 +++++
 plugins/repgrep/meta.json                     |  5 ++++
 plugins/repgrep/plugin.json                   | 34 +++++++++++++++++++++++++++
 plugins/repgrep/skills/quickstart/SKILL.md    | 25 ++++++++++++++++++++
 plugins/rustic/install-guidance.json          |  6 +++++
 plugins/rustic/meta.json                      |  5 ++++
 plugins/rustic/plugin.json                    | 34 +++++++++++++++++++++++++++
 plugins/rustic/skills/quickstart/SKILL.md     | 26 ++++++++++++++++++++
 20 files changed, 354 insertions(+)
```
