### PR TITLE
feat: add 5 new bundled plugins — deptry, flit, twine, memray, delve

### DIFF
--- a/plugins/delve/install-guidance.json
+++ b/plugins/delve/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "delve",
+  "binary": "dlv",
+  "check": "which dlv",
+  "install_steps": [
+    "go install github.com/go-delve/delve/cmd/dlv@latest",
+    "Verify: dlv version",
+    "supercli plugins install ./plugins/delve --on-conflict replace --json"
+  ],
+  "note": "Also installable via: brew install delve (macOS). The binary name is 'dlv', not 'delve'. Requires Go to be installed."
+}

--- a/plugins/delve/meta.json
+++ b/plugins/delve/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "delve (dlv) — debugger for the Go programming language. Supports breakpoints, goroutine inspection, stack traces, variable evaluation, and headless server mode.",
+  "tags": ["delve", "go", "golang", "debugging", "debugger", "development"],
+  "has_learn": true
+}

--- a/plugins/delve/plugin.json
+++ b/plugins/delve/plugin.json
@@ -1,0 +1,139 @@
+{
+  "name": "delve",
+  "version": "0.1.0",
+  "description": "delve (dlv) — debugger for the Go programming language with full runtime inspection",
+  "source": "https://github.com/go-delve/delve",
+  "checks": [
+    { "type": "binary", "name": "dlv" }
+  ],
+  "install_guidance": {
+    "plugin": "delve",
+    "binary": "dlv",
+    "check": "which dlv",
+    "install_steps": [
+      "go install github.com/go-delve/delve/cmd/dlv@latest",
+      "Verify: dlv version",
+      "supercli plugins install ./plugins/delve --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "delve",
+      "resource": "self",
+      "action": "version",
+      "description": "Print dlv version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dlv",
+        "baseArgs": ["version"],
+        "missingDependencyHelp": "Install delve: go install github.com/go-delve/delve/cmd/dlv@latest"
+      },
+      "args": []
+    },
+    {
+      "namespace": "delve",
+      "resource": "debug",
+      "action": "run",
+      "description": "Compile and begin debugging a Go program",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dlv",
+        "baseArgs": ["debug"],
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "timeout_ms": 120000,
+        "missingDependencyHelp": "Install delve"
+      },
+      "args": [
+        { "name": "args", "type": "string", "required": false, "description": "Arguments to pass to the debugged program" }
+      ]
+    },
+    {
+      "namespace": "delve",
+      "resource": "exec",
+      "action": "run",
+      "description": "Debug a precompiled Go binary",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dlv",
+        "baseArgs": ["exec"],
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "timeout_ms": 120000,
+        "missingDependencyHelp": "Install delve"
+      },
+      "args": [
+        { "name": "binary", "type": "string", "required": true, "description": "Path to the Go binary" }
+      ]
+    },
+    {
+      "namespace": "delve",
+      "resource": "test",
+      "action": "run",
+      "description": "Debug Go tests",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dlv",
+        "baseArgs": ["test"],
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "timeout_ms": 120000,
+        "missingDependencyHelp": "Install delve"
+      },
+      "args": [
+        { "name": "package", "type": "string", "required": false, "description": "Package to test" }
+      ]
+    },
+    {
+      "namespace": "delve",
+      "resource": "connect",
+      "action": "run",
+      "description": "Connect to a headless debugger server",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dlv",
+        "baseArgs": ["connect"],
+        "cwd": "invoke_cwd",
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install delve"
+      },
+      "args": [
+        { "name": "addr", "type": "string", "required": true, "description": "Debug server address (host:port)" }
+      ]
+    },
+    {
+      "namespace": "delve",
+      "resource": "dap",
+      "action": "run",
+      "description": "Start a DAP (Debug Adapter Protocol) server",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dlv",
+        "baseArgs": ["dap"],
+        "cwd": "invoke_cwd",
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install delve"
+      },
+      "args": [
+        { "name": "port", "type": "string", "required": false, "description": "Port to listen on" }
+      ]
+    },
+    {
+      "namespace": "delve",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to dlv CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dlv",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "missingDependencyHelp": "Install delve"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/delve/skills/quickstart/SKILL.md
+++ b/plugins/delve/skills/quickstart/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: delve
+description: Use this skill when the user wants to debug Go programs, set breakpoints, inspect variables, step through code, or debug Go tests.
+---
+
+# delve Plugin
+
+Debugger for the Go programming language (binary: dlv).
+
+## Commands
+
+### Debug
+- `delve debug run` — Compile and debug a Go program
+- `delve exec run` — Debug a precompiled Go binary
+- `delve test run` — Debug Go tests
+- `delve connect run` — Connect to a headless debugger server
+- `delve dap run` — Start a DAP server
+
+## Usage Examples
+- "Debug this Go program"
+- "Debug the Go binary"
+- "Run tests with delve"
+- "Start a headless debug server"
+
+## Installation
+
+```bash
+go install github.com/go-delve/delve/cmd/dlv@latest
+```
+
+## Examples
+
+```bash
+# Debug current package
+dlv debug
+
+# Debug with arguments
+dlv debug -- --arg1 value
+
+# Debug a compiled binary
+dlv exec ./myapp
+
+# Debug tests
+dlv test
+
+# Headless server mode
+dlv debug --headless --listen=:2345 --log
+
+# Connect to headless server
+dlv connect localhost:2345
+
+# Start DAP server
+dlv dap
+```

--- a/plugins/deptry/install-guidance.json
+++ b/plugins/deptry/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "deptry",
+  "binary": "deptry",
+  "check": "which deptry",
+  "install_steps": [
+    "pip install deptry",
+    "Verify: deptry --version",
+    "supercli plugins install ./plugins/deptry --on-conflict replace --json"
+  ],
+  "note": "Also installable via: pipx install deptry. Supports pyproject.toml, setup.cfg, and requirements.txt."
+}

