### PR TITLE
feat(plugins): add 5 new bundled plugins — httpie, aichat, detekt, diffsitter, taskwarrior-tui

### DIFF
--- a/plugins/aichat/install-guidance.json
+++ b/plugins/aichat/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "aichat",
+  "binary": "aichat",
+  "check": "which aichat",
+  "install_steps": ["cargo install aichat", "Verify: aichat --version", "supercli plugins install ./plugins/aichat --on-conflict replace --json"]
+}

--- a/plugins/aichat/meta.json
+++ b/plugins/aichat/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "All-in-one LLM CLI tool for chatting with ChatGPT, Claude, Gemini, and other AI models in the terminal",
+  "tags": ["aichat", "cli-tool", "ai", "llm", "chat"],
+  "has_learn": false
+}

--- a/plugins/aichat/plugin.json
+++ b/plugins/aichat/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "aichat",
+  "version": "0.1.0",
+  "description": "All-in-one LLM CLI tool for chatting with ChatGPT, Claude, Gemini, and other AI models in the terminal",
+  "source": "https://github.com/sigoden/aichat",
+  "checks": [{ "type": "binary", "name": "aichat" }],
+  "install_guidance": {
+    "plugin": "aichat",
+    "binary": "aichat",
+    "check": "which aichat",
+    "install_steps": ["cargo install aichat", "Verify: aichat --version", "supercli plugins install ./plugins/aichat --on-conflict replace --json"]
+  },
+  "commands": [{
+    "namespace": "aichat",
+    "resource": "_",
+    "action": "_",
+    "description": "Passthrough to aichat CLI",
+    "adapter": "process",
+    "adapterConfig": {
+      "command": "aichat",
+      "passthrough": true,
+      "missingDependencyHelp": "Install aichat: cargo install aichat"
+    },
+    "args": []
+  }]
+}

--- a/plugins/detekt/install-guidance.json
+++ b/plugins/detekt/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "detekt",
+  "binary": "detekt",
+  "check": "which detekt",
+  "install_steps": ["brew install detekt", "Verify: detekt --version", "supercli plugins install ./plugins/detekt --on-conflict replace --json"]
+}

--- a/plugins/detekt/meta.json
+++ b/plugins/detekt/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Static code analysis tool for Kotlin, detecting code smells, complexity issues, and style violations",
+  "tags": ["detekt", "cli-tool", "kotlin", "linter", "static-analysis"],
+  "has_learn": false
+}

--- a/plugins/detekt/plugin.json
+++ b/plugins/detekt/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "detekt",
+  "version": "0.1.0",
+  "description": "Static code analysis tool for Kotlin, detecting code smells, complexity issues, and style violations",
+  "source": "https://github.com/detekt/detekt",
+  "checks": [{ "type": "binary", "name": "detekt" }],
+  "install_guidance": {
+    "plugin": "detekt",
+    "binary": "detekt",
+    "check": "which detekt",
+    "install_steps": ["brew install detekt", "Verify: detekt --version", "supercli plugins install ./plugins/detekt --on-conflict replace --json"]
+  },
+  "commands": [{
+    "namespace": "detekt",
+    "resource": "_",
+    "action": "_",
+    "description": "Passthrough to detekt CLI",
+    "adapter": "process",
+    "adapterConfig": {
+      "command": "detekt",
+      "passthrough": true,
+      "missingDependencyHelp": "Install detekt: brew install detekt"
+    },
+    "args": []
+  }]
+}

--- a/plugins/diffsitter/install-guidance.json
+++ b/plugins/diffsitter/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "diffsitter",
+  "binary": "diffsitter",
+  "check": "which diffsitter",
+  "install_steps": ["cargo install diffsitter", "Verify: diffsitter --version", "supercli plugins install ./plugins/diffsitter --on-conflict replace --json"]
+}

