### PR TITLE
feat(plugins): add web-ext, pscale, flox, zarf, amplify-cli

### DIFF
--- a/plugins/amplify-cli/install-guidance.json
+++ b/plugins/amplify-cli/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "amplify-cli",
+  "binary": "amplify",
+  "check": "which amplify",
+  "install_steps": [
+    "npm install -g @aws-amplify/cli",
+    "Verify: amplify --version",
+    "supercli plugins install ./plugins/amplify-cli --on-conflict replace --json"
+  ]
+}

--- a/plugins/amplify-cli/meta.json
+++ b/plugins/amplify-cli/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "amplify-cli — AWS Amplify CLI for fullstack serverless application development",
+  "tags": ["amplify", "aws", "serverless", "cli", "cloud", "fullstack"],
+  "has_learn": false
+}

--- a/plugins/amplify-cli/plugin.json
+++ b/plugins/amplify-cli/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "amplify-cli",
+  "version": "0.1.0",
+  "description": "amplify-cli — AWS Amplify CLI for fullstack serverless application development",
+  "source": "https://github.com/aws-amplify/amplify-cli",
+  "checks": [
+    { "type": "binary", "name": "amplify" }
+  ],
+  "install_guidance": {
+    "plugin": "amplify-cli",
+    "binary": "amplify",
+    "check": "which amplify",
+    "install_steps": ["npm install -g @aws-amplify/cli"],
+    "note": "Fullstack serverless application development on AWS."
+  },
+  "commands": [
+    {
+      "namespace": "amplify-cli",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to amplify CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "amplify",
+        "passthrough": true,
+        "missingDependencyHelp": "Install amplify: npm install -g @aws-amplify/cli"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/flox/install-guidance.json
+++ b/plugins/flox/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "flox",
+  "binary": "flox",
+  "check": "which flox",
+  "install_steps": [
+    "brew install flox",
+    "Verify: flox --version",
+    "supercli plugins install ./plugins/flox --on-conflict replace --json"
+  ]
+}

--- a/plugins/flox/meta.json
+++ b/plugins/flox/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "flox — Nix-powered development environment and package manager CLI",
+  "tags": ["flox", "nix", "dev-environment", "cli", "devops", "package-manager"],
+  "has_learn": false
+}

--- a/plugins/flox/plugin.json
+++ b/plugins/flox/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "flox",
+  "version": "0.1.0",
+  "description": "flox — Nix-powered development environment and package manager CLI",
+  "source": "https://github.com/flox/flox",
+  "checks": [
+    { "type": "binary", "name": "flox" }
+  ],
+  "install_guidance": {
+    "plugin": "flox",
+    "binary": "flox",
+    "check": "which flox",
+    "install_steps": ["brew install flox"],
+    "note": "Reproducible development environments powered by Nix."
+  },
+  "commands": [
+    {
+      "namespace": "flox",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to flox CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "flox",
+        "passthrough": true,
+        "missingDependencyHelp": "Install flox: brew install flox"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pscale/install-guidance.json
+++ b/plugins/pscale/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "pscale",
+  "binary": "pscale",
+  "check": "which pscale",
+  "install_steps": [
+    "brew install planetscale/tap/pscale",
+    "Verify: pscale --version",
+    "supercli plugins install ./plugins/pscale --on-conflict replace --json"
+  ]
+}

--- a/plugins/pscale/meta.json
+++ b/plugins/pscale/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "pscale — PlanetScale database CLI for branch, deploy, and schema management",
+  "tags": ["pscale", "planetscale", "database", "mysql", "cli", "devops"],
+  "has_learn": false
+}

--- a/plugins/pscale/plugin.json
+++ b/plugins/pscale/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "pscale",
+  "version": "0.1.0",
+  "description": "pscale — PlanetScale database CLI for branch, deploy, and schema management",
+  "source": "https://github.com/planetscale/cli",
+  "checks": [
+    { "type": "binary", "name": "pscale" }
+  ],
+  "install_guidance": {
+    "plugin": "pscale",
+    "binary": "pscale",
+    "check": "which pscale",
+    "install_steps": ["brew install planetscale/tap/pscale"],
+    "note": "PlanetScale database management from the terminal."
+  },
+  "commands": [
+    {
+      "namespace": "pscale",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to pscale CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pscale",
+        "passthrough": true,
+        "missingDependencyHelp": "Install pscale: brew install planetscale/tap/pscale"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/web-ext/install-guidance.json
+++ b/plugins/web-ext/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "web-ext",
+  "binary": "web-ext",
+  "check": "which web-ext",
+  "install_steps": [
+    "npm install -g web-ext",
+    "Verify: web-ext --version",
+    "supercli plugins install ./plugins/web-ext --on-conflict replace --json"
+  ]
+}

--- a/plugins/web-ext/meta.json
+++ b/plugins/web-ext/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "web-ext — Mozilla web extension development and signing CLI",
+  "tags": ["web-ext", "mozilla", "firefox", "extension", "cli", "nodejs", "development"],
+  "has_learn": false
+}