--- a/plugins/deptry/meta.json
+++ b/plugins/deptry/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "deptry — find unused, missing, and obsolete dependencies in Python projects. Scans imports against declared dependencies to detect issues.",
+  "tags": ["deptry", "python", "dependencies", "linting", "project-management"],
+  "has_learn": true
+}

--- a/plugins/deptry/plugin.json
+++ b/plugins/deptry/plugin.json
@@ -1,0 +1,68 @@
+{
+  "name": "deptry",
+  "version": "0.1.0",
+  "description": "deptry — find unused, missing, and obsolete dependencies in Python projects",
+  "source": "https://github.com/fpgmaas/deptry",
+  "checks": [
+    { "type": "binary", "name": "deptry" }
+  ],
+  "install_guidance": {
+    "plugin": "deptry",
+    "binary": "deptry",
+    "check": "which deptry",
+    "install_steps": [
+      "pip install deptry",
+      "Verify: deptry --version",
+      "supercli plugins install ./plugins/deptry --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "deptry",
+      "resource": "self",
+      "action": "version",
+      "description": "Print deptry version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "deptry",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install deptry: pip install deptry"
+      },
+      "args": []
+    },
+    {
+      "namespace": "deptry",
+      "resource": "project",
+      "action": "check",
+      "description": "Check Python project for unused, missing, or obsolete dependencies",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "deptry",
+        "baseArgs": ["."],
+        "cwd": "invoke_cwd",
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install deptry: pip install deptry"
+      },
+      "args": [
+        { "name": "path", "type": "string", "required": false, "description": "Path to project directory" }
+      ]
+    },
+    {
+      "namespace": "deptry",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to deptry CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "deptry",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "missingDependencyHelp": "Install deptry"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/deptry/skills/quickstart/SKILL.md
+++ b/plugins/deptry/skills/quickstart/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: deptry
+description: Use this skill when the user wants to check Python project dependencies for unused or missing packages, or audit dependency health.
+---
+
+# deptry Plugin
+
+Find unused, missing, and obsolete dependencies in Python projects.
+
+## Commands
+
+### Project
+- `deptry project check` — Check project for dependency issues
+
+## Usage Examples
+- "Check my Python project for unused dependencies"
+- "Find missing dependencies"
+- "Audit dependency health"
+
+## Installation
+
+```bash
+pip install deptry
+```
+
+## Examples
+
+```bash
+# Check current directory
+deptry .
+
+# Check specific directory
+deptry /path/to/project
+
+# Ignore certain packages
+deptry . --ignore my-package
+
+# Exclude specific directories
+deptry . --exclude tests
+
+# JSON output
+deptry . --json
+```

--- a/plugins/flit/install-guidance.json
+++ b/plugins/flit/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "flit",
+  "binary": "flit",
+  "check": "which flit",
+  "install_steps": [
+    "pip install flit",
+    "Verify: flit --version",
+    "supercli plugins install ./plugins/flit --on-conflict replace --json"
+  ],
+  "note": "Flit supports building and publishing Python packages defined in pyproject.toml. Also installable via pipx."
+}

