### PR TITLE
feat(plugins): add 5 new bundled plugins — typst, go-task, cfn-lint, envinfo, markdown-link-check

### DIFF
--- a/plugins/cfn-lint/install-guidance.json
+++ b/plugins/cfn-lint/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "cfn-lint",
+  "binary": "cfn-lint",
+  "check": "which cfn-lint",
+  "install_steps": [
+    "pip install cfn-lint",
+    "Verify: cfn-lint --version",
+    "supercli plugins install ./plugins/cfn-lint --on-conflict replace --json"
+  ],
+  "note": "Python tool. Install via pip or pipx: pipx install cfn-lint"
+}

--- a/plugins/cfn-lint/meta.json
+++ b/plugins/cfn-lint/meta.json
@@ -1,0 +1,11 @@
+{
+  "description": "CFN-Lint — AWS CloudFormation Linter, validates CloudFormation templates against best practices",
+  "tags": [
+    "aws",
+    "cloudformation",
+    "linter",
+    "infrastructure",
+    "validation"
+  ],
+  "has_learn": false
+}

--- a/plugins/cfn-lint/plugin.json
+++ b/plugins/cfn-lint/plugin.json
@@ -1,0 +1,53 @@
+{
+  "name": "cfn-lint",
+  "version": "0.1.0",
+  "description": "CFN-Lint — AWS CloudFormation Linter, validates CloudFormation templates against best practices",
+  "source": "https://github.com/aws-cloudformation/cfn-lint",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "cfn-lint"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "cfn-lint",
+    "binary": "cfn-lint",
+    "check": "which cfn-lint",
+    "install_steps": [
+      "pip install cfn-lint",
+      "Verify: cfn-lint --version",
+      "supercli plugins install ./plugins/cfn-lint --on-conflict replace --json"
+    ],
+    "note": "Python tool. Install via pip or pipx: pipx install cfn-lint"
+  },
+  "commands": [
+    {
+      "namespace": "cfn-lint",
+      "resource": "self",
+      "action": "version",
+      "description": "Print cfn-lint version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cfn-lint",
+        "baseArgs": [
+          "--version"
+        ],
+        "missingDependencyHelp": "Install cfn-lint: pip install cfn-lint"
+      },
+      "args": []
+    },
+    {
+      "namespace": "cfn-lint",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to cfn-lint CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "cfn-lint",
+        "passthrough": true,
+        "missingDependencyHelp": "Install cfn-lint"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/envinfo/install-guidance.json
+++ b/plugins/envinfo/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "envinfo",
+  "binary": "envinfo",
+  "check": "which envinfo",
+  "install_steps": [
+    "npm install -g envinfo",
+    "Verify: envinfo --version",
+    "supercli plugins install ./plugins/envinfo --on-conflict replace --json"
+  ],
+  "note": "Node.js tool. Install via npm."
+}

--- a/plugins/envinfo/meta.json
+++ b/plugins/envinfo/meta.json
@@ -1,0 +1,11 @@
+{
+  "description": "Envinfo — generate a report about the development environment for debugging and issue reporting",
+  "tags": [
+    "environment",
+    "debugging",
+    "system-info",
+    "development",
+    "report"
+  ],
+  "has_learn": false
+}

--- a/plugins/envinfo/plugin.json
+++ b/plugins/envinfo/plugin.json
@@ -1,0 +1,53 @@
+{
+  "name": "envinfo",
+  "version": "0.1.0",
+  "description": "Envinfo — generate a report about the development environment for debugging and issue reporting",
+  "source": "https://github.com/tabrindle/envinfo",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "envinfo"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "envinfo",
+    "binary": "envinfo",
+    "check": "which envinfo",
+    "install_steps": [
+      "npm install -g envinfo",
+      "Verify: envinfo --version",
+      "supercli plugins install ./plugins/envinfo --on-conflict replace --json"
+    ],
+    "note": "Node.js tool. Install via npm."
+  },
+  "commands": [
+    {
+      "namespace": "envinfo",
+      "resource": "self",
+      "action": "version",
+      "description": "Print envinfo version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "envinfo",
+        "baseArgs": [
+          "--version"
+        ],
+        "missingDependencyHelp": "Install envinfo: npm install -g envinfo"
+      },
+      "args": []
+    },
+    {
+      "namespace": "envinfo",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to envinfo CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "envinfo",
+        "passthrough": true,
+        "missingDependencyHelp": "Install envinfo"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/go-task/install-guidance.json
+++ b/plugins/go-task/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "go-task",
+  "binary": "task",
+  "check": "task --version",
+  "install_steps": [
+    "brew install go-task",
+    "Verify: task --version",
+    "supercli plugins install ./plugins/go-task --on-conflict replace --json"
+  ],
+  "note": "Install from package manager. Also via: go install github.com/go-task/task/v3/cmd/task@latest"
+}

