### PR TITLE
docs: add one-line tagline under top README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 <h1 align="center">supercli ⎯ 10,000+ CLI Tools, One Command — and growing daily</h1>
 
+<p align="center"><i>The universal launcher for every CLI tool — no installs, JSON-first, one command.</i></p>
+
 <p align="center">
   <b>Zero install.</b> Run any CLI tool with <code>npx supercli</code>.<br>
   <b>JSON-first by default.</b> Use <code>--human</code> for readable output.


### PR DESCRIPTION
## What changed

Added a one-line tagline immediately under the top-level `<h1>` heading in `README.md`:

> _The universal launcher for every CLI tool — no installs, JSON-first, one command._

## Why

The top heading jumped straight into the badges/details block. A concise, centered tagline gives first-time visitors an instant, scannable summary of what supercli is before they read further.

## How verified

- Visually reviewed the rendered Markdown placement (centered, italic, directly beneath the `<h1>`).
- Confirmed no other README content was altered and the change is a single additive line.

mago task #328


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a centered italicized tagline to the README highlighting key product features and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->