--- a/plugins/flit/meta.json
+++ b/plugins/flit/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "flit — simple way to build and publish Python packages to PyPI. Minimal configuration via pyproject.toml.",
+  "tags": ["flit", "python", "packaging", "pypi", "build-tool"],
+  "has_learn": true
+}

--- a/plugins/flit/plugin.json
+++ b/plugins/flit/plugin.json
@@ -1,0 +1,97 @@
+{
+  "name": "flit",
+  "version": "0.1.0",
+  "description": "flit — simple way to build and publish Python packages to PyPI",
+  "source": "https://github.com/pypa/flit",
+  "checks": [
+    { "type": "binary", "name": "flit" }
+  ],
+  "install_guidance": {
+    "plugin": "flit",
+    "binary": "flit",
+    "check": "which flit",
+    "install_steps": [
+      "pip install flit",
+      "Verify: flit --version",
+      "supercli plugins install ./plugins/flit --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "flit",
+      "resource": "self",
+      "action": "version",
+      "description": "Print flit version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "flit",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install flit: pip install flit"
+      },
+      "args": []
+    },
+    {
+      "namespace": "flit",
+      "resource": "build",
+      "action": "run",
+      "description": "Build a Python package from the current directory",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "flit",
+        "baseArgs": ["build"],
+        "cwd": "invoke_cwd",
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install flit: pip install flit"
+      },
+      "args": []
+    },
+    {
+      "namespace": "flit",
+      "resource": "publish",
+      "action": "run",
+      "description": "Build and publish a Python package to PyPI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "flit",
+        "baseArgs": ["publish"],
+        "cwd": "invoke_cwd",
+        "timeout_ms": 120000,
+        "missingDependencyHelp": "Install flit: pip install flit"
+      },
+      "args": [
+        { "name": "repository", "type": "string", "required": false, "description": "PyPI repository to publish to" }
+      ]
+    },
+    {
+      "namespace": "flit",
+      "resource": "init",
+      "action": "run",
+      "description": "Initialize a new Python package",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "flit",
+        "baseArgs": ["init"],
+        "cwd": "invoke_cwd",
+        "missingDependencyHelp": "Install flit: pip install flit"
+      },
+      "args": []
+    },
+    {
+      "namespace": "flit",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to flit CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "flit",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "missingDependencyHelp": "Install flit"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/flit/skills/quickstart/SKILL.md
+++ b/plugins/flit/skills/quickstart/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: flit
+description: Use this skill when the user wants to build or publish Python packages to PyPI, or initialize a new Python project with modern packaging.
+---
+
+# flit Plugin
+
+Simple way to build and publish Python packages to PyPI.
+
+## Commands
+
+### Build
+- `flit build run` — Build a Python package
+
+### Publish
+- `flit publish run` — Build and publish to PyPI
+
+### Init
+- `flit init run` — Initialize a new Python package
+
+## Usage Examples
+- "Build this Python package"
+- "Publish to PyPI"
+- "Initialize a new Python project"
+
+## Installation
+
+```bash
+pip install flit
+```
+
+## Examples
+
+```bash
+# Build package
+flit build
+
+# Publish to PyPI
+flit publish
+
+# Publish to test PyPI
+flit publish --repository testpypi
+
+# Initialize new project
+flit init
+
+# Install in development mode
+flit install
+```

--- a/plugins/memray/install-guidance.json
+++ b/plugins/memray/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "memray",
+  "binary": "memray",
+  "check": "which memray",
+  "install_steps": [
+    "pip install memray",
+    "Verify: memray --version",
+    "supercli plugins install ./plugins/memray --on-conflict replace --json"
+  ],
+  "note": "Memray supports Python 3.8+. Output formats: flamegraph, table, linetree, stats. Requires a C compiler for installation."
+}

