### PR TITLE
test(#495): 28 unit tests for config-commands.js (upsertCommand, removeCommandsByNamespace, showConfig)

### DIFF
--- a/__tests__/config-commands.test.js
+++ b/__tests__/config-commands.test.js
@@ -1,0 +1,290 @@
+"use strict";
+
+jest.mock("../cli/config-core", () => ({
+  readCache: jest.fn(),
+  writeCache: jest.fn(),
+  emptyConfig: jest.fn(),
+  cacheFilePath: jest.fn(),
+}));
+
+jest.mock("../cli/plugins-store", () => ({
+  listInstalledPlugins: jest.fn(),
+  readServerPluginsLock: jest.fn(),
+}));
+
+const { readCache, writeCache, emptyConfig, cacheFilePath } = require("../cli/config-core");
+const { listInstalledPlugins, readServerPluginsLock } = require("../cli/plugins-store");
+const { upsertCommand, removeCommandsByNamespace, showConfig } = require("../cli/config-commands");
+
+function makeCmd(overrides = {}) {
+  return {
+    namespace: "ai",
+    resource: "text",
+    action: "summarize",
+    adapter: "http",
+    ...overrides,
+  };
+}
+
+const BASE_EMPTY = { version: "1", ttl: 3600, mcp_servers: [], specs: [], commands: [] };
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  emptyConfig.mockReturnValue({ ...BASE_EMPTY, commands: [] });
+  writeCache.mockImplementation(cfg => cfg);
+  cacheFilePath.mockReturnValue("/home/user/.supercli/config.json");
+  listInstalledPlugins.mockReturnValue([]);
+  readServerPluginsLock.mockReturnValue({ installed: {} });
+});
+
+// ─── upsertCommand ────────────────────────────────────────────────────────────
+
+describe("upsertCommand", () => {
+  test("adds command when cache is null (uses emptyConfig)", async () => {
+    readCache.mockReturnValue(null);
+    const cmd = makeCmd();
+    const result = await upsertCommand(cmd);
+    expect(result).toBe(cmd);
+    const written = writeCache.mock.calls[0][0];
+    expect(written.commands).toEqual([cmd]);
+  });
+
+  test("adds command when cache has empty commands array", async () => {
+    readCache.mockReturnValue({ commands: [] });
+    const cmd = makeCmd();
+    await upsertCommand(cmd);
+    const written = writeCache.mock.calls[0][0];
+    expect(written.commands).toHaveLength(1);
+    expect(written.commands[0]).toBe(cmd);
+  });
+
+  test("adds command when cache commands field is not an array", async () => {
+    readCache.mockReturnValue({ commands: null });
+    const cmd = makeCmd();
+    await upsertCommand(cmd);
+    const written = writeCache.mock.calls[0][0];
+    expect(written.commands).toEqual([cmd]);
+  });
+
+  test("appends when no existing command matches namespace+resource+action", async () => {
+    const existing = makeCmd({ namespace: "ns", resource: "r", action: "a" });
+    readCache.mockReturnValue({ commands: [existing] });
+    const newCmd = makeCmd({ namespace: "ns2", resource: "r", action: "a" });
+    await upsertCommand(newCmd);
+    const written = writeCache.mock.calls[0][0];
+    expect(written.commands).toHaveLength(2);
+    expect(written.commands[0]).toEqual(existing);
+    expect(written.commands[1]).toBe(newCmd);
+  });
+
+  test("updates existing command when namespace+resource+action match", async () => {
+    const original = makeCmd({ description: "old" });
+    readCache.mockReturnValue({ commands: [original] });
+    const updated = makeCmd({ description: "new" });
+    await upsertCommand(updated);
+    const written = writeCache.mock.calls[0][0];
+    expect(written.commands).toHaveLength(1);
+    expect(written.commands[0].description).toBe("new");
+  });
+
+  test("updates correct command when multiple commands exist", async () => {
+    const keep = makeCmd({ namespace: "other", resource: "r", action: "a" });
+    const old = makeCmd({ description: "old" });
+    readCache.mockReturnValue({ commands: [keep, old] });
+    const updated = makeCmd({ description: "updated" });
+    await upsertCommand(updated);
+    const written = writeCache.mock.calls[0][0];
+    expect(written.commands).toHaveLength(2);
+    expect(written.commands[0]).toEqual(keep);
+    expect(written.commands[1].description).toBe("updated");
+  });
+
+  test("does not mutate original commands array from cache", async () => {
+    const commands = [makeCmd({ description: "original" })];
+    readCache.mockReturnValue({ commands });
+    await upsertCommand(makeCmd({ description: "updated" }));
+    expect(commands[0].description).toBe("original");
+  });
+
+  test("returns the commandDef passed in", async () => {
+    readCache.mockReturnValue({ commands: [] });
+    const cmd = makeCmd();
+    const returned = await upsertCommand(cmd);
+    expect(returned).toBe(cmd);
+  });
+
+  test("calls writeCache exactly once", async () => {
+    readCache.mockReturnValue({ commands: [] });
+    await upsertCommand(makeCmd());
+    expect(writeCache).toHaveBeenCalledTimes(1);
+  });
+
+  test("null entries in existing commands are preserved then replaced on match", async () => {
+    readCache.mockReturnValue({ commands: [null, makeCmd({ description: "old" })] });
+    const updated = makeCmd({ description: "new" });
+    await upsertCommand(updated);
+    const written = writeCache.mock.calls[0][0];
+    expect(written.commands[0]).toBeNull();
+    expect(written.commands[1].description).toBe("new");
+  });
+
+  test("ignores null entries when searching for match to upsert", async () => {
+    readCache.mockReturnValue({ commands: [null] });
+    const cmd = makeCmd();
+    await upsertCommand(cmd);
+    const written = writeCache.mock.calls[0][0];
+    expect(written.commands[written.commands.length - 1]).toBe(cmd);
+  });
+});
+
+// ─── removeCommandsByNamespace ────────────────────────────────────────────────
+
+describe("removeCommandsByNamespace", () => {
+  test("returns 0 when cache is null", async () => {
+    readCache.mockReturnValue(null);
+    const removed = await removeCommandsByNamespace("ns");
+    expect(removed).toBe(0);
+    expect(writeCache).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 0 when no commands match namespace", async () => {
+    readCache.mockReturnValue({ commands: [makeCmd({ namespace: "other" })] });
+    const removed = await removeCommandsByNamespace("ns");
+    expect(removed).toBe(0);
+  });
+
+  test("removes one matching command and returns 1", async () => {
+    readCache.mockReturnValue({ commands: [makeCmd()] });
+    const removed = await removeCommandsByNamespace("ai");
+    expect(removed).toBe(1);
+    const written = writeCache.mock.calls[0][0];
+    expect(written.commands).toHaveLength(0);
+  });
+
+  test("removes multiple matching commands and returns correct count", async () => {
+    readCache.mockReturnValue({
+      commands: [
+        makeCmd({ resource: "r1", action: "a1" }),
+        makeCmd({ resource: "r2", action: "a2" }),
+        makeCmd({ namespace: "other" }),
+      ],
+    });
+    const removed = await removeCommandsByNamespace("ai");
+    expect(removed).toBe(2);
+    const written = writeCache.mock.calls[0][0];
+    expect(written.commands).toHaveLength(1);
+    expect(written.commands[0].namespace).toBe("other");
+  });
+
+  test("keeps non-matching namespace commands intact", async () => {
+    const keep = makeCmd({ namespace: "keep" });
+    readCache.mockReturnValue({ commands: [makeCmd(), keep] });
+    await removeCommandsByNamespace("ai");
+    const written = writeCache.mock.calls[0][0];
+    expect(written.commands).toEqual([keep]);
+  });
+
+  test("handles non-array commands field (treats as empty)", async () => {
+    readCache.mockReturnValue({ commands: "bad" });
+    const removed = await removeCommandsByNamespace("ai");
+    expect(removed).toBe(0);
+    const written = writeCache.mock.calls[0][0];
+    expect(written.commands).toEqual([]);
+  });
+
+  test("skips null entries without throwing", async () => {
+    readCache.mockReturnValue({ commands: [null, makeCmd()] });
+    const removed = await removeCommandsByNamespace("ai");
+    expect(removed).toBe(1);
+  });
+
+  test("calls writeCache exactly once", async () => {
+    readCache.mockReturnValue({ commands: [] });
+    await removeCommandsByNamespace("ns");
+    expect(writeCache).toHaveBeenCalledTimes(1);
+  });
+
+  test("empty namespace string removes commands with empty namespace", async () => {
+    const cmd = makeCmd({ namespace: "" });
+    readCache.mockReturnValue({ commands: [cmd, makeCmd()] });
+    const removed = await removeCommandsByNamespace("");
+    expect(removed).toBe(1);
+  });
+});
+
+// ─── showConfig ───────────────────────────────────────────────────────────────
+
+describe("showConfig", () => {
+  test("returns cached:false with message when no cache", async () => {
+    readCache.mockReturnValue(null);
+    const result = await showConfig();
+    expect(result.cached).toBe(false);
+    expect(result.message).toMatch(/No config cached/);
+  });
+
+  test("returns full summary when cache exists", async () => {
+    readCache.mockReturnValue({
+      version: "2",
+      ttl: 7200,
+      fetchedAt: 0,
+      commands: [makeCmd(), makeCmd({ action: "a2" })],
+      mcp_servers: [{ name: "s" }],
+      specs: [1, 2, 3],
+    });
+    listInstalledPlugins.mockReturnValue([1, 2]);
+    readServerPluginsLock.mockReturnValue({ installed: { p1: {}, p2: {}, p3: {} } });
+
+    const result = await showConfig();
+    expect(result.version).toBe("2");
+    expect(result.ttl).toBe(7200);
+    expect(result.commands).toBe(2);
+    expect(result.plugins).toBe(2);
+    expect(result.server_plugins).toBe(3);
+    expect(result.mcp_servers).toBe(1);
+    expect(result.specs).toBe(3);
+    expect(result.cacheFile).toBe("/home/user/.supercli/config.json");
+  });
+
+  test("defaults counts to 0 when commands/mcp_servers/specs are absent", async () => {
+    readCache.mockReturnValue({ version: "1", fetchedAt: 0 });
+    const result = await showConfig();
+    expect(result.commands).toBe(0);
+    expect(result.mcp_servers).toBe(0);
+    expect(result.specs).toBe(0);
+  });
+
+  test("fetchedAt is converted to ISO string", async () => {
+    const ts = 1_000_000_000_000;
+    readCache.mockReturnValue({ fetchedAt: ts, commands: [], mcp_servers: [], specs: [] });
+    const result = await showConfig();
+    expect(result.fetchedAt).toBe(new Date(ts).toISOString());
+  });
+
+  test("server_plugins counts keys from installed object", async () => {
+    readCache.mockReturnValue({ commands: [], mcp_servers: [], specs: [], fetchedAt: 0 });
+    readServerPluginsLock.mockReturnValue({ installed: { a: 1, b: 2 } });
+    const result = await showConfig();
+    expect(result.server_plugins).toBe(2);
+  });
+
+  test("server_plugins is 0 when installed field is absent", async () => {
+    readCache.mockReturnValue({ commands: [], mcp_servers: [], specs: [], fetchedAt: 0 });
+    readServerPluginsLock.mockReturnValue({});
+    const result = await showConfig();
+    expect(result.server_plugins).toBe(0);
+  });
+
+  test("uses cacheFilePath() from config-core", async () => {
+    cacheFilePath.mockReturnValue("/custom/path/config.json");
+    readCache.mockReturnValue({ commands: [], mcp_servers: [], specs: [], fetchedAt: 0 });
+    const result = await showConfig();
+    expect(result.cacheFile).toBe("/custom/path/config.json");
+  });
+
+  test("plugins count reflects listInstalledPlugins length", async () => {
+    readCache.mockReturnValue({ commands: [], mcp_servers: [], specs: [], fetchedAt: 0 });
+    listInstalledPlugins.mockReturnValue(["p1", "p2", "p3", "p4"]);
+    const result = await showConfig();
+    expect(result.plugins).toBe(4);
+  });
+});

