### PR TITLE
feat(plugins): add 5 new bundled plugins — aider, browser-sync, sqlcmd, sort-package-json, madge

### DIFF
--- a/plugins/aider/install-guidance.json
+++ b/plugins/aider/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "aider",
+  "binary": "aider",
+  "check": "which aider",
+  "install_steps": [
+    "pip install aider-chat",
+    "Verify: aider --version"
+  ],
+  "note": "Requires Python 3.9+. Set ANTHROPIC_API_KEY or OPENAI_API_KEY for LLM access."
+}

--- a/plugins/aider/meta.json
+++ b/plugins/aider/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "aider — AI pair programming in the terminal. Edit code in your local git repo with LLM assistance.",
+  "tags": ["aider", "ai", "coding", "python", "llm", "assistant"],
+  "has_learn": true
+}

--- a/plugins/aider/plugin.json
+++ b/plugins/aider/plugin.json
@@ -1,0 +1,56 @@
+{
+  "name": "aider",
+  "version": "0.1.0",
+  "description": "aider — AI pair programming in the terminal",
+  "source": "https://github.com/paul-gauthier/aider",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "aider"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "aider",
+    "binary": "aider",
+    "check": "which aider",
+    "install_steps": [
+      "pip install aider-chat",
+      "Verify: aider --version",
+      "supercli plugins install ./plugins/aider --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "aider",
+      "resource": "self",
+      "action": "version",
+      "description": "Print aider version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "aider",
+        "missingDependencyHelp": "Install aider: pip install aider-chat",
+        "baseArgs": [
+          "--version"
+        ]
+      },
+      "args": []
+    },
+    {
+      "namespace": "aider",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to aider CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "aider",
+        "missingDependencyHelp": "Install aider: pip install aider-chat",
+        "passthrough": true,
+        "timeout_ms": 120000
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/aider/skills/quickstart/SKILL.md
+++ b/plugins/aider/skills/quickstart/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: aider
+description: Use this skill when the user wants to use AI pair programming to edit code in the terminal.
+---
+
+# Aider Plugin
+
+AI pair programming tool that lets you edit code in your local git repo with LLM assistance.
+
+## Commands
+
+### Basic
+- `aider _ _` — Passthrough to aider CLI
+
+## Usage Examples
+- "Help me refactor this function using aider"
+- "Use aider to add error handling to the API routes"
+- "Run aider to fix the bug in src/main.py"
+
+## Installation
+
+```bash
+pip install aider-chat
+```
+
+## Key Features
+- Edit code in your local git repository
+- Multiple LLM support (Claude, GPT-4, etc.)
+- Automatic git commits
+- In-chat file editing
+- Voice coding support

--- a/plugins/browser-sync/install-guidance.json
+++ b/plugins/browser-sync/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "browser-sync",
+  "binary": "browser-sync",
+  "check": "which browser-sync",
+  "install_steps": [
+    "npm install -g browser-sync",
+    "Verify: browser-sync --version"
+  ],
+  "note": "Requires Node.js. Commonly used with gulp or npm scripts."
+}

--- a/plugins/browser-sync/meta.json
+++ b/plugins/browser-sync/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "browser-sync — time-saving synchronised browser testing. Syncs file changes and interactions across multiple devices.",
+  "tags": ["browser-sync", "testing", "web", "development", "node"],
+  "has_learn": true
+}

