### PR TITLE
test(#542): 25 unit tests for slash-commands.js (add, remove, list)

### DIFF
--- a/__tests__/slash-commands.test.js
+++ b/__tests__/slash-commands.test.js
@@ -1,0 +1,176 @@
+"use strict"
+
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+
+const {
+  listSlashCommands,
+  addSlashCommand,
+  removeSlashCommand,
+  slashCommandsFile,
+} = require("../cli/slash-commands")
+
+describe("slash-commands", () => {
+  let tempHome
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "supercli-slash-"))
+    process.env.SUPERCLI_HOME = tempHome
+  })
+
+  afterEach(() => {
+    delete process.env.SUPERCLI_HOME
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  // ── slashCommandsFile ─────────────────────────────────────────────────────
+
+  test("slashCommandsFile returns path inside SUPERCLI_HOME", () => {
+    expect(slashCommandsFile()).toBe(path.join(tempHome, "slash-commands.json"))
+  })
+
+  // ── listSlashCommands ─────────────────────────────────────────────────────
+
+  test("listSlashCommands returns empty array when file does not exist", () => {
+    expect(listSlashCommands()).toEqual([])
+  })
+
+  test("listSlashCommands returns commands from persisted file", () => {
+    const cmd = { name: "deploy", description: "deploy app", run: "npm run deploy" }
+    fs.writeFileSync(slashCommandsFile(), JSON.stringify([cmd]))
+    expect(listSlashCommands()).toEqual([cmd])
+  })
+
+  test("listSlashCommands returns empty array for invalid JSON", () => {
+    fs.writeFileSync(slashCommandsFile(), "not-valid-json{")
+    expect(listSlashCommands()).toEqual([])
+  })
+
+  test("listSlashCommands returns empty array when file contains a non-array", () => {
+    fs.writeFileSync(slashCommandsFile(), JSON.stringify({ name: "deploy" }))
+    expect(listSlashCommands()).toEqual([])
+  })
+
+  test("listSlashCommands returns empty array when file contains null", () => {
+    fs.writeFileSync(slashCommandsFile(), "null")
+    expect(listSlashCommands()).toEqual([])
+  })
+
+  // ── addSlashCommand ───────────────────────────────────────────────────────
+
+  test("addSlashCommand throws when entry is null", () => {
+    expect(() => addSlashCommand(null)).toThrow("entry must be a non-null object")
+  })
+
+  test("addSlashCommand throws when entry is a string", () => {
+    expect(() => addSlashCommand("deploy")).toThrow("entry must be a non-null object")
+  })
+
+  test("addSlashCommand throws when entry is an array", () => {
+    expect(() => addSlashCommand([])).toThrow("entry must be a non-null object")
+  })
+
+  test("addSlashCommand throws when name is missing", () => {
+    expect(() => addSlashCommand({ description: "no name" })).toThrow("name is required")
+  })
+
+  test("addSlashCommand throws when name is blank whitespace", () => {
+    expect(() => addSlashCommand({ name: "   " })).toThrow("name is required")
+  })
+
+  test("addSlashCommand persists a new command and returns it", () => {
+    const result = addSlashCommand({ name: "test", run: "npm test" })
+    expect(result).toEqual({ name: "test", run: "npm test" })
+    expect(listSlashCommands()).toEqual([{ name: "test", run: "npm test" }])
+  })
+
+  test("addSlashCommand trims whitespace from name", () => {
+    const result = addSlashCommand({ name: "  lint  ", run: "npm run lint" })
+    expect(result.name).toBe("lint")
+  })
+
+  test("addSlashCommand upserts when name already exists", () => {
+    addSlashCommand({ name: "build", run: "npm run build" })
+    addSlashCommand({ name: "build", run: "make build", description: "updated" })
+    const commands = listSlashCommands()
+    expect(commands).toHaveLength(1)
+    expect(commands[0].run).toBe("make build")
+    expect(commands[0].description).toBe("updated")
+  })
+
+  test("addSlashCommand appends when name is different", () => {
+    addSlashCommand({ name: "a", run: "echo a" })
+    addSlashCommand({ name: "b", run: "echo b" })
+    expect(listSlashCommands()).toHaveLength(2)
+  })
+
+  test("addSlashCommand preserves extra fields on the entry", () => {
+    const result = addSlashCommand({ name: "deploy", env: "production", region: "us-east-1" })
+    expect(result.env).toBe("production")
+    expect(result.region).toBe("us-east-1")
+  })
+
+  test("addSlashCommand creates the directory if it does not exist", () => {
+    const nested = path.join(tempHome, "nested")
+    process.env.SUPERCLI_HOME = nested
+    addSlashCommand({ name: "x" })
+    expect(fs.existsSync(path.join(nested, "slash-commands.json"))).toBe(true)
+  })
+
+  // ── removeSlashCommand ────────────────────────────────────────────────────
+
+  test("removeSlashCommand throws when name is not a string", () => {
+    expect(() => removeSlashCommand(42)).toThrow("name must be a non-empty string")
+  })
+
+  test("removeSlashCommand throws when name is empty string", () => {
+    expect(() => removeSlashCommand("")).toThrow("name must be a non-empty string")
+  })
+
+  test("removeSlashCommand throws when name is blank whitespace", () => {
+    expect(() => removeSlashCommand("   ")).toThrow("name must be a non-empty string")
+  })
+
+  test("removeSlashCommand returns 0 when command does not exist", () => {
+    expect(removeSlashCommand("missing")).toBe(0)
+  })
+
+  test("removeSlashCommand returns 1 and removes the matching command", () => {
+    addSlashCommand({ name: "release", run: "npm run release" })
+    const count = removeSlashCommand("release")
+    expect(count).toBe(1)
+    expect(listSlashCommands()).toEqual([])
+  })
+
+  test("removeSlashCommand removes only the matching command", () => {
+    addSlashCommand({ name: "alpha" })
+    addSlashCommand({ name: "beta" })
+    removeSlashCommand("alpha")
+    const remaining = listSlashCommands()
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].name).toBe("beta")
+  })
+
+  test("removeSlashCommand trims name before matching", () => {
+    addSlashCommand({ name: "trim-me" })
+    expect(removeSlashCommand("  trim-me  ")).toBe(1)
+    expect(listSlashCommands()).toEqual([])
+  })
+
+  // ── round-trip ────────────────────────────────────────────────────────────
+
+  test("full lifecycle: add → list → remove → list", () => {
+    addSlashCommand({ name: "foo", run: "echo foo" })
+    addSlashCommand({ name: "bar", run: "echo bar" })
+    expect(listSlashCommands()).toHaveLength(2)
+
+    removeSlashCommand("foo")
+    const remaining = listSlashCommands()
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].name).toBe("bar")
+
+    removeSlashCommand("bar")
+    expect(listSlashCommands()).toHaveLength(0)
+  })
+})