--- a/plugins/go-task/meta.json
+++ b/plugins/go-task/meta.json
@@ -1,0 +1,11 @@
+{
+  "description": "Task — a task runner / build tool that aims to be simpler and easier to use than Make",
+  "tags": [
+    "task-runner",
+    "build-tool",
+    "make",
+    "automation",
+    "go"
+  ],
+  "has_learn": false
+}

--- a/plugins/go-task/plugin.json
+++ b/plugins/go-task/plugin.json
@@ -1,0 +1,68 @@
+{
+  "name": "go-task",
+  "version": "0.1.0",
+  "description": "Task — a task runner / build tool that aims to be simpler and easier to use than Make",
+  "source": "https://github.com/go-task/task",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "task"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "go-task",
+    "binary": "task",
+    "check": "task --version",
+    "install_steps": [
+      "brew install go-task",
+      "Verify: task --version",
+      "supercli plugins install ./plugins/go-task --on-conflict replace --json"
+    ],
+    "note": "Install from package manager. Also via: go install github.com/go-task/task/v3/cmd/task@latest"
+  },
+  "commands": [
+    {
+      "namespace": "task",
+      "resource": "self",
+      "action": "version",
+      "description": "Print task version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "task",
+        "baseArgs": [
+          "--version"
+        ],
+        "missingDependencyHelp": "Install go-task: brew install go-task"
+      },
+      "args": []
+    },
+    {
+      "namespace": "task",
+      "resource": "--list",
+      "action": "list",
+      "description": "List tasks in the project",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "task",
+        "baseArgs": [
+          "--list"
+        ],
+        "missingDependencyHelp": "Install go-task: brew install go-task"
+      },
+      "args": []
+    },
+    {
+      "namespace": "task",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to task CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "task",
+        "passthrough": true,
+        "missingDependencyHelp": "Install go-task"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/markdown-link-check/install-guidance.json
+++ b/plugins/markdown-link-check/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "markdown-link-check",
+  "binary": "markdown-link-check",
+  "check": "which markdown-link-check",
+  "install_steps": [
+    "npm install -g markdown-link-check",
+    "Verify: markdown-link-check --version",
+    "supercli plugins install ./plugins/markdown-link-check --on-conflict replace --json"
+  ],
+  "note": "Node.js tool. Install via npm."
+}

--- a/plugins/markdown-link-check/meta.json
+++ b/plugins/markdown-link-check/meta.json
@@ -1,0 +1,11 @@
+{
+  "description": "Markdown-link-check — checks all links in markdown files for broken or dead URLs",
+  "tags": [
+    "markdown",
+    "link-checker",
+    "documentation",
+    "validation",
+    "broken-links"
+  ],
+  "has_learn": false
+}

--- a/plugins/markdown-link-check/plugin.json
+++ b/plugins/markdown-link-check/plugin.json
@@ -1,0 +1,53 @@
+{
+  "name": "markdown-link-check",
+  "version": "0.1.0",
+  "description": "Markdown-link-check — checks all links in markdown files for broken or dead URLs",
+  "source": "https://github.com/tcort/markdown-link-check",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "markdown-link-check"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "markdown-link-check",
+    "binary": "markdown-link-check",
+    "check": "which markdown-link-check",
+    "install_steps": [
+      "npm install -g markdown-link-check",
+      "Verify: markdown-link-check --version",
+      "supercli plugins install ./plugins/markdown-link-check --on-conflict replace --json"
+    ],
+    "note": "Node.js tool. Install via npm."
+  },
+  "commands": [
+    {
+      "namespace": "markdown-link-check",
+      "resource": "self",
+      "action": "version",
+      "description": "Print markdown-link-check version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "markdown-link-check",
+        "baseArgs": [
+          "--version"
+        ],
+        "missingDependencyHelp": "Install markdown-link-check: npm install -g markdown-link-check"
+      },
+      "args": []
+    },
+    {
+      "namespace": "markdown-link-check",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to markdown-link-check CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "markdown-link-check",
+        "passthrough": true,
+        "missingDependencyHelp": "Install markdown-link-check"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/typst/install-guidance.json
+++ b/plugins/typst/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "typst",
+  "binary": "typst",
+  "check": "which typst",
+  "install_steps": [
+    "brew install typst",
+    "Verify: typst --version",
+    "supercli plugins install ./plugins/typst --on-conflict replace --json"
+  ],
+  "note": "Install from package manager. Also available via cargo: cargo install typst-cli"
+}