--- a/plugins/browser-sync/plugin.json
+++ b/plugins/browser-sync/plugin.json
@@ -1,0 +1,56 @@
+{
+  "name": "browser-sync",
+  "version": "0.1.0",
+  "description": "browser-sync — time-saving synchronised browser testing",
+  "source": "https://github.com/BrowserSync/browser-sync",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "browser-sync"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "browser-sync",
+    "binary": "browser-sync",
+    "check": "which browser-sync",
+    "install_steps": [
+      "npm install -g browser-sync",
+      "Verify: browser-sync --version",
+      "supercli plugins install ./plugins/browser-sync --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "browser-sync",
+      "resource": "self",
+      "action": "version",
+      "description": "Print browser-sync version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "browser-sync",
+        "missingDependencyHelp": "Install browser-sync: npm install -g browser-sync",
+        "baseArgs": [
+          "--version"
+        ]
+      },
+      "args": []
+    },
+    {
+      "namespace": "browser-sync",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to browser-sync CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "browser-sync",
+        "missingDependencyHelp": "Install browser-sync: npm install -g browser-sync",
+        "passthrough": true,
+        "timeout_ms": 30000
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/browser-sync/skills/quickstart/SKILL.md
+++ b/plugins/browser-sync/skills/quickstart/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: browser-sync
+description: Use this skill when the user wants to synchronise browser testing across multiple devices.
+---
+
+# BrowserSync Plugin
+
+Time-saving synchronised browser testing. It watches files and reloads browsers across devices.
+
+## Commands
+
+### Basic
+- `browser-sync _ _` — Passthrough to browser-sync CLI
+
+## Usage Examples
+- "Start browser-sync for my project"
+- "Watch the src directory and reload on changes"
+- "Start a local server with browser-sync"
+
+## Installation
+
+```bash
+npm install -g browser-sync
+```
+
+## Key Features
+- Live CSS injection (no full page reloads)
+- Synchronised scroll, click, and form actions across devices
+- File watching with automatic reload
+- Proxy mode for existing servers
+- Static server mode

--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "generated_at": "2026-06-23T14:31:41.626Z",
-  "count": 10011,
+  "generated_at": "2026-06-24T03:16:36.168Z",
+  "count": 10016,
   "plugins": [
     {
       "name": "100-exercises-to-learn-rust",
@@ -510,6 +510,10 @@
     {
       "name": "aide",
       "checksum": "79092c492f054228"
+    },
+    {
+      "name": "aider",
+      "checksum": "0282bb2f6ae675f8"
     },
     {
       "name": "ain",
@@ -3262,6 +3266,10 @@
     {
       "name": "browser-cookie",
       "checksum": "d1c5b2abc86c236f"
+    },
+    {
+      "name": "browser-sync",
+      "checksum": "ad437528b0a4669c"
     },
     {
       "name": "browserify",
@@ -22128,6 +22136,10 @@
       "checksum": "abe188d196658576"
     },
     {
+      "name": "madge",
+      "checksum": "bcb6cb06bdb42cf3"
+    },
+    {
       "name": "mado",
       "checksum": "871d26b22d4afa30"
     },
@@ -33132,6 +33144,10 @@
       "checksum": "cc98d9929416e386"
     },
     {
+      "name": "sort-package-json",
+      "checksum": "28074861a8d82d80"
+    },
+    {
       "name": "sot",
       "checksum": "807f900e4788536d"
     },
@@ -33426,6 +33442,10 @@
     {
       "name": "sqlc",
       "checksum": "ae0dd60a8e781e7e"
+    },
+    {
+      "name": "sqlcmd",
+      "checksum": "5be7739978231f7c"
     },
     {
       "name": "sqld",

--- a/plugins/madge/install-guidance.json
+++ b/plugins/madge/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "madge",
+  "binary": "madge",
+  "check": "which madge",
+  "install_steps": [
+    "npm install -g madge",
+    "Verify: madge --version"
+  ],
+  "note": "Generate image output with --image flag (requires Graphviz). Install: apt-get install graphviz."
+}

--- a/plugins/madge/meta.json
+++ b/plugins/madge/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "madge — generate module dependency graphs for JavaScript/TypeScript/CommonJS/AMD projects",
+  "tags": ["madge", "dependencies", "graph", "javascript", "typescript", "analysis"],
+  "has_learn": true
+}

--- a/plugins/madge/plugin.json
+++ b/plugins/madge/plugin.json
@@ -1,0 +1,79 @@
+{
+  "name": "madge",
+  "version": "0.1.0",
+  "description": "madge — generate module dependency graphs for JavaScript/TypeScript projects",
+  "source": "https://github.com/pahen/madge",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "madge"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "madge",
+    "binary": "madge",
+    "check": "which madge",
+    "install_steps": [
+      "npm install -g madge",
+      "Verify: madge --version",
+      "supercli plugins install ./plugins/madge --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "madge",
+      "resource": "self",
+      "action": "version",
+      "description": "Print madge version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "madge",
+        "missingDependencyHelp": "Install madge: npm install -g madge",
+        "baseArgs": [
+          "--version"
+        ]
+      },
+      "args": []
+    },
+    {
+      "namespace": "madge",
+      "resource": "graph",
+      "action": "generate",
+      "description": "Generate a dependency graph for a project",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "madge",
+        "missingDependencyHelp": "Install madge: npm install -g madge",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "cwd": "invoke_cwd"
+      },
+      "args": [
+        {
+          "name": "args",
+          "type": "string",
+          "required": false,
+          "description": "Additional arguments"
+        }
+      ]
+    },
+    {
+      "namespace": "madge",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to madge CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "madge",
+        "missingDependencyHelp": "Install madge: npm install -g madge",
+        "passthrough": true,
+        "timeout_ms": 30000,
+        "cwd": "invoke_cwd"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/madge/skills/quickstart/SKILL.md
+++ b/plugins/madge/skills/quickstart/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: madge
+description: Use this skill when the user wants to generate module dependency graphs for JavaScript/TypeScript projects.
+---
+
+# madge Plugin
+
+Generate module dependency graphs for JavaScript/TypeScript/CommonJS/AMD projects.
+
+## Commands
+
+### Graph
+- `madge graph generate` — Generate a dependency graph
+
+### Basic
+- `madge _ _` — Passthrough to madge CLI
+
+## Usage Examples
+- "Generate a dependency graph for this project"
+- "Find circular dependencies in my codebase"
+- "Visualise module dependencies as an image"
+
+## Installation
+
+```bash
+npm install -g madge
+```
+
+## Key Features
+- Detect circular dependencies
+- Generate dependency graphs (text, JSON, or image)
+- Support for CommonJS, AMD, ES6, TypeScript
+- Webpack resolver support
+- Image output with Graphviz

--- a/plugins/sort-package-json/install-guidance.json
+++ b/plugins/sort-package-json/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "sort-package-json",
+  "binary": "sort-package-json",
+  "check": "which sort-package-json",
+  "install_steps": [
+    "npm install -g sort-package-json",
+    "Verify: sort-package-json --version"
+  ],
+  "note": "Optionally also install eslint-plugin-sort-package-json for IDE integration."
+}

--- a/plugins/sort-package-json/meta.json
+++ b/plugins/sort-package-json/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "sort-package-json — sort package.json files alphabetically with consistent ordering for Node.js projects",
+  "tags": ["sort-package-json", "node", "npm", "package.json", "formatter"],
+  "has_learn": true
+}