--- a/cli/slash-commands.js
+++ b/cli/slash-commands.js
@@ -1,0 +1,74 @@
+"use strict"
+
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+
+function supercliDir() {
+  return process.env.SUPERCLI_HOME || path.join(os.homedir(), ".supercli")
+}
+
+function slashCommandsFile() {
+  return path.join(supercliDir(), "slash-commands.json")
+}
+
+function ensureDir() {
+  const dir = supercliDir()
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+}
+
+function readCommands() {
+  try {
+    const file = slashCommandsFile()
+    if (!fs.existsSync(file)) return []
+    const raw = fs.readFileSync(file, "utf-8")
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+function writeCommands(commands) {
+  ensureDir()
+  fs.writeFileSync(slashCommandsFile(), JSON.stringify(commands, null, 2))
+}
+
+function listSlashCommands() {
+  return readCommands()
+}
+
+function addSlashCommand(entry) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new Error("entry must be a non-null object")
+  }
+  const name = String(entry.name || "").trim()
+  if (!name) throw new Error("name is required")
+
+  const commands = readCommands()
+  const normalized = { ...entry, name }
+  const idx = commands.findIndex(c => c && c.name === name)
+  if (idx >= 0) commands[idx] = normalized
+  else commands.push(normalized)
+  writeCommands(commands)
+  return normalized
+}
+
+function removeSlashCommand(name) {
+  if (typeof name !== "string" || !name.trim()) {
+    throw new Error("name must be a non-empty string")
+  }
+  const trimmed = name.trim()
+  const commands = readCommands()
+  const next = commands.filter(c => c && c.name !== trimmed)
+  const removed = commands.length - next.length
+  writeCommands(next)
+  return removed
+}
+
+module.exports = {
+  listSlashCommands,
+  addSlashCommand,
+  removeSlashCommand,
+  slashCommandsFile,
+}


### PR DESCRIPTION
## What changed

- New module `cli/slash-commands.js` — manages local slash-command shortcuts persisted to `~/.supercli/slash-commands.json` (honours `SUPERCLI_HOME`).
  - `listSlashCommands()` — returns all stored commands (empty array on missing/corrupt file)
  - `addSlashCommand(entry)` — upserts by `name`, validates entry is a non-null, non-array object with a non-blank name; trims whitespace; auto-creates dir
  - `removeSlashCommand(name)` — filters by trimmed name, returns removed count (0 if not found)
  - `slashCommandsFile()` — path helper exposed for tests

- New test file `__tests__/slash-commands.test.js` — 25 unit tests covering:
  - `slashCommandsFile`: path resolves inside `SUPERCLI_HOME`
  - `listSlashCommands`: file-absent, valid file, invalid JSON, non-array, null content
  - `addSlashCommand`: null/string/array entry throws, missing/blank name throws, insert, upsert-in-place, append distinct, extra fields preserved, auto-creates dir, whitespace trimming
  - `removeSlashCommand`: non-string/empty/blank throws, missing returns 0, removes matching, keeps others, trims name before match
  - Full lifecycle: add → list → remove → list

## Why

Task #542: unit test coverage for slash-commands module (add, remove, list operations).

## Verification

```
npx jest __tests__/slash-commands.test.js --no-coverage
# Tests: 25 passed, 25 total — 0.218s
```

Closes #542  _(mago task #542)_
