### PR TITLE
feat(plugins): add vercel, directus, kamal — deployment and CMS CLIs

### DIFF
--- a/plugins/directus/install-guidance.json
+++ b/plugins/directus/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "directus",
+  "binary": "directus",
+  "check": "directus --version",
+  "install_steps": [
+    "npm install -g directus",
+    "Verify: directus --version",
+    "Create .env with DIRECTUS_URL and DIRECTUS_TOKEN",
+    "supercli plugins install ./plugins/directus --on-conflict replace --json"
+  ],
+  "note": "Requires Node.js 18+. Configure via DIRECTUS_URL and DIRECTUS_TOKEN environment variables or .env file in the project directory."
+}

--- a/plugins/directus/meta.json
+++ b/plugins/directus/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "CLI for the Directus headless CMS. Manage projects, collections, items, users, roles, files, webhooks, and schema migrations with JSON output support.",
+  "tags": ["directus", "cms", "headless-cms", "api", "content-management", "cli", "database"],
+  "has_learn": false
+}

--- a/plugins/directus/plugin.json
+++ b/plugins/directus/plugin.json
@@ -1,0 +1,140 @@
+{
+  "name": "directus",
+  "version": "0.1.0",
+  "description": "directus — CLI for the Directus headless CMS. Manage projects, collections, items, users, roles, files, webhooks, and schema migrations. Extensible with flows and custom endpoints. Ideal for content management automation, CI/CD pipelines, and AI agent integration with JSON output support.",
+  "source": "https://github.com/directus/directus",
+  "checks": [
+    { "type": "binary", "name": "directus" }
+  ],
+  "install_guidance": {
+    "plugin": "directus",
+    "binary": "directus",
+    "check": "directus --version",
+    "install_steps": [
+      "npm install -g directus",
+      "Verify: directus --version",
+      "supercli plugins install ./plugins/directus --on-conflict replace --json"
+    ],
+    "note": "Requires Node.js 18+. Configure via DIRECTUS_URL and DIRECTUS_TOKEN environment variables or .env file."
+  },
+  "commands": [
+    {
+      "namespace": "directus",
+      "resource": "self",
+      "action": "version",
+      "description": "Print directus CLI version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "directus",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install directus: npm install -g directus"
+      },
+      "args": []
+    },
+    {
+      "namespace": "directus",
+      "resource": "project",
+      "action": "list",
+      "description": "List Directus projects",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "directus",
+        "baseArgs": ["projects", "list"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install directus: npm install -g directus"
+      },
+      "args": []
+    },
+    {
+      "namespace": "directus",
+      "resource": "collection",
+      "action": "list",
+      "description": "List all collections in the project",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "directus",
+        "baseArgs": ["collection", "list"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install directus: npm install -g directus"
+      },
+      "args": []
+    },
+    {
+      "namespace": "directus",
+      "resource": "user",
+      "action": "list",
+      "description": "List users in the project",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "directus",
+        "baseArgs": ["user", "list"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install directus: npm install -g directus"
+      },
+      "args": []
+    },
+    {
+      "namespace": "directus",
+      "resource": "schema",
+      "action": "snapshot",
+      "description": "Export schema snapshot for version control",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "directus",
+        "baseArgs": ["schema", "snapshot"],
+        "positionalArgs": ["output"],
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install directus: npm install -g directus"
+      },
+      "args": [
+        { "name": "output", "type": "string", "required": true, "description": "Output file path (e.g., schema.yaml)" },
+        { "name": "--yes", "type": "boolean", "required": false, "description": "Skip confirmation" }
+      ]
+    },
+    {
+      "namespace": "directus",
+      "resource": "schema",
+      "action": "apply",
+      "description": "Apply schema snapshot to the project",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "directus",
+        "baseArgs": ["schema", "apply"],
+        "positionalArgs": ["input"],
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install directus: npm install -g directus"
+      },
+      "args": [
+        { "name": "input", "type": "string", "required": true, "description": "Schema file path to apply" },
+        { "name": "--yes", "type": "boolean", "required": false, "description": "Skip confirmation" }
+      ]
+    },
+    {
+      "namespace": "directus",
+      "resource": "role",
+      "action": "list",
+      "description": "List user roles",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "directus",
+        "baseArgs": ["roles", "list"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install directus: npm install -g directus"
+      },
+      "args": []
+    },
+    {
+      "namespace": "directus",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to directus CLI for any command",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "directus",
+        "passthrough": true,
+        "missingDependencyHelp": "Install directus: npm install -g directus"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/kamal/install-guidance.json
+++ b/plugins/kamal/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "kamal",
+  "binary": "kamal",
+  "check": "kamal version",
+  "install_steps": [
+    "gem install kamal",
+    "Verify: kamal version",
+    "Initialize: kamal init (creates config/deploy.yml)",
+    "supercli plugins install ./plugins/kamal --on-conflict replace --json"
+  ],
+  "note": "Requires Ruby 3.0+, Docker on the deployment target, and SSH access to servers. Uses Traefik for ingress routing."
+}

