### PR TITLE
fix: sync CLI_VERSION with package.json — unblocks arg-parser tests

### DIFF
--- a/cli/arg-parser.js
+++ b/cli/arg-parser.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const CLI_VERSION = "1.31.4";
+const CLI_VERSION = "1.31.5";
 
 const RESERVED_FLAGS = [
   "human", "json", "compact", "schema", "help-json", "help",


### PR DESCRIPTION
## What changed

`__tests__/arg-parser.test.js` already existed in `master` (23 tests covering all the required behaviors: `--key=value` syntax, flag value-swallowing, `--` end-of-options, `userFlags` filtering, and `readStdin` JSON/raw/empty/TTY paths).

One test was failing: `CLI_VERSION › matches package.json version` — the constant in `cli/arg-parser.js` was `"1.31.4"` while `package.json` reads `"1.31.5"`. This PR syncs the constant.

## Why

Stale version constant caused a deterministic test failure. No behavior change beyond the constant value.

## Verification

```
npx jest __tests__/arg-parser.test.js --no-coverage
# Tests: 23 passed, 23 total
```

mago task #411


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CLI version to **1.31.5**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->