--- a/plugins/diffsitter/meta.json
+++ b/plugins/diffsitter/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Structural diff tool based on AST analysis, producing semantic diffs rather than line-based diffs",
+  "tags": ["diffsitter", "cli-tool", "diff", "ast", "code-review"],
+  "has_learn": false
+}

--- a/plugins/diffsitter/plugin.json
+++ b/plugins/diffsitter/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "diffsitter",
+  "version": "0.1.0",
+  "description": "Structural diff tool based on AST analysis, producing semantic diffs rather than line-based diffs",
+  "source": "https://github.com/afnanenayet/diffsitter",
+  "checks": [{ "type": "binary", "name": "diffsitter" }],
+  "install_guidance": {
+    "plugin": "diffsitter",
+    "binary": "diffsitter",
+    "check": "which diffsitter",
+    "install_steps": ["cargo install diffsitter", "Verify: diffsitter --version", "supercli plugins install ./plugins/diffsitter --on-conflict replace --json"]
+  },
+  "commands": [{
+    "namespace": "diffsitter",
+    "resource": "_",
+    "action": "_",
+    "description": "Passthrough to diffsitter CLI",
+    "adapter": "process",
+    "adapterConfig": {
+      "command": "diffsitter",
+      "passthrough": true,
+      "missingDependencyHelp": "Install diffsitter: cargo install diffsitter"
+    },
+    "args": []
+  }]
+}

--- a/plugins/httpie/install-guidance.json
+++ b/plugins/httpie/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "httpie",
+  "binary": "http",
+  "check": "which http",
+  "install_steps": ["pip install httpie", "Verify: http --version", "supercli plugins install ./plugins/httpie --on-conflict replace --json"]
+}

--- a/plugins/httpie/meta.json
+++ b/plugins/httpie/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Modern, user-friendly HTTP command-line client with intuitive JSON support, sessions, and plugins",
+  "tags": ["httpie", "cli-tool", "http", "api", "debugging"],
+  "has_learn": false
+}

--- a/plugins/httpie/plugin.json
+++ b/plugins/httpie/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "httpie",
+  "version": "0.1.0",
+  "description": "Modern, user-friendly HTTP command-line client with intuitive JSON support, sessions, and plugins",
+  "source": "https://github.com/httpie/cli",
+  "checks": [{ "type": "binary", "name": "http" }],
+  "install_guidance": {
+    "plugin": "httpie",
+    "binary": "http",
+    "check": "which http",
+    "install_steps": ["pip install httpie", "Verify: http --version", "supercli plugins install ./plugins/httpie --on-conflict replace --json"]
+  },
+  "commands": [{
+    "namespace": "httpie",
+    "resource": "_",
+    "action": "_",
+    "description": "Passthrough to httpie CLI",
+    "adapter": "process",
+    "adapterConfig": {
+      "command": "http",
+      "passthrough": true,
+      "missingDependencyHelp": "Install httpie: pip install httpie"
+    },
+    "args": []
+  }]
+}

--- a/plugins/taskwarrior-tui/install-guidance.json
+++ b/plugins/taskwarrior-tui/install-guidance.json
@@ -1,0 +1,6 @@
+{
+  "plugin": "taskwarrior-tui",
+  "binary": "taskwarrior-tui",
+  "check": "which taskwarrior-tui",
+  "install_steps": ["cargo install taskwarrior-tui", "Verify: taskwarrior-tui --version", "supercli plugins install ./plugins/taskwarrior-tui --on-conflict replace --json"]
+}

--- a/plugins/taskwarrior-tui/meta.json
+++ b/plugins/taskwarrior-tui/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Terminal user interface for Taskwarrior with vi keybindings and interactive task management",
+  "tags": ["taskwarrior-tui", "cli-tool", "taskwarrior", "tui", "productivity"],
+  "has_learn": false
+}