--- a/plugins/kamal/meta.json
+++ b/plugins/kamal/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Deploy web apps anywhere from raw Docker images. Zero-downtime deployments with rolling updates, asset bridging, logging, and SSH-based access. From 37signals (Basecamp).",
+  "tags": ["kamal", "deployment", "docker", "devops", "self-hosted", "ssh", "rails"],
+  "has_learn": false
+}

--- a/plugins/kamal/plugin.json
+++ b/plugins/kamal/plugin.json
@@ -1,0 +1,144 @@
+{
+  "name": "kamal",
+  "version": "0.1.0",
+  "description": "kamal — deploy web apps anywhere from raw Docker images. Zero-downtime deployments with rolling updates, asset bridging, logging, and SSH-based access. Uses Traefik for routing and runs on any Linux host. From 37signals (Basecamp). Ideal for self-hosted deployments without Kubernetes.",
+  "source": "https://github.com/basecamp/kamal",
+  "checks": [
+    { "type": "binary", "name": "kamal" }
+  ],
+  "install_guidance": {
+    "plugin": "kamal",
+    "binary": "kamal",
+    "check": "kamal version",
+    "install_steps": [
+      "gem install kamal",
+      "Verify: kamal version",
+      "Configure: kamal init (creates config/deploy.yml)",
+      "supercli plugins install ./plugins/kamal --on-conflict replace --json"
+    ],
+    "note": "Requires Ruby 3.0+, Docker on the deployment target, and SSH access to servers. Uses Traefik for ingress routing. See https://kamal-deploy.org for docs."
+  },
+  "commands": [
+    {
+      "namespace": "kamal",
+      "resource": "self",
+      "action": "version",
+      "description": "Print kamal version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "kamal",
+        "baseArgs": ["version"],
+        "missingDependencyHelp": "Install kamal: gem install kamal"
+      },
+      "args": []
+    },
+    {
+      "namespace": "kamal",
+      "resource": "deploy",
+      "action": "run",
+      "description": "Deploy the application with zero-downtime rolling update",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "kamal",
+        "baseArgs": ["deploy"],
+        "passthrough": true,
+        "timeout_ms": 120000,
+        "missingDependencyHelp": "Install kamal: gem install kamal"
+      },
+      "args": [
+        { "name": "--version", "type": "string", "required": false, "description": "Specific version tag to deploy" },
+        { "name": "--skip-push", "type": "boolean", "required": false, "description": "Skip Docker image push" }
+      ]
+    },
+    {
+      "namespace": "kamal",
+      "resource": "rollback",
+      "action": "run",
+      "description": "Rollback to a previous deployment version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "kamal",
+        "baseArgs": ["rollback"],
+        "positionalArgs": ["version"],
+        "timeout_ms": 120000,
+        "missingDependencyHelp": "Install kamal: gem install kamal"
+      },
+      "args": [
+        { "name": "version", "type": "string", "required": true, "description": "Version tag to rollback to" }
+      ]
+    },
+    {
+      "namespace": "kamal",
+      "resource": "app",
+      "action": "logs",
+      "description": "Show application logs from servers",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "kamal",
+        "baseArgs": ["app", "logs"],
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install kamal: gem install kamal"
+      },
+      "args": [
+        { "name": "--since", "type": "string", "required": false, "description": "Show logs since timestamp (e.g., '5m', '2h')" },
+        { "name": "--lines", "type": "number", "required": false, "description": "Number of lines to show" }
+      ]
+    },
+    {
+      "namespace": "kamal",
+      "resource": "app",
+      "action": "details",
+      "description": "Show application details and status",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "kamal",
+        "baseArgs": ["app", "details"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install kamal: gem install kamal"
+      },
+      "args": []
+    },
+    {
+      "namespace": "kamal",
+      "resource": "server",
+      "action": "bootstrap",
+      "description": "Bootstrap servers with Docker and dependencies",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "kamal",
+        "baseArgs": ["server", "bootstrap"],
+        "timeout_ms": 120000,
+        "missingDependencyHelp": "Install kamal: gem install kamal"
+      },
+      "args": []
+    },
+    {
+      "namespace": "kamal",
+      "resource": "config",
+      "action": "show",
+      "description": "Show the Kamal configuration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "kamal",
+        "baseArgs": ["config"],
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "Install kamal: gem install kamal"
+      },
+      "args": []
+    },
+    {
+      "namespace": "kamal",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to kamal CLI for any command",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "kamal",
+        "passthrough": true,
+        "missingDependencyHelp": "Install kamal: gem install kamal"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/vercel/install-guidance.json
+++ b/plugins/vercel/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "vercel",
+  "binary": "vercel",
+  "check": "vercel --version",
+  "install_steps": [
+    "npm install -g vercel",
+    "Verify: vercel --version",
+    "Authenticate: vercel login",
+    "supercli plugins install ./plugins/vercel --on-conflict replace --json"
+  ],
+  "note": "Requires Node.js 18+. Run 'vercel login' to authenticate. Deploy with 'vercel deploy' or just 'vercel' in a project directory."
+}