--- a/plugins/web-ext/plugin.json
+++ b/plugins/web-ext/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "web-ext",
+  "version": "0.1.0",
+  "description": "web-ext — Mozilla web extension development and signing CLI",
+  "source": "https://github.com/mozilla/web-ext",
+  "checks": [
+    { "type": "binary", "name": "web-ext" }
+  ],
+  "install_guidance": {
+    "plugin": "web-ext",
+    "binary": "web-ext",
+    "check": "which web-ext",
+    "install_steps": ["npm install -g web-ext"],
+    "note": "Tool for browser extension development and automated signing."
+  },
+  "commands": [
+    {
+      "namespace": "web-ext",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to web-ext CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "web-ext",
+        "passthrough": true,
+        "missingDependencyHelp": "Install web-ext: npm install -g web-ext"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/zarf/install-guidance.json
+++ b/plugins/zarf/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "zarf",
+  "binary": "zarf",
+  "check": "which zarf",
+  "install_steps": [
+    "brew install zarf",
+    "Verify: zarf version",
+    "supercli plugins install ./plugins/zarf --on-conflict replace --json"
+  ]
+}

--- a/plugins/zarf/meta.json
+++ b/plugins/zarf/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "zarf — Kubernetes air-gap deployment and software delivery CLI",
+  "tags": ["zarf", "kubernetes", "k8s", "air-gap", "cli", "devops", "deployment"],
+  "has_learn": false
+}

