### PR TITLE
feat: add 5 media/audio plugins — mediainfo, avifenc, metaflac, pamixer, oggenc

### DIFF
--- a/plugins/avifenc/install-guidance.json
+++ b/plugins/avifenc/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "avifenc",
+  "binary": "avifenc",
+  "check": "which avifenc",
+  "install_steps": ["apt install libavif-bin", "brew install libavif"]
+}

--- a/plugins/avifenc/meta.json
+++ b/plugins/avifenc/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "avifenc — AVIF image encoder from libavif for next-generation image compression",
+  "tags": ["image", "media", "conversion", "compression", "graphics"],
+  "has_learn": false
+}

--- a/plugins/avifenc/plugin.json
+++ b/plugins/avifenc/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "avifenc",
+  "version": "0.1.0",
+  "description": "avifenc — AVIF image encoder from libavif for next-generation image compression",
+  "source": "https://github.com/AOMediaCodec/libavif",
+  "checks": [
+    { "type": "binary", "name": "avifenc" }
+  ],
+  "install_guidance": {
+    "plugin": "avifenc",
+    "binary": "avifenc",
+    "check": "which avifenc",
+    "install_steps": ["apt install libavif-bin", "brew install libavif"],
+    "note": "Image utility."
+  },
+  "commands": [
+    {
+      "namespace": "avifenc",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to avifenc CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "avifenc",
+        "passthrough": true,
+        "missingDependencyHelp": "Install avifenc: apt install libavif-bin"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mediainfo/install-guidance.json
+++ b/plugins/mediainfo/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "mediainfo",
+  "binary": "mediainfo",
+  "check": "which mediainfo",
+  "install_steps": ["apt install mediainfo", "brew install mediainfo"]
+}

--- a/plugins/mediainfo/meta.json
+++ b/plugins/mediainfo/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "MediaInfo — technical metadata viewer for audio and video files",
+  "tags": ["media", "video", "audio", "metadata", "utilities"],
+  "has_learn": false
+}

--- a/plugins/mediainfo/plugin.json
+++ b/plugins/mediainfo/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "mediainfo",
+  "version": "0.1.0",
+  "description": "MediaInfo — technical metadata viewer for audio and video files",
+  "source": "https://github.com/MediaArea/MediaInfo",
+  "checks": [
+    { "type": "binary", "name": "mediainfo" }
+  ],
+  "install_guidance": {
+    "plugin": "mediainfo",
+    "binary": "mediainfo",
+    "check": "which mediainfo",
+    "install_steps": ["apt install mediainfo", "brew install mediainfo"],
+    "note": "Multimedia utility."
+  },
+  "commands": [
+    {
+      "namespace": "mediainfo",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to mediainfo CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mediainfo",
+        "passthrough": true,
+        "missingDependencyHelp": "Install mediainfo: apt install mediainfo"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/metaflac/install-guidance.json
+++ b/plugins/metaflac/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "metaflac",
+  "binary": "metaflac",
+  "check": "which metaflac",
+  "install_steps": ["apt install flac", "brew install flac"]
+}

--- a/plugins/metaflac/meta.json
+++ b/plugins/metaflac/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "metaflac — command-line FLAC metadata editor for audio file tagging",
+  "tags": ["audio", "media", "metadata", "conversion", "utilities"],
+  "has_learn": false
+}

--- a/plugins/metaflac/plugin.json
+++ b/plugins/metaflac/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "metaflac",
+  "version": "0.1.0",
+  "description": "metaflac — command-line FLAC metadata editor for audio file tagging",
+  "source": "https://github.com/xiph/flac",
+  "checks": [
+    { "type": "binary", "name": "metaflac" }
+  ],
+  "install_guidance": {
+    "plugin": "metaflac",
+    "binary": "metaflac",
+    "check": "which metaflac",
+    "install_steps": ["apt install flac", "brew install flac"],
+    "note": "Audio utility."
+  },
+  "commands": [
+    {
+      "namespace": "metaflac",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to metaflac CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "metaflac",
+        "passthrough": true,
+        "missingDependencyHelp": "Install metaflac: apt install flac"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/oggenc/install-guidance.json
+++ b/plugins/oggenc/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "oggenc",
+  "binary": "oggenc",
+  "check": "which oggenc",
+  "install_steps": ["apt install vorbis-tools", "brew install vorbis-tools"]
+}

--- a/plugins/oggenc/meta.json
+++ b/plugins/oggenc/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "oggenc — Ogg Vorbis audio encoder for lossy audio compression",
+  "tags": ["audio", "media", "conversion", "compression", "utilities"],
+  "has_learn": false
+}