--- a/plugins/vercel/meta.json
+++ b/plugins/vercel/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Vercel CLI for deployment, environment management, logs, domains, and project configuration. Deploy frontends, serverless functions, and full-stack apps with zero configuration.",
+  "tags": ["vercel", "deployment", "hosting", "frontend", "serverless", "cli", "devops"],
+  "has_learn": false
+}

--- a/plugins/vercel/plugin.json
+++ b/plugins/vercel/plugin.json
@@ -1,0 +1,114 @@
+{
+  "name": "vercel",
+  "version": "0.1.0",
+  "description": "vercel — Vercel CLI for deployment, environment management, logs, domains, and project configuration. Deploy frontends, serverless functions, and full-stack apps with zero configuration. Integrates with Git for automatic preview deployments. Supports monorepos, environment variables, custom domains, and team collaboration.",
+  "source": "https://github.com/vercel/vercel",
+  "checks": [
+    { "type": "binary", "name": "vercel" }
+  ],
+  "install_guidance": {
+    "plugin": "vercel",
+    "binary": "vercel",
+    "check": "vercel --version",
+    "install_steps": [
+      "npm install -g vercel",
+      "Verify: vercel --version",
+      "Authenticate: vercel login",
+      "supercli plugins install ./plugins/vercel --on-conflict replace --json"
+    ],
+    "note": "Requires Node.js 18+. Run 'vercel login' to authenticate. Deploy with 'vercel deploy' or just 'vercel' in a project directory."
+  },
+  "commands": [
+    {
+      "namespace": "vercel",
+      "resource": "self",
+      "action": "version",
+      "description": "Print vercel CLI version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "vercel",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install vercel: npm install -g vercel"
+      },
+      "args": []
+    },
+    {
+      "namespace": "vercel",
+      "resource": "deploy",
+      "action": "run",
+      "description": "Deploy project to Vercel",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "vercel",
+        "baseArgs": ["deploy"],
+        "passthrough": true,
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install vercel: npm install -g vercel"
+      },
+      "args": [
+        { "name": "--prod", "type": "boolean", "required": false, "description": "Deploy to production" },
+        { "name": "--yes", "type": "boolean", "required": false, "description": "Skip confirmation prompts" },
+        { "name": "--name", "type": "string", "required": false, "description": "Project name" },
+        { "name": "--scope", "type": "string", "required": false, "description": "Team scope" }
+      ]
+    },
+    {
+      "namespace": "vercel",
+      "resource": "env",
+      "action": "list",
+      "description": "List environment variables for a project",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "vercel",
+        "baseArgs": ["env", "list"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install vercel: npm install -g vercel"
+      },
+      "args": []
+    },
+    {
+      "namespace": "vercel",
+      "resource": "logs",
+      "action": "tail",
+      "description": "Tail deployment logs",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "vercel",
+        "baseArgs": ["logs"],
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "missingDependencyHelp": "Install vercel: npm install -g vercel"
+      },
+      "args": [
+        { "name": "deployment-url", "type": "string", "required": false, "description": "Deployment URL or ID" }
+      ]
+    },
+    {
+      "namespace": "vercel",
+      "resource": "domains",
+      "action": "list",
+      "description": "List custom domains for a project",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "vercel",
+        "baseArgs": ["domains", "list"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install vercel: npm install -g vercel"
+      },
+      "args": []
+    },
+    {
+      "namespace": "vercel",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to vercel CLI for any command",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "vercel",
+        "passthrough": true,
+        "missingDependencyHelp": "Install vercel: npm install -g vercel. Authenticate: vercel login"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #307 (am/am-f17c27-th40ap): feat(plugins): add 4 new bundled plugins — slidev, espanso, wiki-tui, surrealdb
    touches: plugins/espanso/install-guidance.json, plugins/espanso/meta.json, plugins/espanso/plugin.json, plugins/espanso/skills/quickstart/SKILL.md, plugins/slidev/install-guidance.json, plugins/slidev/meta.json, plugins/slidev/plugin.json, plugins/slidev/skills/quickstart/SKILL.md, plugins/surrealdb/install-guidance.json, plugins/surrealdb/meta.json, plugins/surrealdb/plugin.json, plugins/surrealdb/skills/quickstart/SKILL.md (+4 more)
- PR #306 (am/am-f17c27-th3z6p): feat: add 5 new bundled plugins — deptry, flit, twine, memray, delve
    touches: plugins/delve/install-guidance.json, plugins/delve/meta.json, plugins/delve/plugin.json, plugins/delve/skills/quickstart/SKILL.md, plugins/deptry/install-guidance.json, plugins/deptry/meta.json, plugins/deptry/plugin.json, plugins/deptry/skills/quickstart/SKILL.md, plugins/flit/install-guidance.json, plugins/flit/meta.json, plugins/flit/plugin.json, plugins/flit/skills/quickstart/SKILL.md (+8 more)
- PR #305 (am/am-f17c27-th3y61): feat: add 4 new bundled plugins — httpie, unar, newsboat, tinygo
    touches: plugins/httpie/install-guidance.json, plugins/httpie/meta.json, plugins/httpie/plugin.json, plugins/newsboat/install-guidance.json, plugins/newsboat/meta.json, plugins/newsboat/plugin.json, plugins/tinygo/install-guidance.json, plugins/tinygo/meta.json, plugins/tinygo/plugin.json, plugins/unar/install-guidance.json, plugins/unar/meta.json, plugins/unar/plugin.json
- PR #304 (am/am-f17c27-th3x8p): feat: add 5 media/audio plugins — mediainfo, avifenc, metaflac, pamixer, oggenc
    touches: plugins/avifenc/install-guidance.json, plugins/avifenc/meta.json, plugins/avifenc/plugin.json, plugins/mediainfo/install-guidance.json, plugins/mediainfo/meta.json, plugins/mediainfo/plugin.json, plugins/metaflac/install-guidance.json, plugins/metaflac/meta.json, plugins/metaflac/plugin.json, plugins/oggenc/install-guidance.json, plugins/oggenc/meta.json, plugins/oggenc/plugin.json (+3 more)
- PR #281 (am/am-f17c27-th02lm): fix(k0s,k3s): set canonical source URLs
    touches: plugins/k0s/plugin.json, plugins/k3s/plugin.json, plugins/okteto-cli/plugin.json, plugins/oracle-cloud/plugin.json, plugins/up/plugin.json
- PR #280 (am/am-f17c27-th029w): feat: add fzf-make plugin — fuzzy-find and run make/just/npm targets
    touches: plugins/fzf-make/install-guidance.json, plugins/fzf-make/meta.json, plugins/fzf-make/plugin.json
- PR #272 (am/am-f17c27-tgzta5): feat: add 5 new plugins
    touches: plugins/frawk/install-guidance.json, plugins/frawk/meta.json, plugins/frawk/plugin.json, plugins/slumber/install-guidance.json, plugins/slumber/meta.json, plugins/slumber/plugin.json, plugins/vgrep/install-guidance.json, plugins/vgrep/meta.json, plugins/vgrep/plugin.json, plugins/xplr/install-guidance.json, plugins/xplr/meta.json, plugins/xplr/plugin.json (+3 more)
- PR #271 (am/am-f17c27-tgzsui): fix(aws): expand description and tags for discoverability
    touches: plugins/aws/meta.json, plugins/aws/plugin.json, plugins/delta/meta.json, plugins/delta/plugin.json, plugins/rg/meta.json, plugins/rg/plugin.json


**Branch:** `am/am-f17c27-th41i1`

## Summary

feat(plugins): add 3 new bundled plugins — vercel, directus, kamal

Adds three widely-used deployment and CMS CLI tools:
- **vercel**: Vercel CLI — deploy frontends, serverless functions, and full-stack apps with zero configuration. npm-installable, integrates with Git for preview deployments.
- **directus**: Directus headless CMS CLI — manage projects, collections, items, users, roles, schema migrations, and webhooks. Supports JSON output for AI agent integration.
- **kamal**: Kamal deployment tool from 37signals — zero-downtime deployments from Docker images to any Linux host via SSH. Uses Traefik for ingress routing.

All three are well-known, actively maintained tools from established organizations, filling gaps in the deployment and CMS categories.

**Diff:**
```
plugins/directus/install-guidance.json |  12 +++
 plugins/directus/meta.json             |   5 ++
 plugins/directus/plugin.json           | 140 ++++++++++++++++++++++++++++++++
 plugins/kamal/install-guidance.json    |  12 +++
 plugins/kamal/meta.json                |   5 ++
 plugins/kamal/plugin.json              | 144 +++++++++++++++++++++++++++++++++
 plugins/vercel/install-guidance.json   |  12 +++
 plugins/vercel/meta.json               |   5 ++
 plugins/vercel/plugin.json             | 114 ++++++++++++++++++++++++++
 9 files changed, 449 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Directus headless CMS plugin with CLI support for managing projects, collections, users, and database schema snapshots
  * Added Kamal deployment automation plugin supporting Docker deployments, rollbacks, application logs, and server management tasks
  * Added Vercel hosting plugin for managing cloud deployments, environment variables, custom domains, and accessing application logs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->