--- a/plugins/taskwarrior-tui/plugin.json
+++ b/plugins/taskwarrior-tui/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "taskwarrior-tui",
+  "version": "0.1.0",
+  "description": "Terminal user interface for Taskwarrior with vi keybindings and interactive task management",
+  "source": "https://github.com/kdheepak/taskwarrior-tui",
+  "checks": [{ "type": "binary", "name": "taskwarrior-tui" }],
+  "install_guidance": {
+    "plugin": "taskwarrior-tui",
+    "binary": "taskwarrior-tui",
+    "check": "which taskwarrior-tui",
+    "install_steps": ["cargo install taskwarrior-tui", "Verify: taskwarrior-tui --version", "supercli plugins install ./plugins/taskwarrior-tui --on-conflict replace --json"]
+  },
+  "commands": [{
+    "namespace": "taskwarrior-tui",
+    "resource": "_",
+    "action": "_",
+    "description": "Passthrough to taskwarrior-tui CLI",
+    "adapter": "process",
+    "adapterConfig": {
+      "command": "taskwarrior-tui",
+      "passthrough": true,
+      "missingDependencyHelp": "Install taskwarrior-tui: cargo install taskwarrior-tui"
+    },
+    "args": []
+  }]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #315 (am/am-f17c27-th48w5): feat(plugins): add 5 new bundled plugins — aider, browser-sync, sqlcmd, sort-package-json, madge
    touches: plugins/aider/install-guidance.json, plugins/aider/meta.json, plugins/aider/plugin.json, plugins/aider/skills/quickstart/SKILL.md, plugins/browser-sync/install-guidance.json, plugins/browser-sync/meta.json, plugins/browser-sync/plugin.json, plugins/browser-sync/skills/quickstart/SKILL.md, plugins/catalog.json, plugins/madge/install-guidance.json, plugins/madge/meta.json, plugins/madge/plugin.json (+9 more)
- PR #314 (am/am-f17c27-th47vh): feat(plugins): add web-ext, pscale, flox, zarf, amplify-cli
    touches: plugins/amplify-cli/install-guidance.json, plugins/amplify-cli/meta.json, plugins/amplify-cli/plugin.json, plugins/flox/install-guidance.json, plugins/flox/meta.json, plugins/flox/plugin.json, plugins/pscale/install-guidance.json, plugins/pscale/meta.json, plugins/pscale/plugin.json, plugins/web-ext/install-guidance.json, plugins/web-ext/meta.json, plugins/web-ext/plugin.json (+3 more)
- PR #313 (am/am-f17c27-th46y5): feat(plugins): add 5 new bundled plugins — git-town, prowler, terraform-docs, conventional-changelog-cli, ncat
    touches: plugins/conventional-changelog-cli/install-guidance.json, plugins/conventional-changelog-cli/meta.json, plugins/conventional-changelog-cli/plugin.json, plugins/git-town/install-guidance.json, plugins/git-town/meta.json, plugins/git-town/plugin.json, plugins/ncat/install-guidance.json, plugins/ncat/meta.json, plugins/ncat/plugin.json, plugins/prowler/install-guidance.json, plugins/prowler/meta.json, plugins/prowler/plugin.json (+3 more)
- PR #312 (am/am-f17c27-th45xh): feat(plugins): add 5 new bundled plugins — mockery, mailhog, xcaddy, hostctl, maddy
    touches: plugins/hostctl/install-guidance.json, plugins/hostctl/meta.json, plugins/hostctl/plugin.json, plugins/maddy/install-guidance.json, plugins/maddy/meta.json, plugins/maddy/plugin.json, plugins/mailhog/install-guidance.json, plugins/mailhog/meta.json, plugins/mailhog/plugin.json, plugins/mockery/install-guidance.json, plugins/mockery/meta.json, plugins/mockery/plugin.json (+3 more)
