### PR TITLE
feat(plugins): add 4 new bundled plugins — ollama, pagefind, gptscript, staticrypt

### DIFF
--- a/plugins/gptscript/install-guidance.json
+++ b/plugins/gptscript/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "gptscript",
+  "binary": "gptscript",
+  "check": "which gptscript",
+  "install_steps": ["brew install gptscript", "curl -fsSL https://get.gptscript.ai/install.sh | sh"]
+}

--- a/plugins/gptscript/meta.json
+++ b/plugins/gptscript/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "gptscript — natural language programming framework for AI workflows",
+  "tags": ["gptscript", "ai", "llm", "scripting", "automation"],
+  "has_learn": false
+}

--- a/plugins/gptscript/plugin.json
+++ b/plugins/gptscript/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "gptscript",
+  "version": "0.1.0",
+  "description": "gptscript — natural language programming framework for AI workflows",
+  "source": "https://github.com/gptscript-ai/gptscript",
+  "checks": [
+    { "type": "binary", "name": "gptscript" }
+  ],
+  "install_guidance": {
+    "plugin": "gptscript",
+    "binary": "gptscript",
+    "check": "which gptscript",
+    "install_steps": ["brew install gptscript", "curl -fsSL https://get.gptscript.ai/install.sh | sh"],
+    "note": "Cross-platform. Available via Homebrew, direct script, or GitHub releases."
+  },
+  "commands": [
+    {
+      "namespace": "gptscript",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to gptscript CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "gptscript",
+        "passthrough": true,
+        "missingDependencyHelp": "Install gptscript: brew install gptscript"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ollama/install-guidance.json
+++ b/plugins/ollama/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "ollama",
+  "binary": "ollama",
+  "check": "which ollama",
+  "install_steps": ["curl -fsSL https://ollama.com/install.sh | sh"]
+}

--- a/plugins/ollama/meta.json
+++ b/plugins/ollama/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "ollama — run large language models locally with a simple CLI",
+  "tags": ["ollama", "ai", "llm", "machine-learning", "cli"],
+  "has_learn": false
+}

--- a/plugins/ollama/plugin.json
+++ b/plugins/ollama/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "ollama",
+  "version": "0.1.0",
+  "description": "ollama — run large language models locally with a simple CLI",
+  "source": "https://github.com/ollama/ollama",
+  "checks": [
+    { "type": "binary", "name": "ollama" }
+  ],
+  "install_guidance": {
+    "plugin": "ollama",
+    "binary": "ollama",
+    "check": "which ollama",
+    "install_steps": ["curl -fsSL https://ollama.com/install.sh | sh"],
+    "note": "System utility. Supports Linux, macOS, and Windows (WSL2)."
+  },
+  "commands": [
+    {
+      "namespace": "ollama",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to ollama CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ollama",
+        "passthrough": true,
+        "missingDependencyHelp": "Install ollama: curl -fsSL https://ollama.com/install.sh | sh"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pagefind/install-guidance.json
+++ b/plugins/pagefind/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "pagefind",
+  "binary": "pagefind",
+  "check": "which pagefind",
+  "install_steps": ["npm install -g pagefind"]
+}

--- a/plugins/pagefind/meta.json
+++ b/plugins/pagefind/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "pagefind — static site search indexer with zero-config setup",
+  "tags": ["pagefind", "search", "static-site", "jamstack", "documentation"],
+  "has_learn": false
+}

--- a/plugins/pagefind/plugin.json
+++ b/plugins/pagefind/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "pagefind",
+  "version": "0.1.0",
+  "description": "pagefind — static site search indexer with zero-config setup",
+  "source": "https://github.com/CloudCannon/pagefind",
+  "checks": [
+    { "type": "binary", "name": "pagefind" }
+  ],
+  "install_guidance": {
+    "plugin": "pagefind",
+    "binary": "pagefind",
+    "check": "which pagefind",
+    "install_steps": ["npm install -g pagefind"],
+    "note": "Node.js tool. Requires Node.js 18+."
+  },
+  "commands": [
+    {
+      "namespace": "pagefind",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to pagefind CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pagefind",
+        "passthrough": true,
+        "missingDependencyHelp": "Install pagefind: npm install -g pagefind"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/staticrypt/install-guidance.json
+++ b/plugins/staticrypt/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "staticrypt",
+  "binary": "staticrypt",
+  "check": "which staticrypt",
+  "install_steps": ["npm install -g staticrypt"]
+}

--- a/plugins/staticrypt/meta.json
+++ b/plugins/staticrypt/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "staticrypt — password-protect static HTML pages with encryption",
+  "tags": ["staticrypt", "encryption", "static-site", "security", "cli"],
+  "has_learn": false
+}

