### PR TITLE
feat(plugins): add 5 new bundled plugins — mockery, mailhog, xcaddy, hostctl, maddy

### DIFF
--- a/plugins/hostctl/install-guidance.json
+++ b/plugins/hostctl/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "hostctl",
+  "binary": "hostctl",
+  "check": "hostctl version",
+  "install_steps": [
+    "go install github.com/guumaster/hostctl@latest",
+    "Verify: hostctl version",
+    "Or install via Homebrew: brew tap guumaster/tap && brew install hostctl",
+    "supercli plugins install ./plugins/hostctl --on-conflict replace --json"
+  ],
+  "note": "Requires Go 1.18+. Profiles make it easy to switch between different /etc/hosts configurations."
+}

--- a/plugins/hostctl/meta.json
+++ b/plugins/hostctl/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Manage /etc/hosts entries using named profiles for easy switching between environments",
+  "tags": ["hosts", "dns", "networking", "development", "devops"],
+  "has_learn": false
+}

--- a/plugins/hostctl/plugin.json
+++ b/plugins/hostctl/plugin.json
@@ -1,0 +1,169 @@
+{
+  "name": "hostctl",
+  "version": "0.1.0",
+  "description": "hostctl — Manage /etc/hosts with profiles. Organize host entries into named profiles, switch between them, and maintain a clean hosts file with simple CLI commands.",
+  "source": "https://github.com/guumaster/hostctl",
+  "checks": [
+    { "type": "binary", "name": "hostctl" }
+  ],
+  "install_guidance": {
+    "plugin": "hostctl",
+    "binary": "hostctl",
+    "check": "hostctl version",
+    "install_steps": [
+      "go install github.com/guumaster/hostctl@latest",
+      "Verify: hostctl version",
+      "Add profile: hostctl profile add myprofile",
+      "supercli plugins install ./plugins/hostctl --on-conflict replace --json"
+    ],
+    "note": "Requires Go 1.18+. Also available via Homebrew: brew tap guumaster/tap && brew install hostctl"
+  },
+  "commands": [
+    {
+      "namespace": "hostctl",
+      "resource": "profile",
+      "action": "list",
+      "description": "List all host profiles",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hostctl",
+        "baseArgs": ["profile", "list"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install hostctl: go install github.com/guumaster/hostctl@latest"
+      },
+      "args": []
+    },
+    {
+      "namespace": "hostctl",
+      "resource": "profile",
+      "action": "add",
+      "description": "Add a new host profile",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hostctl",
+        "baseArgs": ["profile", "add"],
+        "positionalArgs": ["name"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install hostctl: go install github.com/guumaster/hostctl@latest"
+      },
+      "args": [
+        { "name": "name", "type": "string", "required": true, "description": "Profile name" }
+      ]
+    },
+    {
+      "namespace": "hostctl",
+      "resource": "profile",
+      "action": "remove",
+      "description": "Remove a host profile",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hostctl",
+        "baseArgs": ["profile", "remove"],
+        "positionalArgs": ["name"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install hostctl: go install github.com/guumaster/hostctl@latest"
+      },
+      "args": [
+        { "name": "name", "type": "string", "required": true, "description": "Profile name" }
+      ]
+    },
+    {
+      "namespace": "hostctl",
+      "resource": "host",
+      "action": "add",
+      "description": "Add a host entry to a profile",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hostctl",
+        "baseArgs": ["host", "add"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install hostctl: go install github.com/guumaster/hostctl@latest"
+      },
+      "args": [
+        { "name": "--profile", "type": "string", "required": true, "description": "Profile name" },
+        { "name": "--ip", "type": "string", "required": true, "description": "IP address" },
+        { "name": "--hostname", "type": "string", "required": true, "description": "Hostname" }
+      ]
+    },
+    {
+      "namespace": "hostctl",
+      "resource": "host",
+      "action": "remove",
+      "description": "Remove a host entry from a profile",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hostctl",
+        "baseArgs": ["host", "remove"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install hostctl: go install github.com/guumaster/hostctl@latest"
+      },
+      "args": [
+        { "name": "--profile", "type": "string", "required": true, "description": "Profile name" },
+        { "name": "--hostname", "type": "string", "required": true, "description": "Hostname" }
+      ]
+    },
+    {
+      "namespace": "hostctl",
+      "resource": "host",
+      "action": "list",
+      "description": "List hosts in a profile",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hostctl",
+        "baseArgs": ["host", "list"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install hostctl: go install github.com/guumaster/hostctl@latest"
+      },
+      "args": [
+        { "name": "--profile", "type": "string", "required": true, "description": "Profile name" }
+      ]
+    },
+    {
+      "namespace": "hostctl",
+      "resource": "host",
+      "action": "enable",
+      "description": "Enable a profile (activate hosts)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hostctl",
+        "baseArgs": ["host", "enable"],
+        "positionalArgs": ["profile"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install hostctl"
+      },
+      "args": [
+        { "name": "profile", "type": "string", "required": true, "description": "Profile name to enable" }
+      ]
+    },
+    {
+      "namespace": "hostctl",
+      "resource": "host",
+      "action": "disable",
+      "description": "Disable a profile (deactivate hosts)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hostctl",
+        "baseArgs": ["host", "disable"],
+        "positionalArgs": ["profile"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install hostctl"
+      },
+      "args": [
+        { "name": "profile", "type": "string", "required": true, "description": "Profile name to disable" }
+      ]
+    },
+    {
+      "namespace": "hostctl",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to hostctl for any command",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hostctl",
+        "passthrough": true,
+        "missingDependencyHelp": "Install hostctl: go install github.com/guumaster/hostctl@latest"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/maddy/install-guidance.json
+++ b/plugins/maddy/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "maddy",
+  "binary": "maddy",
+  "check": "maddy --version",
+  "install_steps": [
+    "Download from https://github.com/foxcpp/maddy/releases",
+    "Or install via distro packages (see https://maddy.email/)",
+    "Configure: maddy test --config /etc/maddy/maddy.conf",
+    "Run: maddy run",
+    "supercli plugins install ./plugins/maddy --on-conflict replace --json"
+  ],
+  "note": "All-in-one mail server. Configuration at https://maddy.email/."
+}

--- a/plugins/maddy/meta.json
+++ b/plugins/maddy/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Composable all-in-one mail server replacing Postfix, Dovecot, and OpenDKIM with a single daemon",
+  "tags": ["email", "mail-server", "smtp", "imap", "self-hosted"],
+  "has_learn": false
+}

--- a/plugins/maddy/plugin.json
+++ b/plugins/maddy/plugin.json
@@ -1,0 +1,86 @@
+{
+  "name": "maddy",
+  "version": "0.1.0",
+  "description": "maddy — Composable all-in-one mail server. Replace Postfix, Dovecot, OpenDKIM, OpenSPF, OpenDMARC with a single daemon with SMTP, IMAP, JMAP, and submission support.",
+  "source": "https://github.com/foxcpp/maddy",
+  "checks": [
+    { "type": "binary", "name": "maddy" }
+  ],
+  "install_guidance": {
+    "plugin": "maddy",
+    "binary": "maddy",
+    "check": "maddy --version",
+    "install_steps": [
+      "Download from https://github.com/foxcpp/maddy/releases",
+      "Or use distribution packages: https://maddy.email/",
+      "Configure: edit /etc/maddy/maddy.conf",
+      "Run: maddy run",
+      "supercli plugins install ./plugins/maddy --on-conflict replace --json"
+    ],
+    "note": "Replaces multiple mail server components with a single binary. See https://maddy.email/ for configuration guide."
+  },
+  "commands": [
+    {
+      "namespace": "maddy",
+      "resource": "server",
+      "action": "run",
+      "description": "Start maddy mail server",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "maddy",
+        "baseArgs": ["run"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install maddy from https://github.com/foxcpp/maddy/releases"
+      },
+      "args": [
+        { "name": "--config", "type": "string", "required": false, "description": "Config file path" }
+      ]
+    },
+    {
+      "namespace": "maddy",
+      "resource": "server",
+      "action": "test",
+      "description": "Test maddy configuration",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "maddy",
+        "baseArgs": ["test"],
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "Install maddy"
+      },
+      "args": [
+        { "name": "--config", "type": "string", "required": false, "description": "Config file to test" }
+      ]
+    },
+    {
+      "namespace": "maddy",
+      "resource": "creds",
+      "action": "hash",
+      "description": "Hash a password for maddy authentication",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "maddy",
+        "baseArgs": ["hash"],
+        "positionalArgs": ["password"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install maddy"
+      },
+      "args": [
+        { "name": "password", "type": "string", "required": true, "description": "Password to hash" }
+      ]
+    },
+    {
+      "namespace": "maddy",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to maddy for any command",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "maddy",
+        "passthrough": true,
+        "missingDependencyHelp": "Install maddy from https://github.com/foxcpp/maddy/releases"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mailhog/install-guidance.json
+++ b/plugins/mailhog/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "mailhog",
+  "binary": "mailhog",
+  "check": "mailhog version",
+  "install_steps": [
+    "brew install mailhog",
+    "Or download binary from https://github.com/mailhog/MailHog/releases",
+    "Run: mailhog (starts SMTP on :1025, web UI on :8025)",
+    "supercli plugins install ./plugins/mailhog --on-conflict replace --json"
+  ],
+  "note": "Starts SMTP server on port 1025 and web UI on port 8025. Use with mhsendmail for PHP integration."
+}

--- a/plugins/mailhog/meta.json
+++ b/plugins/mailhog/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Web and API-based SMTP testing tool for capturing and viewing test emails during development",
+  "tags": ["email", "smtp", "testing", "development", "web-ui"],
+  "has_learn": false
+}

--- a/plugins/mailhog/plugin.json
+++ b/plugins/mailhog/plugin.json
@@ -1,0 +1,86 @@
+{
+  "name": "mailhog",
+  "version": "0.1.0",
+  "description": "MailHog — Web and API-based SMTP testing tool. Catch and view test emails in a local web UI during development with JSON API access and auto-reload.",
+  "source": "https://github.com/mailhog/MailHog",
+  "checks": [
+    { "type": "binary", "name": "mailhog" },
+    { "type": "binary", "name": "mhsendmail" }
+  ],
+  "install_guidance": {
+    "plugin": "mailhog",
+    "binary": "mailhog",
+    "check": "mailhog version",
+    "install_steps": [
+      "brew install mailhog",
+      "Or download from https://github.com/mailhog/MailHog/releases",
+      "Run: mailhog (starts SMTP on :1025, web UI on :8025)",
+      "supercli plugins install ./plugins/mailhog --on-conflict replace --json"
+    ],
+    "note": "Also install mhsendmail to redirect PHP sendmail to MailHog: go install github.com/mailhog/mhsendmail@latest"
+  },
+  "commands": [
+    {
+      "namespace": "mailhog",
+      "resource": "server",
+      "action": "start",
+      "description": "Start MailHog SMTP test server (default :1025 SMTP, :8025 HTTP)",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mailhog",
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install mailhog: brew install mailhog"
+      },
+      "args": [
+        { "name": "--smtp-bind-addr", "type": "string", "required": false, "description": "SMTP bind address (default 0.0.0.0:1025)" },
+        { "name": "--api-bind-addr", "type": "string", "required": false, "description": "API bind address (default 0.0.0.0:8025)" },
+        { "name": "--ui-bind-addr", "type": "string", "required": false, "description": "Web UI bind address (default 0.0.0.0:8025)" },
+        { "name": "--storage", "type": "string", "required": false, "description": "Storage type: memory or mongodb (default memory)" }
+      ]
+    },
+    {
+      "namespace": "mailhog",
+      "resource": "api",
+      "action": "messages",
+      "description": "List captured messages via MailHog API",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "curl",
+        "baseArgs": ["-s", "http://localhost:8025/api/v2/messages"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Start MailHog first: mailhog"
+      },
+      "args": [
+        { "name": "--limit", "type": "number", "required": false, "description": "Limit results (default 50)" },
+        { "name": "--start", "type": "number", "required": false, "description": "Start offset" }
+      ]
+    },
+    {
+      "namespace": "mailhog",
+      "resource": "api",
+      "action": "delete",
+      "description": "Delete all captured messages",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "curl",
+        "baseArgs": ["-s", "-X", "DELETE", "http://localhost:8025/api/v1/messages"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Start MailHog first: mailhog"
+      },
+      "args": []
+    },
+    {
+      "namespace": "mailhog",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to mailhog for any command",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mailhog",
+        "passthrough": true,
+        "missingDependencyHelp": "Install mailhog: brew install mailhog"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mockery/install-guidance.json
+++ b/plugins/mockery/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "mockery",
+  "binary": "mockery",
+  "check": "mockery --version",
+  "install_steps": [
+    "go install github.com/vektra/mockery/v2@latest",
+    "Verify: mockery --version",
+    "Or install via Homebrew: brew install mockery",
+    "supercli plugins install ./plugins/mockery --on-conflict replace --json"
+  ],
+  "note": "Requires Go 1.20+. Homebrew is an alternative install method."
+}

--- a/plugins/mockery/meta.json
+++ b/plugins/mockery/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Go mock code generator that automatically generates mock implementations from Go interface definitions with testify support",
+  "tags": ["go", "testing", "mocking", "code-generation", "golang"],
+  "has_learn": false
+}

--- a/plugins/mockery/plugin.json
+++ b/plugins/mockery/plugin.json
@@ -1,0 +1,80 @@
+{
+  "name": "mockery",
+  "version": "0.1.0",
+  "description": "mockery — Go mock code generator. Automatically generates mock implementations from Go interface definitions with support for testify, mockgen compatibility, and in-package mocks.",
+  "source": "https://github.com/vektra/mockery",
+  "checks": [
+    { "type": "binary", "name": "mockery" }
+  ],
+  "install_guidance": {
+    "plugin": "mockery",
+    "binary": "mockery",
+    "check": "mockery --version",
+    "install_steps": [
+      "go install github.com/vektra/mockery/v2@latest",
+      "Verify: mockery --version",
+      "supercli plugins install ./plugins/mockery --on-conflict replace --json"
+    ],
+    "note": "Requires Go 1.20+. Alternatively install via brew: brew install mockery"
+  },
+  "commands": [
+    {
+      "namespace": "mockery",
+      "resource": "mock",
+      "action": "generate",
+      "description": "Generate mock for a Go interface by name",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mockery",
+        "baseArgs": ["--name"],
+        "positionalArgs": ["name"],
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install mockery: go install github.com/vektra/mockery/v2@latest"
+      },
+      "args": [
+        { "name": "name", "type": "string", "required": true, "description": "Interface name to mock" },
+        { "name": "--srcpkg", "type": "string", "required": false, "description": "Source package path" },
+        { "name": "--dir", "type": "string", "required": false, "description": "Directory to search for interfaces" },
+        { "name": "--output", "type": "string", "required": false, "description": "Output directory for mocks" },
+        { "name": "--testonly", "type": "boolean", "required": false, "description": "Generate mocks in _test.go files" },
+        { "name": "--inpackage", "type": "boolean", "required": false, "description": "Generate mock inside the source package" },
+        { "name": "--all", "type": "boolean", "required": false, "description": "Generate mocks for all interfaces found" },
+        { "name": "--recursive", "type": "boolean", "required": false, "description": "Search directories recursively" }
+      ]
+    },
+    {
+      "namespace": "mockery",
+      "resource": "mock",
+      "action": "all",
+      "description": "Generate mocks for all interfaces in a package",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mockery",
+        "baseArgs": ["--all"],
+        "passthrough": true,
+        "timeout_ms": 120000,
+        "missingDependencyHelp": "Install mockery: go install github.com/vektra/mockery/v2@latest"
+      },
+      "args": [
+        { "name": "--dir", "type": "string", "required": false, "description": "Root directory to search" },
+        { "name": "--recursive", "type": "boolean", "required": false, "description": "Search recursively" },
+        { "name": "--output", "type": "string", "required": false, "description": "Output directory" },
+        { "name": "--inpackage", "type": "boolean", "required": false, "description": "In-package mocks" },
+        { "name": "--testonly", "type": "boolean", "required": false, "description": "Test-only mocks" }
+      ]
+    },
+    {
+      "namespace": "mockery",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to mockery for any command",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mockery",
+        "passthrough": true,
+        "missingDependencyHelp": "Install mockery: go install github.com/vektra/mockery/v2@latest"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/xcaddy/install-guidance.json
+++ b/plugins/xcaddy/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "xcaddy",
+  "binary": "xcaddy",
+  "check": "xcaddy version",
+  "install_steps": [
+    "go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest",
+    "Verify: xcaddy version",
+    "Or install via Homebrew: brew install xcaddy",
+    "supercli plugins install ./plugins/xcaddy --on-conflict replace --json"
+  ],
+  "note": "Requires Go 1.20+. Build a custom Caddy: xcaddy build --with github.com/caddyserver/nginx-adapter"
+}

--- a/plugins/xcaddy/meta.json
+++ b/plugins/xcaddy/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Build Caddy web server with custom plugins and modules from the command line",
+  "tags": ["caddy", "web-server", "go", "build-tool", "plugins"],
+  "has_learn": false
+}