--- a/plugins/zarf/plugin.json
+++ b/plugins/zarf/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "zarf",
+  "version": "0.1.0",
+  "description": "zarf — Kubernetes air-gap deployment and software delivery CLI",
+  "source": "https://github.com/zarf-dev/zarf",
+  "checks": [
+    { "type": "binary", "name": "zarf" }
+  ],
+  "install_guidance": {
+    "plugin": "zarf",
+    "binary": "zarf",
+    "check": "which zarf",
+    "install_steps": ["brew install zarf"],
+    "note": "Declarative Kubernetes air-gap deployment tool."
+  },
+  "commands": [
+    {
+      "namespace": "zarf",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to zarf CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "zarf",
+        "passthrough": true,
+        "missingDependencyHelp": "Install zarf: brew install zarf"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #313 (am/am-f17c27-th46y5): feat(plugins): add 5 new bundled plugins — git-town, prowler, terraform-docs, conventional-changelog-cli, ncat
    touches: plugins/conventional-changelog-cli/install-guidance.json, plugins/conventional-changelog-cli/meta.json, plugins/conventional-changelog-cli/plugin.json, plugins/git-town/install-guidance.json, plugins/git-town/meta.json, plugins/git-town/plugin.json, plugins/ncat/install-guidance.json, plugins/ncat/meta.json, plugins/ncat/plugin.json, plugins/prowler/install-guidance.json, plugins/prowler/meta.json, plugins/prowler/plugin.json (+3 more)
- PR #312 (am/am-f17c27-th45xh): feat(plugins): add 5 new bundled plugins — mockery, mailhog, xcaddy, hostctl, maddy
    touches: plugins/hostctl/install-guidance.json, plugins/hostctl/meta.json, plugins/hostctl/plugin.json, plugins/maddy/install-guidance.json, plugins/maddy/meta.json, plugins/maddy/plugin.json, plugins/mailhog/install-guidance.json, plugins/mailhog/meta.json, plugins/mailhog/plugin.json, plugins/mockery/install-guidance.json, plugins/mockery/meta.json, plugins/mockery/plugin.json (+3 more)
- PR #311 (am/am-f17c27-th44xd): feat(plugins): add 5 new bundled plugins — typst, go-task, cfn-lint, envinfo, markdown-link-check
    touches: plugins/cfn-lint/install-guidance.json, plugins/cfn-lint/meta.json, plugins/cfn-lint/plugin.json, plugins/envinfo/install-guidance.json, plugins/envinfo/meta.json, plugins/envinfo/plugin.json, plugins/go-task/install-guidance.json, plugins/go-task/meta.json, plugins/go-task/plugin.json, plugins/markdown-link-check/install-guidance.json, plugins/markdown-link-check/meta.json, plugins/markdown-link-check/plugin.json (+3 more)
- PR #310 (am/am-f17c27-th43mp): feat(plugins): add 4 new bundled plugins — ollama, pagefind, gptscript, staticrypt
    touches: plugins/gptscript/install-guidance.json, plugins/gptscript/meta.json, plugins/gptscript/plugin.json, plugins/ollama/install-guidance.json, plugins/ollama/meta.json, plugins/ollama/plugin.json, plugins/pagefind/install-guidance.json, plugins/pagefind/meta.json, plugins/pagefind/plugin.json, plugins/staticrypt/install-guidance.json, plugins/staticrypt/meta.json, plugins/staticrypt/plugin.json
- PR #309 (am/am-f17c27-th42fd): feat(plugins): add 10 new bundled plugins — pkgx, cotton, projen, cmus, massren, beets, editly, mpv, nasa-cli, pianobar
    touches: plugins/beets/install-guidance.json, plugins/beets/meta.json, plugins/beets/plugin.json, plugins/cmus/install-guidance.json, plugins/cmus/meta.json, plugins/cmus/plugin.json, plugins/cotton/install-guidance.json, plugins/cotton/meta.json, plugins/cotton/plugin.json, plugins/editly/install-guidance.json, plugins/editly/meta.json, plugins/editly/plugin.json (+18 more)
- PR #308 (am/am-f17c27-th41i1): feat(plugins): add vercel, directus, kamal — deployment and CMS CLIs
    touches: plugins/directus/install-guidance.json, plugins/directus/meta.json, plugins/directus/plugin.json, plugins/kamal/install-guidance.json, plugins/kamal/meta.json, plugins/kamal/plugin.json, plugins/vercel/install-guidance.json, plugins/vercel/meta.json, plugins/vercel/plugin.json
- PR #307 (am/am-f17c27-th40ap): feat(plugins): add 4 new bundled plugins — slidev, espanso, wiki-tui, surrealdb
    touches: plugins/espanso/install-guidance.json, plugins/espanso/meta.json, plugins/espanso/plugin.json, plugins/espanso/skills/quickstart/SKILL.md, plugins/slidev/install-guidance.json, plugins/slidev/meta.json, plugins/slidev/plugin.json, plugins/slidev/skills/quickstart/SKILL.md, plugins/surrealdb/install-guidance.json, plugins/surrealdb/meta.json, plugins/surrealdb/plugin.json, plugins/surrealdb/skills/quickstart/SKILL.md (+4 more)
- PR #306 (am/am-f17c27-th3z6p): feat: add 5 new bundled plugins — deptry, flit, twine, memray, delve
    touches: plugins/delve/install-guidance.json, plugins/delve/meta.json, plugins/delve/plugin.json, plugins/delve/skills/quickstart/SKILL.md, plugins/deptry/install-guidance.json, plugins/deptry/meta.json, plugins/deptry/plugin.json, plugins/deptry/skills/quickstart/SKILL.md, plugins/flit/install-guidance.json, plugins/flit/meta.json, plugins/flit/plugin.json, plugins/flit/skills/quickstart/SKILL.md (+8 more)


**Branch:** `am/am-f17c27-th47vh`

## Summary

Added 5 new bundled plugins: web-ext (Mozilla web extension CLI), pscale (PlanetScale database CLI), flox (Nix-powered dev environment manager), zarf (K8s air-gap deployment tool), and amplify-cli (AWS Amplify fullstack development CLI). Each plugin includes plugin.json, meta.json, and install-guidance.json following the standard schema. No existing files were modified.

**Diff:**
```
plugins/amplify-cli/install-guidance.json | 10 ++++++++++
 plugins/amplify-cli/meta.json             |  5 +++++
 plugins/amplify-cli/plugin.json           | 31 +++++++++++++++++++++++++++++++
 plugins/flox/install-guidance.json        | 10 ++++++++++
 plugins/flox/meta.json                    |  5 +++++
 plugins/flox/plugin.json                  | 31 +++++++++++++++++++++++++++++++
 plugins/pscale/install-guidance.json      | 10 ++++++++++
 plugins/pscale/meta.json                  |  5 +++++
 plugins/pscale/plugin.json                | 31 +++++++++++++++++++++++++++++++
 plugins/web-ext/install-guidance.json     | 10 ++++++++++
 plugins/web-ext/meta.json                 |  5 +++++
 plugins/web-ext/plugin.json               | 31 +++++++++++++++++++++++++++++++
 plugins/zarf/install-guidance.json        | 10 ++++++++++
 plugins/zarf/meta.json                    |  5 +++++
 plugins/zarf/plugin.json                  | 31 +++++++++++++++++++++++++++++++
 15 files changed, 230 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for five new CLI plugins:
    * Amplify CLI for fullstack serverless application development
    * Flox for Nix-powered development environments
    * PlanetScale CLI for database management
    * Web-ext for Firefox extension development
    * Zarf for Kubernetes deployment and air-gap package management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->