--- a/plugins/memray/meta.json
+++ b/plugins/memray/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "memray — memory profiler for Python applications by Bloomberg. Tracks memory allocations per line, generates live flame graphs, table reports, and more.",
+  "tags": ["memray", "python", "profiling", "memory", "debugging", "performance"],
+  "has_learn": true
+}

--- a/plugins/memray/plugin.json
+++ b/plugins/memray/plugin.json
@@ -1,0 +1,103 @@
+{
+  "name": "memray",
+  "version": "0.1.0",
+  "description": "memray — memory profiler for Python applications with live flame graphs and reports",
+  "source": "https://github.com/bloomberg/memray",
+  "checks": [
+    { "type": "binary", "name": "memray" }
+  ],
+  "install_guidance": {
+    "plugin": "memray",
+    "binary": "memray",
+    "check": "which memray",
+    "install_steps": [
+      "pip install memray",
+      "Verify: memray --version",
+      "supercli plugins install ./plugins/memray --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "memray",
+      "resource": "self",
+      "action": "version",
+      "description": "Print memray version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "memray",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install memray: pip install memray"
+      },
+      "args": []
+    },
+    {
+      "namespace": "memray",
+      "resource": "run",
+      "action": "profile",
+      "description": "Profile a Python script and generate memory reports",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "memray",
+        "baseArgs": ["run"],
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "timeout_ms": 120000,
+        "missingDependencyHelp": "Install memray: pip install memray"
+      },
+      "args": [
+        { "name": "script", "type": "string", "required": true, "description": "Python script to profile" }
+      ]
+    },
+    {
+      "namespace": "memray",
+      "resource": "flamegraph",
+      "action": "generate",
+      "description": "Generate a flame graph from a memray snapshot file",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "memray",
+        "baseArgs": ["flamegraph"],
+        "cwd": "invoke_cwd",
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install memray: pip install memray"
+      },
+      "args": [
+        { "name": "snapshot", "type": "string", "required": true, "description": "Memray snapshot file (.bin)" }
+      ]
+    },
+    {
+      "namespace": "memray",
+      "resource": "table",
+      "action": "generate",
+      "description": "Generate a table report from a memray snapshot file",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "memray",
+        "baseArgs": ["table"],
+        "cwd": "invoke_cwd",
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install memray: pip install memray"
+      },
+      "args": [
+        { "name": "snapshot", "type": "string", "required": true, "description": "Memray snapshot file (.bin)" }
+      ]
+    },
+    {
+      "namespace": "memray",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to memray CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "memray",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "missingDependencyHelp": "Install memray"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/memray/skills/quickstart/SKILL.md
+++ b/plugins/memray/skills/quickstart/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: memray
+description: Use this skill when the user wants to profile Python memory usage, find memory leaks, generate flame graphs, or analyze Python application memory behavior.
+---
+
+# memray Plugin
+
+Memory profiler for Python applications with live flame graphs and reports.
+
+## Commands
+
+### Run
+- `memray run profile` — Profile a Python script
+
+### Flamegraph
+- `memray flamegraph generate` — Generate a flame graph from a snapshot
+
+### Table
+- `memray table generate` — Generate a table report from a snapshot
+
+## Usage Examples
+- "Profile this Python script for memory usage"
+- "Generate a flame graph from the memory snapshot"
+- "Show memory allocations in a table"
+
+## Installation
+
+```bash
+pip install memray
+```
+
+## Examples
+
+```bash
+# Profile a script
+memray run my_script.py
+
+# Profile and generate live flamegraph
+memray run --live my_script.py
+
+# Generate flame graph from snapshot
+memray flamegraph output.bin
+
+# Generate table report
+memray table output.bin
+
+# Show statistics
+memray stats output.bin
+
+# Track specific function
+memray run -f my_function my_script.py
+```

--- a/plugins/twine/install-guidance.json
+++ b/plugins/twine/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "twine",
+  "binary": "twine",
+  "check": "which twine",
+  "install_steps": [
+    "pip install twine",
+    "Verify: twine --version",
+    "supercli plugins install ./plugins/twine --on-conflict replace --json"
+  ],
+  "note": "Twine is the recommended tool for uploading Python packages to PyPI. Supports --repository for test PyPI or custom repos."
+}