--- a/plugins/oggenc/plugin.json
+++ b/plugins/oggenc/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "oggenc",
+  "version": "0.1.0",
+  "description": "oggenc — Ogg Vorbis audio encoder for lossy audio compression",
+  "source": "https://github.com/xiph/vorbis-tools",
+  "checks": [
+    { "type": "binary", "name": "oggenc" }
+  ],
+  "install_guidance": {
+    "plugin": "oggenc",
+    "binary": "oggenc",
+    "check": "which oggenc",
+    "install_steps": ["apt install vorbis-tools", "brew install vorbis-tools"],
+    "note": "Audio utility."
+  },
+  "commands": [
+    {
+      "namespace": "oggenc",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to oggenc CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "oggenc",
+        "passthrough": true,
+        "missingDependencyHelp": "Install oggenc: apt install vorbis-tools"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pamixer/install-guidance.json
+++ b/plugins/pamixer/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "pamixer",
+  "binary": "pamixer",
+  "check": "which pamixer",
+  "install_steps": ["apt install pamixer", "brew install pamixer"]
+}

--- a/plugins/pamixer/meta.json
+++ b/plugins/pamixer/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "pamixer — PulseAudio command-line mixer for volume and mute control",
+  "tags": ["audio", "media", "linux", "pulseaudio", "utilities"],
+  "has_learn": false
+}

--- a/plugins/pamixer/plugin.json
+++ b/plugins/pamixer/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "pamixer",
+  "version": "0.1.0",
+  "description": "pamixer — PulseAudio command-line mixer for volume and mute control",
+  "source": "https://github.com/cdemoulins/pamixer",
+  "checks": [
+    { "type": "binary", "name": "pamixer" }
+  ],
+  "install_guidance": {
+    "plugin": "pamixer",
+    "binary": "pamixer",
+    "check": "which pamixer",
+    "install_steps": ["apt install pamixer", "brew install pamixer"],
+    "note": "Audio utility."
+  },
+  "commands": [
+    {
+      "namespace": "pamixer",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to pamixer CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pamixer",
+        "passthrough": true,
+        "missingDependencyHelp": "Install pamixer: apt install pamixer"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #281 (am/am-f17c27-th02lm): fix(k0s,k3s): set canonical source URLs
    touches: plugins/k0s/plugin.json, plugins/k3s/plugin.json, plugins/okteto-cli/plugin.json, plugins/oracle-cloud/plugin.json, plugins/up/plugin.json
- PR #280 (am/am-f17c27-th029w): feat: add fzf-make plugin — fuzzy-find and run make/just/npm targets
    touches: plugins/fzf-make/install-guidance.json, plugins/fzf-make/meta.json, plugins/fzf-make/plugin.json
- PR #272 (am/am-f17c27-tgzta5): feat: add 5 new plugins
    touches: plugins/frawk/install-guidance.json, plugins/frawk/meta.json, plugins/frawk/plugin.json, plugins/slumber/install-guidance.json, plugins/slumber/meta.json, plugins/slumber/plugin.json, plugins/vgrep/install-guidance.json, plugins/vgrep/meta.json, plugins/vgrep/plugin.json, plugins/xplr/install-guidance.json, plugins/xplr/meta.json, plugins/xplr/plugin.json (+3 more)
- PR #271 (am/am-f17c27-tgzsui): fix(aws): expand description and tags for discoverability
    touches: plugins/aws/meta.json, plugins/aws/plugin.json, plugins/delta/meta.json, plugins/delta/plugin.json, plugins/rg/meta.json, plugins/rg/plugin.json
- PR #270 (am/am-f17c27-tgzr9t): fix(7zip): set canonical source URL
    touches: plugins/7zip/plugin.json, plugins/ack/plugin.json, plugins/ant/plugin.json
- PR #269 (am/am-f17c27-tgzo7c): fix(jq): restore source URL and split malformed tags
    touches: plugins/amtool/meta.json, plugins/amtool/plugin.json, plugins/htop/meta.json, plugins/htop/plugin.json, plugins/jq/meta.json, plugins/jq/plugin.json
- PR #268 (am/am-f17c27-tgxpuu): fix(cargo-nextest): correct source URL and expand tags
    touches: plugins/cargo-nextest/meta.json, plugins/cargo-nextest/plugin.json, plugins/cargo-test/plugin.json, plugins/gotestsum/meta.json, plugins/gotestsum/plugin.json


**Branch:** `am/am-f17c27-th3x8p`

## Summary

feat: add 5 new bundled plugins for media/audio CLI tools (mediainfo, avifenc, metaflac, pamixer, oggenc). These are well-established open-source tools for media metadata analysis (MediaInfo), AVIF image encoding (libavif), FLAC metadata editing, PulseAudio volume control, and Ogg Vorbis audio encoding.

**Diff:**
```
plugins/avifenc/install-guidance.json   |  6 ++++++
 plugins/avifenc/meta.json               |  5 +++++
 plugins/avifenc/plugin.json             | 31 +++++++++++++++++++++++++++++++
 plugins/mediainfo/install-guidance.json |  6 ++++++
 plugins/mediainfo/meta.json             |  5 +++++
 plugins/mediainfo/plugin.json           | 31 +++++++++++++++++++++++++++++++
 plugins/metaflac/install-guidance.json  |  6 ++++++
 plugins/metaflac/meta.json              |  5 +++++
 plugins/metaflac/plugin.json            | 31 +++++++++++++++++++++++++++++++
 plugins/oggenc/install-guidance.json    |  6 ++++++
 plugins/oggenc/meta.json                |  5 +++++
 plugins/oggenc/plugin.json              | 31 +++++++++++++++++++++++++++++++
 plugins/pamixer/install-guidance.json   |  6 ++++++
 plugins/pamixer/meta.json               |  5 +++++
 plugins/pamixer/plugin.json             | 31 +++++++++++++++++++++++++++++++
 15 files changed, 210 insertions(+)
```