--- a/__tests__/execute-handler.test.js
+++ b/__tests__/execute-handler.test.js
@@ -1,0 +1,449 @@
+"use strict";
+
+jest.mock("../cli/executor", () => ({ execute: jest.fn() }));
+jest.mock("../cli/plan-runtime", () => ({
+  buildLocalPlan: jest.fn(),
+  annotateServerPlan: jest.fn(),
+  outputHumanPlan: jest.fn(),
+}));
+
+const { execute } = require("../cli/executor");
+const { buildLocalPlan, annotateServerPlan, outputHumanPlan } = require("../cli/plan-runtime");
+const { handleExecute, handlePlan, handleExecutePlan } = require("../cli/execute-handler");
+
+// ─── shared fixtures ──────────────────────────────────────────────────────────
+
+function makeCmd(overrides = {}) {
+  return {
+    namespace: "ai",
+    resource: "text",
+    action: "summarize",
+    adapter: "http",
+    ...overrides,
+  };
+}
+
+function makeIo(overrides = {}) {
+  return {
+    SERVER: "https://example.com",
+    humanMode: false,
+    output: jest.fn(),
+    outputError: jest.fn(),
+    outputHumanTable: jest.fn(),
+    writeLog: jest.fn(),
+    getClientId: jest.fn().mockReturnValue("client-abc"),
+    makeStreamEmitter: jest.fn().mockReturnValue(jest.fn()),
+    ...overrides,
+  };
+}
+
+// ─── handleExecute ─────────────────────────────────────────────────────────────
+
+describe("handleExecute", () => {
+  let stderrSpy;
+  let consoleSpy;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    stderrSpy = jest.spyOn(process.stderr, "write").mockImplementation(() => {});
+    consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+
+  test("forwards cmd, uFlags and config to execute()", async () => {
+    const cmd = makeCmd();
+    const uFlags = { limit: 5 };
+    const config = { apiKey: "xyz" };
+    const io = makeIo({ SERVER: "https://srv.io" });
+    execute.mockResolvedValue({ id: 1 });
+
+    await handleExecute(cmd, uFlags, config, io);
+
+    expect(execute).toHaveBeenCalledWith(
+      cmd,
+      uFlags,
+      expect.objectContaining({ server: "https://srv.io", config })
+    );
+  });
+
+  test("passes empty string as server when SERVER is falsy", async () => {
+    const cmd = makeCmd();
+    const io = makeIo({ SERVER: null });
+    execute.mockResolvedValue({});
+
+    await handleExecute(cmd, {}, {}, io);
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ server: "" })
+    );
+  });
+
+  test("passes null onStreamEvent when adapterConfig is absent", async () => {
+    const cmd = makeCmd(); // no adapterConfig
+    const io = makeIo();
+    execute.mockResolvedValue({});
+
+    await handleExecute(cmd, {}, {}, io);
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ onStreamEvent: null })
+    );
+    expect(io.makeStreamEmitter).not.toHaveBeenCalled();
+  });
+
+  test("passes null onStreamEvent when stream is not jsonl", async () => {
+    const cmd = makeCmd({ adapterConfig: { stream: "text" } });
+    const io = makeIo();
+    execute.mockResolvedValue({});
+
+    await handleExecute(cmd, {}, {}, io);
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ onStreamEvent: null })
+    );
+    expect(io.makeStreamEmitter).not.toHaveBeenCalled();
+  });
+
+  test("calls makeStreamEmitter and passes result as onStreamEvent when stream is jsonl", async () => {
+    const emitterFn = jest.fn();
+    const io = makeIo({ makeStreamEmitter: jest.fn().mockReturnValue(emitterFn) });
+    const cmd = makeCmd({ adapterConfig: { stream: "jsonl" } });
+    execute.mockResolvedValue({});
+
+    await handleExecute(cmd, {}, {}, io);
+
+    expect(io.makeStreamEmitter).toHaveBeenCalledWith("ai.text.summarize");
+    expect(execute).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ onStreamEvent: emitterFn })
+    );
+  });
+
+  test("calls writeLog with correct fields", async () => {
+    const cmd = makeCmd();
+    const uFlags = { q: "hello" };
+    const io = makeIo();
+    execute.mockResolvedValue({ done: true });
+
+    await handleExecute(cmd, uFlags, {}, io);
+
+    expect(io.writeLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "ai.text.summarize",
+        args: uFlags,
+        status: "success",
+        client_id: "client-abc",
+      })
+    );
+    const logged = io.writeLog.mock.calls[0][0];
+    expect(typeof logged.duration_ms).toBe("number");
+    expect(typeof logged.timestamp).toBe("string");
+  });
+
+  test("calls getClientId to populate client_id in writeLog", async () => {
+    const io = makeIo();
+    io.getClientId.mockReturnValue("custom-client");
+    execute.mockResolvedValue({});
+
+    await handleExecute(makeCmd(), {}, {}, io);
+
+    expect(io.getClientId).toHaveBeenCalled();
+    expect(io.writeLog).toHaveBeenCalledWith(
+      expect.objectContaining({ client_id: "custom-client" })
+    );
+  });
+
+  test("calls output with structured envelope in non-human mode", async () => {
+    const io = makeIo({ humanMode: false });
+    execute.mockResolvedValue({ items: [1, 2] });
+
+    await handleExecute(makeCmd(), {}, {}, io);
+
+    expect(io.output).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: "1.0",
+        command: "ai.text.summarize",
+        data: { items: [1, 2] },
+      })
+    );
+    const envelope = io.output.mock.calls[0][0];
+    expect(typeof envelope.duration_ms).toBe("number");
+  });
+
+  test("does not call outputHumanTable or outputError in non-human mode", async () => {
+    const io = makeIo({ humanMode: false });
+    execute.mockResolvedValue([{ a: 1 }]);
+
+    await handleExecute(makeCmd(), {}, {}, io);
+
+    expect(io.outputHumanTable).not.toHaveBeenCalled();
+    expect(io.outputError).not.toHaveBeenCalled();
+  });
+
+  test("human mode + array result: calls outputHumanTable with up to 20 rows", async () => {
+    const io = makeIo({ humanMode: true });
+    const rows = Array.from({ length: 5 }, (_, i) => ({ id: i, name: `r${i}` }));
+    execute.mockResolvedValue(rows);
+
+    await handleExecute(makeCmd(), {}, {}, io);
+
+    expect(io.outputHumanTable).toHaveBeenCalledWith(
+      rows,
+      expect.arrayContaining([expect.objectContaining({ key: "id" })])
+    );
+  });
+
+  test("human mode + array > 20 rows: slices to 20 and logs 'and N more'", async () => {
+    const io = makeIo({ humanMode: true });
+    const rows = Array.from({ length: 25 }, (_, i) => ({ id: i }));
+    execute.mockResolvedValue(rows);
+
+    await handleExecute(makeCmd(), {}, {}, io);
+
+    const tableArg = io.outputHumanTable.mock.calls[0][0];
+    expect(tableArg).toHaveLength(20);
+    const loggedLines = consoleSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(loggedLines).toContain("5 more");
+  });
+
+  test("human mode + object result: logs each key-value pair", async () => {
+    const io = makeIo({ humanMode: true });
+    execute.mockResolvedValue({ status: "ok", count: 3 });
+
+    await handleExecute(makeCmd(), {}, {}, io);
+
+    const loggedLines = consoleSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(loggedLines).toContain("status");
+    expect(loggedLines).toContain("ok");
+    expect(loggedLines).toContain("count");
+    expect(loggedLines).toContain("3");
+  });
+
+  test("human mode + nested object value: JSON.stringify applied", async () => {
+    const io = makeIo({ humanMode: true });
+    execute.mockResolvedValue({ meta: { version: "1.0" } });
+
+    await handleExecute(makeCmd(), {}, {}, io);
+
+    const loggedLines = consoleSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(loggedLines).toContain('"version":"1.0"');
+  });
+
+  test("propagates error thrown by execute()", async () => {
+    const io = makeIo();
+    const err = Object.assign(new Error("adapter failed"), { code: 110 });
+    execute.mockRejectedValue(err);
+
+    await expect(handleExecute(makeCmd(), {}, {}, io)).rejects.toThrow("adapter failed");
+    expect(io.output).not.toHaveBeenCalled();
+    expect(io.writeLog).not.toHaveBeenCalled();
+  });
+});
+
+// ─── handlePlan ────────────────────────────────────────────────────────────────
+
+describe("handlePlan", () => {
+  let consoleSpy;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    delete global.fetch;
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    delete global.fetch;
+  });
+
+  function makeIoPlan(overrides = {}) {
+    return {
+      SERVER: "https://srv.io",
+      hasServer: false,
+      humanMode: false,
+      output: jest.fn(),
+      outputError: jest.fn(),
+      ...overrides,
+    };
+  }
+
+  test("no server: calls buildLocalPlan and passes result to output", async () => {
+    const localPlan = { plan_id: "lp1", persisted: false };
+    buildLocalPlan.mockReturnValue(localPlan);
+    const io = makeIoPlan({ hasServer: false, humanMode: false });
+    const cmd = makeCmd();
+    const args = { q: "a" };
+
+    await handlePlan(cmd, args, io);
+
+    expect(buildLocalPlan).toHaveBeenCalledWith(cmd, args);
+    expect(io.output).toHaveBeenCalledWith(localPlan);
+  });
+
+  test("no server + human mode: calls outputHumanPlan", async () => {
+    const localPlan = { plan_id: "lp1", steps: [] };
+    buildLocalPlan.mockReturnValue(localPlan);
+    const io = makeIoPlan({ hasServer: false, humanMode: true });
+
+    await handlePlan(makeCmd(), {}, io);
+
+    expect(outputHumanPlan).toHaveBeenCalledWith(localPlan);
+    expect(io.output).not.toHaveBeenCalled();
+  });
+
+  test("with server: fetches /api/plans and outputs annotated plan", async () => {
+    const serverPlan = { plan_id: "sp1", steps: [] };
+    const annotated = { ...serverPlan, persisted: true, execution_mode: "server" };
+    annotateServerPlan.mockReturnValue(annotated);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(serverPlan),
+    });
+    const io = makeIoPlan({ hasServer: true, humanMode: false });
+    const cmd = makeCmd();
+
+    await handlePlan(cmd, { q: "b" }, io);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://srv.io/api/plans",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(annotateServerPlan).toHaveBeenCalledWith(serverPlan);
+    expect(io.output).toHaveBeenCalledWith(annotated);
+  });
+
+  test("with server + human mode: calls outputHumanPlan with annotated plan", async () => {
+    const annotated = { plan_id: "sp2", persisted: true, steps: [] };
+    annotateServerPlan.mockReturnValue(annotated);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({}),
+    });
+    const io = makeIoPlan({ hasServer: true, humanMode: true });
+
+    await handlePlan(makeCmd(), {}, io);
+
+    expect(outputHumanPlan).toHaveBeenCalledWith(annotated);
+    expect(io.output).not.toHaveBeenCalled();
+  });
+
+  test("with server: POST body includes command and args", async () => {
+    annotateServerPlan.mockReturnValue({});
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({}),
+    });
+    const io = makeIoPlan({ hasServer: true });
+    const cmd = makeCmd();
+
+    await handlePlan(cmd, { limit: 10 }, io);
+
+    const [, opts] = global.fetch.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.command).toBe("ai.text.summarize");
+    expect(body.args).toEqual({ limit: 10 });
+    expect(body.cmd).toEqual(cmd);
+  });
+
+  test("with server + fetch throws: calls outputError with code 105", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("network failure"));
+    const io = makeIoPlan({ hasServer: true });
+
+    await handlePlan(makeCmd(), {}, io);
+
+    expect(io.outputError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 105,
+        type: "integration_error",
+        recoverable: true,
+      })
+    );
+    const err = io.outputError.mock.calls[0][0];
+    expect(err.message).toContain("network failure");
+  });
+});
+
+// ─── handleExecutePlan ─────────────────────────────────────────────────────────
+
+describe("handleExecutePlan", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    delete global.fetch;
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  function makeIoExec(overrides = {}) {
+    return {
+      SERVER: "https://srv.io",
+      output: jest.fn(),
+      outputError: jest.fn(),
+      ...overrides,
+    };
+  }
+
+  test("fetches the execute endpoint for the given planId", async () => {
+    const io = makeIoExec();
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue({ status: "executed" }),
+    });
+
+    await handleExecutePlan("plan-99", io);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://srv.io/api/plans/plan-99/execute",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  test("passes JSON result to output", async () => {
+    const io = makeIoExec();
+    const result = { status: "executed", id: "plan-99" };
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue(result),
+    });
+
+    await handleExecutePlan("plan-99", io);
+
+    expect(io.output).toHaveBeenCalledWith(result);
+  });
+
+  test("calls outputError with code 105 when fetch throws", async () => {
+    const io = makeIoExec();
+    global.fetch = jest.fn().mockRejectedValue(new Error("connection refused"));
+
+    await handleExecutePlan("plan-99", io);
+
+    expect(io.outputError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 105,
+        type: "integration_error",
+        recoverable: true,
+      })
+    );
+    const err = io.outputError.mock.calls[0][0];
+    expect(err.message).toContain("connection refused");
+  });
+
+  test("does not call output when fetch throws", async () => {
+    const io = makeIoExec();
+    global.fetch = jest.fn().mockRejectedValue(new Error("timeout"));
+
+    await handleExecutePlan("plan-42", io);
+
+    expect(io.output).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Direct unit test suite for `cli/config-commands.js` — the module that owns command upsert and removal logic in the local config cache.

## Why

`config.test.js` exercises these functions via the `config.js` re-export but shares mocks with config-core tests, limiting isolation. A dedicated file mocks `config-core` and `plugins-store` directly so each exported function can be exercised independently with precise assertions.

## Tests (28 assertions, all green)

### `upsertCommand`
- Null cache → falls back to `emptyConfig`, pushes new command
- Empty commands array → appends
- Non-array `commands` field → treated as empty
- Appends when namespace+resource+action do not match any existing entry
- Updates in-place when all three key fields match
- Correct command updated when multiple commands are present
- Original cache array not mutated (slice isolation)
- Returns the commandDef reference
- `writeCache` called exactly once
- Null entries in commands array are preserved and do not cause crashes during match search

### `removeCommandsByNamespace`
- Null cache → returns 0, still writes
- No match → returns 0
- Single match removed, returns 1
- Multiple matches removed, correct count returned
- Non-matching namespace commands kept intact
- Non-array commands field handled (treated as empty)
- Null entries skipped without throwing
- `writeCache` called exactly once
- Empty-string namespace removes commands where `namespace === ""`

### `showConfig`
- No cache → `{cached: false, message: ...}`
- Full cache → correct counts for commands, plugins, server_plugins, mcp_servers, specs
- Missing fields → defaults to 0
- `fetchedAt` converted to ISO string
- `server_plugins` counts keys from `installed` sub-object
- `installed` absent → `server_plugins` is 0
- `cacheFilePath()` return value forwarded as `cacheFile`
- `plugins` count matches `listInstalledPlugins` length

## Verification

```
npx jest __tests__/config-commands.test.js --no-coverage
# Test Suites: 1 passed, 1 total
# Tests:       28 passed, 28 total
# Time:        0.207 s
```

Closes #495  _(mago task #495)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broad automated coverage for CLI config, execution, and planning flows.
  * Improves confidence in cache updates, command removal, config display, and plan execution output.
  * Verifies human-friendly and JSON outputs, error handling, and stream behavior across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->