### PR TITLE
feat: add 5 bundled plugins — mods, goss, resvg, overmind, hivemind

### DIFF
--- a/plugins/goss/install-guidance.json
+++ b/plugins/goss/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "goss",
+  "binary": "goss",
+  "check": "which goss",
+  "install_steps": [
+    "curl -fsSL https://goss.rocks/install | sh",
+    "Or: brew install goss",
+    "Verify: goss --version",
+    "supercli plugins install ./plugins/goss --on-conflict replace --json"
+  ],
+  "note": "goss lets you validate server configuration, docker containers, and infrastructure state with fast YAML-based tests."
+}

--- a/plugins/goss/meta.json
+++ b/plugins/goss/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Quick and Easy server testing/validation — define infrastructure tests as YAML and run them fast",
+  "tags": ["goss", "testing", "validation", "devops", "infrastructure", "docker", "yaml"],
+  "has_learn": false
+}

--- a/plugins/goss/plugin.json
+++ b/plugins/goss/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "goss",
+  "version": "0.1.0",
+  "description": "Quick and Easy server testing/validation — define infrastructure tests as YAML and run them fast",
+  "source": "https://github.com/goss-org/goss",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "goss"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "goss",
+    "binary": "goss",
+    "check": "which goss",
+    "install_steps": [
+      "curl -fsSL https://goss.rocks/install | sh",
+      "Or: brew install goss",
+      "Verify: goss --version",
+      "supercli plugins install ./plugins/goss --on-conflict replace --json"
+    ],
+    "note": "goss lets you validate server configuration, docker containers, and infrastructure state with fast YAML-based tests. Use `goss add` to generate tests, `goss validate` to run them."
+  },
+  "commands": [
+    {
+      "namespace": "goss",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to goss CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "goss",
+        "passthrough": true,
+        "missingDependencyHelp": "Install goss: curl -fsSL https://goss.rocks/install | sh"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/hivemind/install-guidance.json
+++ b/plugins/hivemind/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "hivemind",
+  "binary": "hivemind",
+  "check": "which hivemind",
+  "install_steps": [
+    "brew install hivemind",
+    "Or: go install github.com/DarthSim/hivemind@latest",
+    "Verify: hivemind --version",
+    "supercli plugins install ./plugins/hivemind --on-conflict replace --json"
+  ],
+  "note": "Hivemind is a lightweight process manager for Procfile-based applications. Unlike overmind, it does not require tmux. Written in Go."
+}

--- a/plugins/hivemind/meta.json
+++ b/plugins/hivemind/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Process manager for Procfile-based applications — lightweight alternative to overmind/foreman",
+  "tags": ["hivemind", "procfile", "process-manager", "go", "development", "lightweight"],
+  "has_learn": false
+}

--- a/plugins/hivemind/plugin.json
+++ b/plugins/hivemind/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "hivemind",
+  "version": "0.1.0",
+  "description": "Process manager for Procfile-based applications — lightweight alternative to overmind/foreman",
+  "source": "https://github.com/DarthSim/hivemind",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "hivemind"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "hivemind",
+    "binary": "hivemind",
+    "check": "which hivemind",
+    "install_steps": [
+      "brew install hivemind",
+      "Or: go install github.com/DarthSim/hivemind@latest",
+      "Verify: hivemind --version",
+      "supercli plugins install ./plugins/hivemind --on-conflict replace --json"
+    ],
+    "note": "Hivemind is a lightweight process manager for Procfile-based applications. Unlike overmind, it does not require tmux. Written in Go."
+  },
+  "commands": [
+    {
+      "namespace": "hivemind",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to hivemind CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hivemind",
+        "passthrough": true,
+        "missingDependencyHelp": "Install hivemind: brew install hivemind"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/mods/install-guidance.json
+++ b/plugins/mods/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "mods",
+  "binary": "mods",
+  "check": "which mods",
+  "install_steps": [
+    "brew install charmbracelet/tap/mods",
+    "Or: go install github.com/charmbracelet/mods@latest",
+    "Verify: mods --version",
+    "supercli plugins install ./plugins/mods --on-conflict replace --json"
+  ],
+  "note": "Requires an API key for an LLM provider (OpenAI, Anthropic, Gemini, etc.). Set MODS_MODEL and provider environment variables."
+}

--- a/plugins/mods/meta.json
+++ b/plugins/mods/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "AI on the command line — ask questions, process files, generate content, and automate workflows with LLMs",
+  "tags": ["mods", "ai", "llm", "charmbracelet", "cli", "openai", "anthropic", "gemini"],
+  "has_learn": false
+}