--- a/plugins/xcaddy/plugin.json
+++ b/plugins/xcaddy/plugin.json
@@ -1,0 +1,56 @@
+{
+  "name": "xcaddy",
+  "version": "0.1.0",
+  "description": "xcaddy — Build Caddy with custom plugins. Compile a custom Caddy binary with specific modules and versions using a simple command-line interface.",
+  "source": "https://github.com/caddyserver/xcaddy",
+  "checks": [
+    { "type": "binary", "name": "xcaddy" }
+  ],
+  "install_guidance": {
+    "plugin": "xcaddy",
+    "binary": "xcaddy",
+    "check": "xcaddy version",
+    "install_steps": [
+      "go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest",
+      "Verify: xcaddy version",
+      "Build Caddy with plugins: xcaddy build --with github.com/caddyserver/nginx-adapter",
+      "supercli plugins install ./plugins/xcaddy --on-conflict replace --json"
+    ],
+    "note": "Requires Go 1.20+. Alternatively install via brew: brew install xcaddy"
+  },
+  "commands": [
+    {
+      "namespace": "xcaddy",
+      "resource": "build",
+      "action": "caddy",
+      "description": "Build Caddy with specified plugins",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "xcaddy",
+        "baseArgs": ["build"],
+        "passthrough": true,
+        "timeout_ms": 300000,
+        "missingDependencyHelp": "Install xcaddy: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest"
+      },
+      "args": [
+        { "name": "version", "type": "string", "required": false, "description": "Caddy version to build (default latest)" },
+        { "name": "--with", "type": "string", "required": false, "description": "Plugin to include (can repeat: --with foo --with bar)" },
+        { "name": "--output", "type": "string", "required": false, "description": "Output binary path" },
+        { "name": "--replace", "type": "string", "required": false, "description": "Go module replacement directive" }
+      ]
+    },
+    {
+      "namespace": "xcaddy",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to xcaddy for any command",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "xcaddy",
+        "passthrough": true,
+        "missingDependencyHelp": "Install xcaddy: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #311 (am/am-f17c27-th44xd): feat(plugins): add 5 new bundled plugins — typst, go-task, cfn-lint, envinfo, markdown-link-check
    touches: plugins/cfn-lint/install-guidance.json, plugins/cfn-lint/meta.json, plugins/cfn-lint/plugin.json, plugins/envinfo/install-guidance.json, plugins/envinfo/meta.json, plugins/envinfo/plugin.json, plugins/go-task/install-guidance.json, plugins/go-task/meta.json, plugins/go-task/plugin.json, plugins/markdown-link-check/install-guidance.json, plugins/markdown-link-check/meta.json, plugins/markdown-link-check/plugin.json (+3 more)
- PR #310 (am/am-f17c27-th43mp): feat(plugins): add 4 new bundled plugins — ollama, pagefind, gptscript, staticrypt
    touches: plugins/gptscript/install-guidance.json, plugins/gptscript/meta.json, plugins/gptscript/plugin.json, plugins/ollama/install-guidance.json, plugins/ollama/meta.json, plugins/ollama/plugin.json, plugins/pagefind/install-guidance.json, plugins/pagefind/meta.json, plugins/pagefind/plugin.json, plugins/staticrypt/install-guidance.json, plugins/staticrypt/meta.json, plugins/staticrypt/plugin.json
- PR #309 (am/am-f17c27-th42fd): feat(plugins): add 10 new bundled plugins — pkgx, cotton, projen, cmus, massren, beets, editly, mpv, nasa-cli, pianobar
    touches: plugins/beets/install-guidance.json, plugins/beets/meta.json, plugins/beets/plugin.json, plugins/cmus/install-guidance.json, plugins/cmus/meta.json, plugins/cmus/plugin.json, plugins/cotton/install-guidance.json, plugins/cotton/meta.json, plugins/cotton/plugin.json, plugins/editly/install-guidance.json, plugins/editly/meta.json, plugins/editly/plugin.json (+18 more)
- PR #308 (am/am-f17c27-th41i1): feat(plugins): add vercel, directus, kamal — deployment and CMS CLIs
    touches: plugins/directus/install-guidance.json, plugins/directus/meta.json, plugins/directus/plugin.json, plugins/kamal/install-guidance.json, plugins/kamal/meta.json, plugins/kamal/plugin.json, plugins/vercel/install-guidance.json, plugins/vercel/meta.json, plugins/vercel/plugin.json
- PR #307 (am/am-f17c27-th40ap): feat(plugins): add 4 new bundled plugins — slidev, espanso, wiki-tui, surrealdb
    touches: plugins/espanso/install-guidance.json, plugins/espanso/meta.json, plugins/espanso/plugin.json, plugins/espanso/skills/quickstart/SKILL.md, plugins/slidev/install-guidance.json, plugins/slidev/meta.json, plugins/slidev/plugin.json, plugins/slidev/skills/quickstart/SKILL.md, plugins/surrealdb/install-guidance.json, plugins/surrealdb/meta.json, plugins/surrealdb/plugin.json, plugins/surrealdb/skills/quickstart/SKILL.md (+4 more)
- PR #306 (am/am-f17c27-th3z6p): feat: add 5 new bundled plugins — deptry, flit, twine, memray, delve
    touches: plugins/delve/install-guidance.json, plugins/delve/meta.json, plugins/delve/plugin.json, plugins/delve/skills/quickstart/SKILL.md, plugins/deptry/install-guidance.json, plugins/deptry/meta.json, plugins/deptry/plugin.json, plugins/deptry/skills/quickstart/SKILL.md, plugins/flit/install-guidance.json, plugins/flit/meta.json, plugins/flit/plugin.json, plugins/flit/skills/quickstart/SKILL.md (+8 more)
- PR #305 (am/am-f17c27-th3y61): feat: add 4 new bundled plugins — httpie, unar, newsboat, tinygo
    touches: plugins/httpie/install-guidance.json, plugins/httpie/meta.json, plugins/httpie/plugin.json, plugins/newsboat/install-guidance.json, plugins/newsboat/meta.json, plugins/newsboat/plugin.json, plugins/tinygo/install-guidance.json, plugins/tinygo/meta.json, plugins/tinygo/plugin.json, plugins/unar/install-guidance.json, plugins/unar/meta.json, plugins/unar/plugin.json
- PR #304 (am/am-f17c27-th3x8p): feat: add 5 media/audio plugins — mediainfo, avifenc, metaflac, pamixer, oggenc
    touches: plugins/avifenc/install-guidance.json, plugins/avifenc/meta.json, plugins/avifenc/plugin.json, plugins/mediainfo/install-guidance.json, plugins/mediainfo/meta.json, plugins/mediainfo/plugin.json, plugins/metaflac/install-guidance.json, plugins/metaflac/meta.json, plugins/metaflac/plugin.json, plugins/oggenc/install-guidance.json, plugins/oggenc/meta.json, plugins/oggenc/plugin.json (+3 more)


**Branch:** `am/am-f17c27-th45xh`

## Summary

Add 5 new bundled plugins to the supercli catalog:
- mockery: Go mock code generator (github.com/vektra/mockery)
- mailhog: SMTP testing tool with web UI (github.com/mailhog/MailHog)
- xcaddy: Build Caddy with custom plugins (github.com/caddyserver/xcaddy)
- hostctl: Manage /etc/hosts with profiles (github.com/guumaster/hostctl)
- maddy: Composable all-in-one mail server (github.com/foxcpp/maddy)

Each plugin has plugin.json with command definitions, meta.json for registry metadata, and install-guidance.json for installation instructions. No existing files were modified. Closes #299 and #301 were not addressed as they require different changes outside scope.

**Diff:**
```
plugins/hostctl/install-guidance.json |  12 +++
 plugins/hostctl/meta.json             |   5 +
 plugins/hostctl/plugin.json           | 169 ++++++++++++++++++++++++++++++++++
 plugins/maddy/install-guidance.json   |  13 +++
 plugins/maddy/meta.json               |   5 +
 plugins/maddy/plugin.json             |  86 +++++++++++++++++
 plugins/mailhog/install-guidance.json |  12 +++
 plugins/mailhog/meta.json             |   5 +
 plugins/mailhog/plugin.json           |  86 +++++++++++++++++
 plugins/mockery/install-guidance.json |  12 +++
 plugins/mockery/meta.json             |   5 +
 plugins/mockery/plugin.json           |  80 ++++++++++++++++
 plugins/xcaddy/install-guidance.json  |  12 +++
 plugins/xcaddy/meta.json              |   5 +
 plugins/xcaddy/plugin.json            |  56 +++++++++++
 15 files changed, 563 insertions(+)
```