- PR #311 (am/am-f17c27-th44xd): feat(plugins): add 5 new bundled plugins — typst, go-task, cfn-lint, envinfo, markdown-link-check
    touches: plugins/cfn-lint/install-guidance.json, plugins/cfn-lint/meta.json, plugins/cfn-lint/plugin.json, plugins/envinfo/install-guidance.json, plugins/envinfo/meta.json, plugins/envinfo/plugin.json, plugins/go-task/install-guidance.json, plugins/go-task/meta.json, plugins/go-task/plugin.json, plugins/markdown-link-check/install-guidance.json, plugins/markdown-link-check/meta.json, plugins/markdown-link-check/plugin.json (+3 more)
- PR #310 (am/am-f17c27-th43mp): feat(plugins): add 4 new bundled plugins — ollama, pagefind, gptscript, staticrypt
    touches: plugins/gptscript/install-guidance.json, plugins/gptscript/meta.json, plugins/gptscript/plugin.json, plugins/ollama/install-guidance.json, plugins/ollama/meta.json, plugins/ollama/plugin.json, plugins/pagefind/install-guidance.json, plugins/pagefind/meta.json, plugins/pagefind/plugin.json, plugins/staticrypt/install-guidance.json, plugins/staticrypt/meta.json, plugins/staticrypt/plugin.json
- PR #309 (am/am-f17c27-th42fd): feat(plugins): add 10 new bundled plugins — pkgx, cotton, projen, cmus, massren, beets, editly, mpv, nasa-cli, pianobar
    touches: plugins/beets/install-guidance.json, plugins/beets/meta.json, plugins/beets/plugin.json, plugins/cmus/install-guidance.json, plugins/cmus/meta.json, plugins/cmus/plugin.json, plugins/cotton/install-guidance.json, plugins/cotton/meta.json, plugins/cotton/plugin.json, plugins/editly/install-guidance.json, plugins/editly/meta.json, plugins/editly/plugin.json (+18 more)
- PR #308 (am/am-f17c27-th41i1): feat(plugins): add vercel, directus, kamal — deployment and CMS CLIs
    touches: plugins/directus/install-guidance.json, plugins/directus/meta.json, plugins/directus/plugin.json, plugins/kamal/install-guidance.json, plugins/kamal/meta.json, plugins/kamal/plugin.json, plugins/vercel/install-guidance.json, plugins/vercel/meta.json, plugins/vercel/plugin.json


**Branch:** `am/am-f17c27-th49wt`

## Summary

Added 5 new bundled plugins: httpie (modern HTTP client), aichat (all-in-one LLM CLI), detekt (Kotlin static analysis), diffsitter (AST-based structural diff), and taskwarrior-tui (terminal UI for Taskwarrior). Each plugin has plugin.json, meta.json, and install-guidance.json following the isolated directory convention. These are real, useful CLI tools not previously in the catalog.

**Diff:**
```
plugins/aichat/install-guidance.json          |  6 ++++++
 plugins/aichat/meta.json                      |  5 +++++
 plugins/aichat/plugin.json                    | 26 ++++++++++++++++++++++++++
 plugins/detekt/install-guidance.json          |  6 ++++++
 plugins/detekt/meta.json                      |  5 +++++
 plugins/detekt/plugin.json                    | 26 ++++++++++++++++++++++++++
 plugins/diffsitter/install-guidance.json      |  6 ++++++
 plugins/diffsitter/meta.json                  |  5 +++++
 plugins/diffsitter/plugin.json                | 26 ++++++++++++++++++++++++++
 plugins/httpie/install-guidance.json          |  6 ++++++
 plugins/httpie/meta.json                      |  5 +++++
 plugins/httpie/plugin.json                    | 26 ++++++++++++++++++++++++++
 plugins/taskwarrior-tui/install-guidance.json |  6 ++++++
 plugins/taskwarrior-tui/meta.json             |  5 +++++
 plugins/taskwarrior-tui/plugin.json           | 26 ++++++++++++++++++++++++++
 15 files changed, 185 insertions(+)
```