--- a/plugins/mods/plugin.json
+++ b/plugins/mods/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "mods",
+  "version": "0.1.0",
+  "description": "AI on the command line — ask questions, process files, generate content, and automate workflows with LLMs",
+  "source": "https://github.com/charmbracelet/mods",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "mods"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "mods",
+    "binary": "mods",
+    "check": "which mods",
+    "install_steps": [
+      "brew install charmbracelet/tap/mods",
+      "Or: go install github.com/charmbracelet/mods@latest",
+      "Verify: mods --version",
+      "supercli plugins install ./plugins/mods --on-conflict replace --json"
+    ],
+    "note": "Requires an API key for an LLM provider (OpenAI, Anthropic, Gemini, etc.). Set MODS_MODEL and provider env vars. See https://github.com/charmbracelet/mods for setup."
+  },
+  "commands": [
+    {
+      "namespace": "mods",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to mods CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "mods",
+        "passthrough": true,
+        "missingDependencyHelp": "Install mods: brew install charmbracelet/tap/mods"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/overmind/install-guidance.json
+++ b/plugins/overmind/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "overmind",
+  "binary": "overmind",
+  "check": "which overmind",
+  "install_steps": [
+    "brew install overmind",
+    "Or: gem install overmind",
+    "Verify: overmind --version",
+    "supercli plugins install ./plugins/overmind --on-conflict replace --json"
+  ],
+  "note": "Overmind manages Procfile-based applications using tmux. Each process runs in its own tmux pane. Requires tmux. Written in Go."
+}

--- a/plugins/overmind/meta.json
+++ b/plugins/overmind/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Process manager for Procfile-based applications with tmux integration",
+  "tags": ["overmind", "procfile", "process-manager", "tmux", "go", "development"],
+  "has_learn": false
+}

--- a/plugins/overmind/plugin.json
+++ b/plugins/overmind/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "overmind",
+  "version": "0.1.0",
+  "description": "Process manager for Procfile-based applications with tmux integration",
+  "source": "https://github.com/DarthSim/overmind",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "overmind"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "overmind",
+    "binary": "overmind",
+    "check": "which overmind",
+    "install_steps": [
+      "brew install overmind",
+      "Or: gem install overmind",
+      "Or download from https://github.com/DarthSim/overmind/releases",
+      "Verify: overmind --version",
+      "supercli plugins install ./plugins/overmind --on-conflict replace --json"
+    ],
+    "note": "Overmind manages Procfile-based applications using tmux. Each process runs in its own tmux pane. Requires tmux. Written in Go."
+  },
+  "commands": [
+    {
+      "namespace": "overmind",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to overmind CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "overmind",
+        "passthrough": true,
+        "missingDependencyHelp": "Install overmind: brew install overmind"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/resvg/install-guidance.json
+++ b/plugins/resvg/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "resvg",
+  "binary": "resvg",
+  "check": "which resvg",
+  "install_steps": [
+    "brew install resvg",
+    "Or: cargo install resvg",
+    "Verify: resvg --version",
+    "supercli plugins install ./plugins/resvg --on-conflict replace --json"
+  ],
+  "note": "resvg is an SVG rendering engine. Converts SVG to PNG/PDF/SVG formats. Written in Rust."
+}

--- a/plugins/resvg/meta.json
+++ b/plugins/resvg/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "SVG rendering and optimization CLI — convert SVG to PNG/PDF/SVG, minify and preview SVG files",
+  "tags": ["resvg", "svg", "rendering", "image", "conversion", "rust", "graphics"],
+  "has_learn": false
+}

--- a/plugins/resvg/plugin.json
+++ b/plugins/resvg/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "resvg",
+  "version": "0.1.0",
+  "description": "SVG rendering and optimization CLI — convert SVG to PNG/PDF/SVG, minify and preview SVG files",
+  "source": "https://github.com/linebender/resvg",
+  "checks": [
+    {
+      "type": "binary",
+      "name": "resvg"
+    }
+  ],
+  "install_guidance": {
+    "plugin": "resvg",
+    "binary": "resvg",
+    "check": "which resvg",
+    "install_steps": [
+      "brew install resvg",
+      "Or: cargo install resvg",
+      "Or download from https://github.com/linebender/resvg/releases",
+      "Verify: resvg --version",
+      "supercli plugins install ./plugins/resvg --on-conflict replace --json"
+    ],
+    "note": "resvg is an SVG rendering engine with a CLI for converting SVG to PNG/PDF/SVG. It supports SVG 1.1, SVG 2.0 features, and produces high-quality output. Written in Rust."
+  },
+  "commands": [
+    {
+      "namespace": "resvg",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to resvg CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "resvg",
+        "passthrough": true,
+        "missingDependencyHelp": "Install resvg: brew install resvg"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

**Branch:** `am/am-f17c27-thjx5f`

## Summary

Add 5 new bundled plugins (mods, goss, resvg, overmind, hivemind) to grow the plugin catalog toward 12000. These are real, useful CLI tools that were not previously in the catalog. Each follows the standard passthrough adapter pattern with plugin.json, meta.json, and install-guidance.json.

**Diff:**
```
plugins/goss/install-guidance.json     | 12 ++++++++++
 plugins/goss/meta.json                 |  5 +++++
 plugins/goss/plugin.json               | 39 +++++++++++++++++++++++++++++++++
 plugins/hivemind/install-guidance.json | 12 ++++++++++
 plugins/hivemind/meta.json             |  5 +++++
 plugins/hivemind/plugin.json           | 39 +++++++++++++++++++++++++++++++++
 plugins/mods/install-guidance.json     | 12 ++++++++++
 plugins/mods/meta.json                 |  5 +++++
 plugins/mods/plugin.json               | 39 +++++++++++++++++++++++++++++++++
 plugins/overmind/install-guidance.json | 12 ++++++++++
 plugins/overmind/meta.json             |  5 +++++
 plugins/overmind/plugin.json           | 40 ++++++++++++++++++++++++++++++++++
 plugins/resvg/install-guidance.json    | 12 ++++++++++
 plugins/resvg/meta.json                |  5 +++++
 plugins/resvg/plugin.json              | 40 ++++++++++++++++++++++++++++++++++
 15 files changed, 282 insertions(+)
```