--- a/plugins/sort-package-json/plugin.json
+++ b/plugins/sort-package-json/plugin.json
@@ -1,0 +1,79 @@
+{
+  "name": "sort-package-json",
+  "version": "0.1.0",
+  "description": "sort-package-json — sort package.json alphabetically",
+  "source": "https://github.com/keithamus/sort-package-json",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "sort-package-json"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "sort-package-json",
+    "binary": "sort-package-json",
+    "check": "which sort-package-json",
+    "install_steps": [
+      "npm install -g sort-package-json",
+      "Verify: sort-package-json --version",
+      "supercli plugins install ./plugins/sort-package-json --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "sort-package-json",
+      "resource": "self",
+      "action": "version",
+      "description": "Print sort-package-json version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sort-package-json",
+        "missingDependencyHelp": "Install sort-package-json: npm install -g sort-package-json",
+        "baseArgs": [
+          "--version"
+        ]
+      },
+      "args": []
+    },
+    {
+      "namespace": "sort-package-json",
+      "resource": "file",
+      "action": "sort",
+      "description": "Sort a package.json file",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sort-package-json",
+        "missingDependencyHelp": "Install sort-package-json: npm install -g sort-package-json",
+        "passthrough": true,
+        "timeout_ms": 10000,
+        "cwd": "invoke_cwd"
+      },
+      "args": [
+        {
+          "name": "files",
+          "type": "string",
+          "required": false,
+          "description": "Files to sort (defaults to package.json)"
+        }
+      ]
+    },
+    {
+      "namespace": "sort-package-json",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to sort-package-json CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sort-package-json",
+        "missingDependencyHelp": "Install sort-package-json: npm install -g sort-package-json",
+        "passthrough": true,
+        "timeout_ms": 10000,
+        "cwd": "invoke_cwd"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/sort-package-json/skills/quickstart/SKILL.md
+++ b/plugins/sort-package-json/skills/quickstart/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: sort-package-json
+description: Use this skill when the user wants to sort a package.json file alphabetically.
+---
+
+# sort-package-json Plugin
+
+Sort package.json files alphabetically for consistent ordering in Node.js projects.
+
+## Commands
+
+### Sort
+- `sort-package-json file sort` — Sort package.json files
+
+### Basic
+- `sort-package-json _ _` — Passthrough to sort-package-json CLI
+
+## Usage Examples
+- "Sort the package.json in this project"
+- "Run sort-package-json to organise dependencies"
+
+## Installation
+
+```bash
+npm install -g sort-package-json
+```
+
+## Key Features
+- Sorts package.json keys alphabetically
+- Sorts dependencies, devDependencies, scripts, etc.
+- Consistent ordering across projects
+- Preserves JSON formatting and comments

--- a/plugins/sqlcmd/install-guidance.json
+++ b/plugins/sqlcmd/install-guidance.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "sqlcmd",
+  "binary": "sqlcmd",
+  "check": "which sqlcmd",
+  "install_steps": [
+    "npm install -g sqlcmd",
+    "Verify: sqlcmd --version"
+  ],
+  "note": "Also available via: brew install sqlcmd (macOS), or download from Microsoft. The npm package is the go-sqlcmd CLI."
+}