--- a/plugins/twine/meta.json
+++ b/plugins/twine/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "twine — securely upload Python packages to PyPI with verified HTTPS connections. Supports dist/ directory, package signing, and repository targeting.",
+  "tags": ["twine", "python", "pypi", "packaging", "publishing", "security"],
+  "has_learn": true
+}

--- a/plugins/twine/plugin.json
+++ b/plugins/twine/plugin.json
@@ -1,0 +1,85 @@
+{
+  "name": "twine",
+  "version": "0.1.0",
+  "description": "twine — securely upload Python packages to PyPI with verified HTTPS connections",
+  "source": "https://github.com/pypa/twine",
+  "checks": [
+    { "type": "binary", "name": "twine" }
+  ],
+  "install_guidance": {
+    "plugin": "twine",
+    "binary": "twine",
+    "check": "which twine",
+    "install_steps": [
+      "pip install twine",
+      "Verify: twine --version",
+      "supercli plugins install ./plugins/twine --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "twine",
+      "resource": "self",
+      "action": "version",
+      "description": "Print twine version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "twine",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install twine: pip install twine"
+      },
+      "args": []
+    },
+    {
+      "namespace": "twine",
+      "resource": "upload",
+      "action": "run",
+      "description": "Upload distribution packages to PyPI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "twine",
+        "baseArgs": ["upload"],
+        "cwd": "invoke_cwd",
+        "timeout_ms": 120000,
+        "missingDependencyHelp": "Install twine: pip install twine"
+      },
+      "args": [
+        { "name": "dist", "type": "string", "required": true, "description": "Distribution file(s) to upload (glob pattern)" }
+      ]
+    },
+    {
+      "namespace": "twine",
+      "resource": "upload",
+      "action": "check",
+      "description": "Check distribution packages for common issues",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "twine",
+        "baseArgs": ["check"],
+        "cwd": "invoke_cwd",
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install twine: pip install twine"
+      },
+      "args": [
+        { "name": "dist", "type": "string", "required": true, "description": "Distribution file(s) to check (glob pattern)" }
+      ]
+    },
+    {
+      "namespace": "twine",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to twine CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "twine",
+        "cwd": "invoke_cwd",
+        "passthrough": true,
+        "missingDependencyHelp": "Install twine"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/twine/skills/quickstart/SKILL.md
+++ b/plugins/twine/skills/quickstart/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: twine
+description: Use this skill when the user wants to upload Python packages to PyPI, check distribution files, or publish Python packages securely.
+---
+
+# twine Plugin
+
+Securely upload Python packages to PyPI with verified HTTPS connections.
+
+## Commands
+
+### Upload
+- `twine upload run` — Upload distribution packages to PyPI
+
+### Check
+- `twine upload check` — Check distribution packages for common issues
+
+## Usage Examples
+- "Upload dist/* to PyPI"
+- "Check my distribution files"
+- "Publish to test PyPI"
+
+## Installation
+
+```bash
+pip install twine
+```
+
+## Examples
+
+```bash
+# Upload to PyPI
+twine upload dist/*
+
+# Upload to test PyPI
+twine upload --repository testpypi dist/*
+
+# Check distribution files
+twine check dist/*
+
+# Upload with a specific username
+twine upload --username __token__ dist/*
+
+# Skip existing files
+twine upload --skip-existing dist/*
+```


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #305 (am/am-f17c27-th3y61): feat: add 4 new bundled plugins — httpie, unar, newsboat, tinygo
    touches: plugins/httpie/install-guidance.json, plugins/httpie/meta.json, plugins/httpie/plugin.json, plugins/newsboat/install-guidance.json, plugins/newsboat/meta.json, plugins/newsboat/plugin.json, plugins/tinygo/install-guidance.json, plugins/tinygo/meta.json, plugins/tinygo/plugin.json, plugins/unar/install-guidance.json, plugins/unar/meta.json, plugins/unar/plugin.json
- PR #304 (am/am-f17c27-th3x8p): feat: add 5 media/audio plugins — mediainfo, avifenc, metaflac, pamixer, oggenc
    touches: plugins/avifenc/install-guidance.json, plugins/avifenc/meta.json, plugins/avifenc/plugin.json, plugins/mediainfo/install-guidance.json, plugins/mediainfo/meta.json, plugins/mediainfo/plugin.json, plugins/metaflac/install-guidance.json, plugins/metaflac/meta.json, plugins/metaflac/plugin.json, plugins/oggenc/install-guidance.json, plugins/oggenc/meta.json, plugins/oggenc/plugin.json (+3 more)
- PR #281 (am/am-f17c27-th02lm): fix(k0s,k3s): set canonical source URLs
    touches: plugins/k0s/plugin.json, plugins/k3s/plugin.json, plugins/okteto-cli/plugin.json, plugins/oracle-cloud/plugin.json, plugins/up/plugin.json
- PR #280 (am/am-f17c27-th029w): feat: add fzf-make plugin — fuzzy-find and run make/just/npm targets
    touches: plugins/fzf-make/install-guidance.json, plugins/fzf-make/meta.json, plugins/fzf-make/plugin.json
- PR #272 (am/am-f17c27-tgzta5): feat: add 5 new plugins
    touches: plugins/frawk/install-guidance.json, plugins/frawk/meta.json, plugins/frawk/plugin.json, plugins/slumber/install-guidance.json, plugins/slumber/meta.json, plugins/slumber/plugin.json, plugins/vgrep/install-guidance.json, plugins/vgrep/meta.json, plugins/vgrep/plugin.json, plugins/xplr/install-guidance.json, plugins/xplr/meta.json, plugins/xplr/plugin.json (+3 more)
- PR #271 (am/am-f17c27-tgzsui): fix(aws): expand description and tags for discoverability
    touches: plugins/aws/meta.json, plugins/aws/plugin.json, plugins/delta/meta.json, plugins/delta/plugin.json, plugins/rg/meta.json, plugins/rg/plugin.json
- PR #270 (am/am-f17c27-tgzr9t): fix(7zip): set canonical source URL
    touches: plugins/7zip/plugin.json, plugins/ack/plugin.json, plugins/ant/plugin.json
- PR #269 (am/am-f17c27-tgzo7c): fix(jq): restore source URL and split malformed tags
    touches: plugins/amtool/meta.json, plugins/amtool/plugin.json, plugins/htop/meta.json, plugins/htop/plugin.json, plugins/jq/meta.json, plugins/jq/plugin.json


**Branch:** `am/am-f17c27-th3z6p`

## Summary

feat: add 5 new bundled plugins — deptry (Python dependency checker), flit (Python packaging/publishing), twine (secure PyPI upload), memray (Python memory profiler by Bloomberg), and delve (Go debugger). These are well-known, actively maintained developer tools in the Python and Go ecosystems that fill gaps in the existing catalog.

**Diff:**
```
plugins/delve/install-guidance.json       |  11 +++
 plugins/delve/meta.json                   |   5 ++
 plugins/delve/plugin.json                 | 139 ++++++++++++++++++++++++++++++
 plugins/delve/skills/quickstart/SKILL.md  |  54 ++++++++++++
 plugins/deptry/install-guidance.json      |  11 +++
 plugins/deptry/meta.json                  |   5 ++
 plugins/deptry/plugin.json                |  68 +++++++++++++++
 plugins/deptry/skills/quickstart/SKILL.md |  43 +++++++++
 plugins/flit/install-guidance.json        |  11 +++
 plugins/flit/meta.json                    |   5 ++
 plugins/flit/plugin.json                  |  97 +++++++++++++++++++++
 plugins/flit/skills/quickstart/SKILL.md   |  49 +++++++++++
 plugins/memray/install-guidance.json      |  11 +++
 plugins/memray/meta.json                  |   5 ++
 plugins/memray/plugin.json                | 103 ++++++++++++++++++++++
 plugins/memray/skills/quickstart/SKILL.md |  52 +++++++++++
 plugins/twine/install-guidance.json       |  11 +++
 plugins/twine/meta.json                   |   5 ++
 plugins/twine/plugin.json                 |  85 ++++++++++++++++++
 plugins/twine/skills/quickstart/SKILL.md  |  46 ++++++++++
 20 files changed, 816 insertions(+)
```