--- a/plugins/staticrypt/plugin.json
+++ b/plugins/staticrypt/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "staticrypt",
+  "version": "0.1.0",
+  "description": "staticrypt — password-protect static HTML pages with encryption",
+  "source": "https://github.com/robinmoisson/staticrypt",
+  "checks": [
+    { "type": "binary", "name": "staticrypt" }
+  ],
+  "install_guidance": {
+    "plugin": "staticrypt",
+    "binary": "staticrypt",
+    "check": "which staticrypt",
+    "install_steps": ["npm install -g staticrypt"],
+    "note": "Node.js tool. Requires Node.js 14+."
+  },
+  "commands": [
+    {
+      "namespace": "staticrypt",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to staticrypt CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "staticrypt",
+        "passthrough": true,
+        "missingDependencyHelp": "Install staticrypt: npm install -g staticrypt"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #309 (am/am-f17c27-th42fd): feat(plugins): add 10 new bundled plugins — pkgx, cotton, projen, cmus, massren, beets, editly, mpv, nasa-cli, pianobar
    touches: plugins/beets/install-guidance.json, plugins/beets/meta.json, plugins/beets/plugin.json, plugins/cmus/install-guidance.json, plugins/cmus/meta.json, plugins/cmus/plugin.json, plugins/cotton/install-guidance.json, plugins/cotton/meta.json, plugins/cotton/plugin.json, plugins/editly/install-guidance.json, plugins/editly/meta.json, plugins/editly/plugin.json (+18 more)
- PR #308 (am/am-f17c27-th41i1): feat(plugins): add vercel, directus, kamal — deployment and CMS CLIs
    touches: plugins/directus/install-guidance.json, plugins/directus/meta.json, plugins/directus/plugin.json, plugins/kamal/install-guidance.json, plugins/kamal/meta.json, plugins/kamal/plugin.json, plugins/vercel/install-guidance.json, plugins/vercel/meta.json, plugins/vercel/plugin.json
- PR #307 (am/am-f17c27-th40ap): feat(plugins): add 4 new bundled plugins — slidev, espanso, wiki-tui, surrealdb
    touches: plugins/espanso/install-guidance.json, plugins/espanso/meta.json, plugins/espanso/plugin.json, plugins/espanso/skills/quickstart/SKILL.md, plugins/slidev/install-guidance.json, plugins/slidev/meta.json, plugins/slidev/plugin.json, plugins/slidev/skills/quickstart/SKILL.md, plugins/surrealdb/install-guidance.json, plugins/surrealdb/meta.json, plugins/surrealdb/plugin.json, plugins/surrealdb/skills/quickstart/SKILL.md (+4 more)
- PR #306 (am/am-f17c27-th3z6p): feat: add 5 new bundled plugins — deptry, flit, twine, memray, delve
    touches: plugins/delve/install-guidance.json, plugins/delve/meta.json, plugins/delve/plugin.json, plugins/delve/skills/quickstart/SKILL.md, plugins/deptry/install-guidance.json, plugins/deptry/meta.json, plugins/deptry/plugin.json, plugins/deptry/skills/quickstart/SKILL.md, plugins/flit/install-guidance.json, plugins/flit/meta.json, plugins/flit/plugin.json, plugins/flit/skills/quickstart/SKILL.md (+8 more)
- PR #305 (am/am-f17c27-th3y61): feat: add 4 new bundled plugins — httpie, unar, newsboat, tinygo
    touches: plugins/httpie/install-guidance.json, plugins/httpie/meta.json, plugins/httpie/plugin.json, plugins/newsboat/install-guidance.json, plugins/newsboat/meta.json, plugins/newsboat/plugin.json, plugins/tinygo/install-guidance.json, plugins/tinygo/meta.json, plugins/tinygo/plugin.json, plugins/unar/install-guidance.json, plugins/unar/meta.json, plugins/unar/plugin.json
- PR #304 (am/am-f17c27-th3x8p): feat: add 5 media/audio plugins — mediainfo, avifenc, metaflac, pamixer, oggenc
    touches: plugins/avifenc/install-guidance.json, plugins/avifenc/meta.json, plugins/avifenc/plugin.json, plugins/mediainfo/install-guidance.json, plugins/mediainfo/meta.json, plugins/mediainfo/plugin.json, plugins/metaflac/install-guidance.json, plugins/metaflac/meta.json, plugins/metaflac/plugin.json, plugins/oggenc/install-guidance.json, plugins/oggenc/meta.json, plugins/oggenc/plugin.json (+3 more)
- PR #281 (am/am-f17c27-th02lm): fix(k0s,k3s): set canonical source URLs
    touches: plugins/k0s/plugin.json, plugins/k3s/plugin.json, plugins/okteto-cli/plugin.json, plugins/oracle-cloud/plugin.json, plugins/up/plugin.json
- PR #280 (am/am-f17c27-th029w): feat: add fzf-make plugin — fuzzy-find and run make/just/npm targets
    touches: plugins/fzf-make/install-guidance.json, plugins/fzf-make/meta.json, plugins/fzf-make/plugin.json


**Branch:** `am/am-f17c27-th43mp`

## Summary

Added 4 new bundled plugins: ollama (local LLM runner), pagefind (static site search indexer), gptscript (natural language programming framework), and staticrypt (password-protect static HTML pages). Each includes plugin.json, meta.json, and install-guidance.json following the standard schema. These fill gaps in AI tooling, static-site search, and encryption categories.

**Diff:**
```
plugins/gptscript/install-guidance.json  |  6 ++++++
 plugins/gptscript/meta.json              |  5 +++++
 plugins/gptscript/plugin.json            | 31 +++++++++++++++++++++++++++++++
 plugins/ollama/install-guidance.json     |  6 ++++++
 plugins/ollama/meta.json                 |  5 +++++
 plugins/ollama/plugin.json               | 31 +++++++++++++++++++++++++++++++
 plugins/pagefind/install-guidance.json   |  6 ++++++
 plugins/pagefind/meta.json               |  5 +++++
 plugins/pagefind/plugin.json             | 31 +++++++++++++++++++++++++++++++
 plugins/staticrypt/install-guidance.json |  6 ++++++
 plugins/staticrypt/meta.json             |  5 +++++
 plugins/staticrypt/plugin.json           | 31 +++++++++++++++++++++++++++++++
 12 files changed, 168 insertions(+)
```