--- a/plugins/typst/meta.json
+++ b/plugins/typst/meta.json
@@ -1,0 +1,12 @@
+{
+  "description": "Typst — modern markup-based typesetting system, a LaTeX alternative",
+  "tags": [
+    "typesetting",
+    "document",
+    "pdf",
+    "latex",
+    "markup",
+    "typst"
+  ],
+  "has_learn": false
+}

--- a/plugins/typst/plugin.json
+++ b/plugins/typst/plugin.json
@@ -1,0 +1,53 @@
+{
+  "name": "typst",
+  "version": "0.1.0",
+  "description": "Typst — modern markup-based typesetting system, a LaTeX alternative",
+  "source": "https://github.com/typst/typst",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "typst"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "typst",
+    "binary": "typst",
+    "check": "which typst",
+    "install_steps": [
+      "brew install typst",
+      "Verify: typst --version",
+      "supercli plugins install ./plugins/typst --on-conflict replace --json"
+    ],
+    "note": "Install from package manager. Also available via cargo: cargo install typst-cli"
+  },
+  "commands": [
+    {
+      "namespace": "typst",
+      "resource": "self",
+      "action": "version",
+      "description": "Print typst version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "typst",
+        "baseArgs": [
+          "--version"
+        ],
+        "missingDependencyHelp": "Install typst: brew install typst"
+      },
+      "args": []
+    },
+    {
+      "namespace": "typst",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to typst CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "typst",
+        "passthrough": true,
+        "missingDependencyHelp": "Install typst"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #310 (am/am-f17c27-th43mp): feat(plugins): add 4 new bundled plugins — ollama, pagefind, gptscript, staticrypt
    touches: plugins/gptscript/install-guidance.json, plugins/gptscript/meta.json, plugins/gptscript/plugin.json, plugins/ollama/install-guidance.json, plugins/ollama/meta.json, plugins/ollama/plugin.json, plugins/pagefind/install-guidance.json, plugins/pagefind/meta.json, plugins/pagefind/plugin.json, plugins/staticrypt/install-guidance.json, plugins/staticrypt/meta.json, plugins/staticrypt/plugin.json
- PR #309 (am/am-f17c27-th42fd): feat(plugins): add 10 new bundled plugins — pkgx, cotton, projen, cmus, massren, beets, editly, mpv, nasa-cli, pianobar
    touches: plugins/beets/install-guidance.json, plugins/beets/meta.json, plugins/beets/plugin.json, plugins/cmus/install-guidance.json, plugins/cmus/meta.json, plugins/cmus/plugin.json, plugins/cotton/install-guidance.json, plugins/cotton/meta.json, plugins/cotton/plugin.json, plugins/editly/install-guidance.json, plugins/editly/meta.json, plugins/editly/plugin.json (+18 more)
- PR #308 (am/am-f17c27-th41i1): feat(plugins): add vercel, directus, kamal — deployment and CMS CLIs
    touches: plugins/directus/install-guidance.json, plugins/directus/meta.json, plugins/directus/plugin.json, plugins/kamal/install-guidance.json, plugins/kamal/meta.json, plugins/kamal/plugin.json, plugins/vercel/install-guidance.json, plugins/vercel/meta.json, plugins/vercel/plugin.json
- PR #307 (am/am-f17c27-th40ap): feat(plugins): add 4 new bundled plugins — slidev, espanso, wiki-tui, surrealdb
    touches: plugins/espanso/install-guidance.json, plugins/espanso/meta.json, plugins/espanso/plugin.json, plugins/espanso/skills/quickstart/SKILL.md, plugins/slidev/install-guidance.json, plugins/slidev/meta.json, plugins/slidev/plugin.json, plugins/slidev/skills/quickstart/SKILL.md, plugins/surrealdb/install-guidance.json, plugins/surrealdb/meta.json, plugins/surrealdb/plugin.json, plugins/surrealdb/skills/quickstart/SKILL.md (+4 more)
- PR #306 (am/am-f17c27-th3z6p): feat: add 5 new bundled plugins — deptry, flit, twine, memray, delve
    touches: plugins/delve/install-guidance.json, plugins/delve/meta.json, plugins/delve/plugin.json, plugins/delve/skills/quickstart/SKILL.md, plugins/deptry/install-guidance.json, plugins/deptry/meta.json, plugins/deptry/plugin.json, plugins/deptry/skills/quickstart/SKILL.md, plugins/flit/install-guidance.json, plugins/flit/meta.json, plugins/flit/plugin.json, plugins/flit/skills/quickstart/SKILL.md (+8 more)
- PR #305 (am/am-f17c27-th3y61): feat: add 4 new bundled plugins — httpie, unar, newsboat, tinygo
    touches: plugins/httpie/install-guidance.json, plugins/httpie/meta.json, plugins/httpie/plugin.json, plugins/newsboat/install-guidance.json, plugins/newsboat/meta.json, plugins/newsboat/plugin.json, plugins/tinygo/install-guidance.json, plugins/tinygo/meta.json, plugins/tinygo/plugin.json, plugins/unar/install-guidance.json, plugins/unar/meta.json, plugins/unar/plugin.json
- PR #304 (am/am-f17c27-th3x8p): feat: add 5 media/audio plugins — mediainfo, avifenc, metaflac, pamixer, oggenc
    touches: plugins/avifenc/install-guidance.json, plugins/avifenc/meta.json, plugins/avifenc/plugin.json, plugins/mediainfo/install-guidance.json, plugins/mediainfo/meta.json, plugins/mediainfo/plugin.json, plugins/metaflac/install-guidance.json, plugins/metaflac/meta.json, plugins/metaflac/plugin.json, plugins/oggenc/install-guidance.json, plugins/oggenc/meta.json, plugins/oggenc/plugin.json (+3 more)
- PR #281 (am/am-f17c27-th02lm): fix(k0s,k3s): set canonical source URLs
    touches: plugins/k0s/plugin.json, plugins/k3s/plugin.json, plugins/okteto-cli/plugin.json, plugins/oracle-cloud/plugin.json, plugins/up/plugin.json


**Branch:** `am/am-f17c27-th44xd`

## Summary

Add 5 new bundled plugins: typst (modern typesetting), go-task (task runner), cfn-lint (CloudFormation linter), envinfo (env reporting), markdown-link-check (broken link detection). These are well-established CLI tools with active GitHub repos and stable releases, filling gaps in the catalog's documentation, infrastructure, and development tooling sections.

**Diff:**
```
plugins/cfn-lint/install-guidance.json            | 11 ++++
 plugins/cfn-lint/meta.json                        | 11 ++++
 plugins/cfn-lint/plugin.json                      | 53 ++++++++++++++++++
 plugins/envinfo/install-guidance.json             | 11 ++++
 plugins/envinfo/meta.json                         | 11 ++++
 plugins/envinfo/plugin.json                       | 53 ++++++++++++++++++
 plugins/go-task/install-guidance.json             | 11 ++++
 plugins/go-task/meta.json                         | 11 ++++
 plugins/go-task/plugin.json                       | 68 +++++++++++++++++++++++
 plugins/markdown-link-check/install-guidance.json | 11 ++++
 plugins/markdown-link-check/meta.json             | 11 ++++
 plugins/markdown-link-check/plugin.json           | 53 ++++++++++++++++++
 plugins/typst/install-guidance.json               | 11 ++++
 plugins/typst/meta.json                           | 12 ++++
 plugins/typst/plugin.json                         | 53 ++++++++++++++++++
 15 files changed, 391 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added five new plugins: cfn-lint for CloudFormation validation, envinfo for system environment information, go-task for task execution, markdown-link-check for link validation, and typst for document typesetting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->