--- a/plugins/sqlcmd/meta.json
+++ b/plugins/sqlcmd/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "sqlcmd — Microsoft SQL Server command-line query tool. Query and manage SQL Server, Azure SQL DB, and Azure Synapse.",
+  "tags": ["sqlcmd", "sql-server", "database", "microsoft", "sql"],
+  "has_learn": true
+}

--- a/plugins/sqlcmd/plugin.json
+++ b/plugins/sqlcmd/plugin.json
@@ -1,0 +1,56 @@
+{
+  "name": "sqlcmd",
+  "version": "0.1.0",
+  "description": "sqlcmd — Microsoft SQL Server command-line query tool",
+  "source": "https://github.com/microsoft/go-sqlcmd",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "sqlcmd"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "sqlcmd",
+    "binary": "sqlcmd",
+    "check": "which sqlcmd",
+    "install_steps": [
+      "npm install -g sqlcmd",
+      "Verify: sqlcmd --version",
+      "supercli plugins install ./plugins/sqlcmd --on-conflict replace --json"
+    ]
+  },
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
+  "commands": [
+    {
+      "namespace": "sqlcmd",
+      "resource": "self",
+      "action": "version",
+      "description": "Print sqlcmd version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sqlcmd",
+        "missingDependencyHelp": "Install sqlcmd: npm install -g sqlcmd",
+        "baseArgs": [
+          "--version"
+        ]
+      },
+      "args": []
+    },
+    {
+      "namespace": "sqlcmd",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to sqlcmd CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "sqlcmd",
+        "missingDependencyHelp": "Install sqlcmd: npm install -g sqlcmd",
+        "passthrough": true,
+        "timeout_ms": 30000
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/sqlcmd/skills/quickstart/SKILL.md
+++ b/plugins/sqlcmd/skills/quickstart/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: sqlcmd
+description: Use this skill when the user wants to query Microsoft SQL Server from the command line.
+---
+
+# sqlcmd Plugin
+
+Microsoft SQL Server command-line query tool. Query and manage SQL Server, Azure SQL DB, and Azure Synapse.
+
+## Commands
+
+### Basic
+- `sqlcmd _ _` — Passthrough to sqlcmd CLI
+
+## Usage Examples
+- "Query SQL Server using sqlcmd"
+- "Run a SQL script against Azure SQL Database"
+- "List all databases on the server"
+
+## Installation
+
+```bash
+npm install -g sqlcmd
+```
+
+## Key Features
+- Run Transact-SQL queries
+- Connect to SQL Server, Azure SQL DB, Azure Synapse
+- Script execution and output formatting
+- Windows, macOS, and Linux support


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #314 (am/am-f17c27-th47vh): feat(plugins): add web-ext, pscale, flox, zarf, amplify-cli
    touches: plugins/amplify-cli/install-guidance.json, plugins/amplify-cli/meta.json, plugins/amplify-cli/plugin.json, plugins/flox/install-guidance.json, plugins/flox/meta.json, plugins/flox/plugin.json, plugins/pscale/install-guidance.json, plugins/pscale/meta.json, plugins/pscale/plugin.json, plugins/web-ext/install-guidance.json, plugins/web-ext/meta.json, plugins/web-ext/plugin.json (+3 more)
- PR #313 (am/am-f17c27-th46y5): feat(plugins): add 5 new bundled plugins — git-town, prowler, terraform-docs, conventional-changelog-cli, ncat
    touches: plugins/conventional-changelog-cli/install-guidance.json, plugins/conventional-changelog-cli/meta.json, plugins/conventional-changelog-cli/plugin.json, plugins/git-town/install-guidance.json, plugins/git-town/meta.json, plugins/git-town/plugin.json, plugins/ncat/install-guidance.json, plugins/ncat/meta.json, plugins/ncat/plugin.json, plugins/prowler/install-guidance.json, plugins/prowler/meta.json, plugins/prowler/plugin.json (+3 more)
- PR #312 (am/am-f17c27-th45xh): feat(plugins): add 5 new bundled plugins — mockery, mailhog, xcaddy, hostctl, maddy
    touches: plugins/hostctl/install-guidance.json, plugins/hostctl/meta.json, plugins/hostctl/plugin.json, plugins/maddy/install-guidance.json, plugins/maddy/meta.json, plugins/maddy/plugin.json, plugins/mailhog/install-guidance.json, plugins/mailhog/meta.json, plugins/mailhog/plugin.json, plugins/mockery/install-guidance.json, plugins/mockery/meta.json, plugins/mockery/plugin.json (+3 more)
- PR #311 (am/am-f17c27-th44xd): feat(plugins): add 5 new bundled plugins — typst, go-task, cfn-lint, envinfo, markdown-link-check
    touches: plugins/cfn-lint/install-guidance.json, plugins/cfn-lint/meta.json, plugins/cfn-lint/plugin.json, plugins/envinfo/install-guidance.json, plugins/envinfo/meta.json, plugins/envinfo/plugin.json, plugins/go-task/install-guidance.json, plugins/go-task/meta.json, plugins/go-task/plugin.json, plugins/markdown-link-check/install-guidance.json, plugins/markdown-link-check/meta.json, plugins/markdown-link-check/plugin.json (+3 more)
- PR #310 (am/am-f17c27-th43mp): feat(plugins): add 4 new bundled plugins — ollama, pagefind, gptscript, staticrypt
    touches: plugins/gptscript/install-guidance.json, plugins/gptscript/meta.json, plugins/gptscript/plugin.json, plugins/ollama/install-guidance.json, plugins/ollama/meta.json, plugins/ollama/plugin.json, plugins/pagefind/install-guidance.json, plugins/pagefind/meta.json, plugins/pagefind/plugin.json, plugins/staticrypt/install-guidance.json, plugins/staticrypt/meta.json, plugins/staticrypt/plugin.json
- PR #309 (am/am-f17c27-th42fd): feat(plugins): add 10 new bundled plugins — pkgx, cotton, projen, cmus, massren, beets, editly, mpv, nasa-cli, pianobar
    touches: plugins/beets/install-guidance.json, plugins/beets/meta.json, plugins/beets/plugin.json, plugins/cmus/install-guidance.json, plugins/cmus/meta.json, plugins/cmus/plugin.json, plugins/cotton/install-guidance.json, plugins/cotton/meta.json, plugins/cotton/plugin.json, plugins/editly/install-guidance.json, plugins/editly/meta.json, plugins/editly/plugin.json (+18 more)
- PR #308 (am/am-f17c27-th41i1): feat(plugins): add vercel, directus, kamal — deployment and CMS CLIs
    touches: plugins/directus/install-guidance.json, plugins/directus/meta.json, plugins/directus/plugin.json, plugins/kamal/install-guidance.json, plugins/kamal/meta.json, plugins/kamal/plugin.json, plugins/vercel/install-guidance.json, plugins/vercel/meta.json, plugins/vercel/plugin.json
- PR #307 (am/am-f17c27-th40ap): feat(plugins): add 4 new bundled plugins — slidev, espanso, wiki-tui, surrealdb
    touches: plugins/espanso/install-guidance.json, plugins/espanso/meta.json, plugins/espanso/plugin.json, plugins/espanso/skills/quickstart/SKILL.md, plugins/slidev/install-guidance.json, plugins/slidev/meta.json, plugins/slidev/plugin.json, plugins/slidev/skills/quickstart/SKILL.md, plugins/surrealdb/install-guidance.json, plugins/surrealdb/meta.json, plugins/surrealdb/plugin.json, plugins/surrealdb/skills/quickstart/SKILL.md (+4 more)


**Branch:** `am/am-f17c27-th48w5`

## Summary

Added 5 new bundled plugins: aider (AI pair programming CLI), browser-sync (synchronised browser testing), sqlcmd (Microsoft SQL Server CLI), sort-package-json (sort package.json files), and madge (module dependency graph generator). Each includes plugin.json, meta.json, install-guidance.json, and skills/quickstart/SKILL.md following the isolated plugin convention. Catalog regenerated (10016 plugins).

**Diff:**
```
plugins/aider/install-guidance.json                | 10 +++
 plugins/aider/meta.json                            |  5 ++
 plugins/aider/plugin.json                          | 56 +++++++++++++++
 plugins/aider/skills/quickstart/SKILL.md           | 31 +++++++++
 plugins/browser-sync/install-guidance.json         | 10 +++
 plugins/browser-sync/meta.json                     |  5 ++
 plugins/browser-sync/plugin.json                   | 56 +++++++++++++++
 plugins/browser-sync/skills/quickstart/SKILL.md    | 31 +++++++++
 plugins/catalog.json                               | 24 ++++++-
 plugins/madge/install-guidance.json                | 10 +++
 plugins/madge/meta.json                            |  5 ++
 plugins/madge/plugin.json                          | 79 ++++++++++++++++++++++
 plugins/madge/skills/quickstart/SKILL.md           | 34 ++++++++++
 plugins/sort-package-json/install-guidance.json    | 10 +++
 plugins/sort-package-json/meta.json                |  5 ++
 plugins/sort-package-json/plugin.json              | 79 ++++++++++++++++++++++
 .../sort-package-json/skills/quickstart/SKILL.md   | 32 +++++++++
 plugins/sqlcmd/install-guidance.json               | 10 +++
 plugins/sqlcmd/meta.json                           |  5 ++
 plugins/sqlcmd/plugin.json                         | 56 +++++++++++++++
 plugins/sqlcmd/skills/quickstart/SKILL.md          | 30 ++++++++
 21 files changed, 581 insertions(+), 2 deletions(-)
```
