### PR TITLE
feat: add 5 bundled plugins — binenv, webi, hermit, chsrc, uplot

### DIFF
--- a/plugins/binenv/install-guidance.json
+++ b/plugins/binenv/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "binenv",
+  "binary": "binenv",
+  "check": "which binenv",
+  "install_steps": [
+    "go install github.com/devops-works/binenv@latest",
+    "Verify: binenv --version",
+    "supercli plugins install ./plugins/binenv --on-conflict replace --json"
+  ],
+  "note": "Also available as a prebuilt binary from GitHub releases: https://github.com/devops-works/binenv/releases"
+}

--- a/plugins/binenv/meta.json
+++ b/plugins/binenv/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "binenv — binary version manager. Installs/manages versions of CLI tools (kubectl, terraform, etc.) via shims and a lock file.",
+  "tags": ["binenv", "binary", "version-manager", "cli", "tools", "devops"],
+  "has_learn": false
+}

--- a/plugins/binenv/plugin.json
+++ b/plugins/binenv/plugin.json
@@ -1,0 +1,80 @@
+{
+  "name": "binenv",
+  "version": "0.1.0",
+  "description": "binenv — binary version manager. Installs and manages versions of CLI binaries with shims and a lock file",
+  "source": "https://github.com/devops-works/binenv",
+  "checks": [
+    { "type": "binary", "name": "binenv" }
+  ],
+  "install_guidance": {
+    "plugin": "binenv",
+    "binary": "binenv",
+    "check": "which binenv",
+    "install_steps": [
+      "go install github.com/devops-works/binenv@latest",
+      "Verify: binenv --version",
+      "supercli plugins install ./plugins/binenv --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "binenv",
+      "resource": "self",
+      "action": "version",
+      "description": "Print binenv version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "binenv",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install binenv: go install github.com/devops-works/binenv@latest"
+      },
+      "args": []
+    },
+    {
+      "namespace": "binenv",
+      "resource": "binary",
+      "action": "install",
+      "description": "Install a specific binary version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "binenv",
+        "baseArgs": ["install"],
+        "positionalArgs": ["name", "version"],
+        "missingDependencyHelp": "Install binenv"
+      },
+      "args": [
+        { "name": "name", "type": "string", "required": true, "description": "Binary name to install" },
+        { "name": "version", "type": "string", "required": false, "description": "Version to install (default: latest)" }
+      ]
+    },
+    {
+      "namespace": "binenv",
+      "resource": "binary",
+      "action": "list",
+      "description": "List installed binaries and versions",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "binenv",
+        "baseArgs": ["list"],
+        "missingDependencyHelp": "Install binenv"
+      },
+      "args": []
+    },
+    {
+      "namespace": "binenv",
+      "resource": "binary",
+      "action": "available",
+      "description": "List available versions for a binary",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "binenv",
+        "baseArgs": ["available"],
+        "positionalArgs": ["name"],
+        "missingDependencyHelp": "Install binenv"
+      },
+      "args": [
+        { "name": "name", "type": "string", "required": true, "description": "Binary name" }
+      ]
+    }
+  ]
+}

--- a/plugins/chsrc/install-guidance.json
+++ b/plugins/chsrc/install-guidance.json
@@ -1,0 +1,12 @@
+{
+  "plugin": "chsrc",
+  "binary": "chsrc",
+  "check": "which chsrc",
+  "install_steps": [
+    "brew install chsrc",
+    "or: Download binary from https://github.com/RubyMetric/chsrc/releases",
+    "Verify: chsrc --version",
+    "supercli plugins install ./plugins/chsrc --on-conflict replace --json"
+  ],
+  "note": "Also available via: scoop, winget, and direct binary download."
+}

--- a/plugins/chsrc/meta.json
+++ b/plugins/chsrc/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "chsrc — cross-platform source mirror changer. Switches to faster mirrors for brew, pip, npm, apt, and more.",
+  "tags": ["chsrc", "mirror", "source", "package-manager", "tools", "system"],
+  "has_learn": false
+}

--- a/plugins/chsrc/plugin.json
+++ b/plugins/chsrc/plugin.json
@@ -1,0 +1,80 @@
+{
+  "name": "chsrc",
+  "version": "0.1.0",
+  "description": "chsrc — cross-platform universal source mirror changer. Switches software sources for various package managers and tools",
+  "source": "https://github.com/RubyMetric/chsrc",
+  "checks": [
+    { "type": "binary", "name": "chsrc" }
+  ],
+  "install_guidance": {
+    "plugin": "chsrc",
+    "binary": "chsrc",
+    "check": "which chsrc",
+    "install_steps": [
+      "brew install chsrc",
+      "or: curl -L https://github.com/RubyMetric/chsrc/releases/latest/download/chsrc-x64-linux -o /usr/local/bin/chsrc && chmod +x /usr/local/bin/chsrc",
+      "Verify: chsrc --version",
+      "supercli plugins install ./plugins/chsrc --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "chsrc",
+      "resource": "self",
+      "action": "version",
+      "description": "Print chsrc version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "chsrc",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install chsrc: brew install chsrc"
+      },
+      "args": []
+    },
+    {
+      "namespace": "chsrc",
+      "resource": "source",
+      "action": "list",
+      "description": "List available source mirrors",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "chsrc",
+        "baseArgs": ["list"],
+        "missingDependencyHelp": "Install chsrc"
+      },
+      "args": []
+    },
+    {
+      "namespace": "chsrc",
+      "resource": "source",
+      "action": "set",
+      "description": "Set a source mirror for a tool",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "chsrc",
+        "baseArgs": ["set"],
+        "positionalArgs": ["tool"],
+        "missingDependencyHelp": "Install chsrc"
+      },
+      "args": [
+        { "name": "tool", "type": "string", "required": true, "description": "Tool/package manager to set mirror for (e.g., brew, pip, npm)" }
+      ]
+    },
+    {
+      "namespace": "chsrc",
+      "resource": "source",
+      "action": "reset",
+      "description": "Reset source mirrors to default",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "chsrc",
+        "baseArgs": ["reset"],
+        "positionalArgs": ["tool"],
+        "missingDependencyHelp": "Install chsrc"
+      },
+      "args": [
+        { "name": "tool", "type": "string", "required": true, "description": "Tool to reset mirrors for" }
+      ]
+    }
+  ]
+}

--- a/plugins/hermit/install-guidance.json
+++ b/plugins/hermit/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "hermit",
+  "binary": "hermit",
+  "check": "which hermit",
+  "install_steps": [
+    "curl -fsSL https://github.com/cashapp/hermit/releases/download/stable/get-hermit.sh | sh",
+    "Verify: hermit --version",
+    "supercli plugins install ./plugins/hermit --on-conflict replace --json"
+  ],
+  "note": "Activate hermit per project: 'hermit init' in the project root. Also available via 'go install github.com/cashapp/hermit@latest'."
+}

--- a/plugins/hermit/meta.json
+++ b/plugins/hermit/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "hermit — per-project tool manager. Isolated tool environments per project for consistent dev and CI tooling.",
+  "tags": ["hermit", "tool-manager", "project", "environment", "dev-tools", "go"],
+  "has_learn": false
+}

--- a/plugins/hermit/plugin.json
+++ b/plugins/hermit/plugin.json
@@ -1,0 +1,76 @@
+{
+  "name": "hermit",
+  "version": "0.1.0",
+  "description": "hermit — per-project tool manager. Manages isolated sets of CLI tools per project for consistent environments across teams and CI",
+  "source": "https://github.com/cashapp/hermit",
+  "checks": [
+    { "type": "binary", "name": "hermit" }
+  ],
+  "install_guidance": {
+    "plugin": "hermit",
+    "binary": "hermit",
+    "check": "which hermit",
+    "install_steps": [
+      "curl -fsSL https://github.com/cashapp/hermit/releases/download/stable/get-hermit.sh | sh",
+      "Verify: hermit --version",
+      "supercli plugins install ./plugins/hermit --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "hermit",
+      "resource": "self",
+      "action": "version",
+      "description": "Print hermit version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hermit",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install hermit: curl -fsSL https://github.com/cashapp/hermit/releases/download/stable/get-hermit.sh | sh"
+      },
+      "args": []
+    },
+    {
+      "namespace": "hermit",
+      "resource": "env",
+      "action": "init",
+      "description": "Initialize hermit in the current project",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hermit",
+        "baseArgs": ["init"],
+        "missingDependencyHelp": "Install hermit"
+      },
+      "args": []
+    },
+    {
+      "namespace": "hermit",
+      "resource": "binary",
+      "action": "install",
+      "description": "Install a tool into the hermit-managed project",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hermit",
+        "baseArgs": ["install"],
+        "positionalArgs": ["name"],
+        "missingDependencyHelp": "Install hermit"
+      },
+      "args": [
+        { "name": "name", "type": "string", "required": true, "description": "Tool name to install" }
+      ]
+    },
+    {
+      "namespace": "hermit",
+      "resource": "binary",
+      "action": "list",
+      "description": "List installed hermit-managed tools",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "hermit",
+        "baseArgs": ["list"],
+        "missingDependencyHelp": "Install hermit"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/uplot/install-guidance.json
+++ b/plugins/uplot/install-guidance.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "uplot",
+  "binary": "uplot",
+  "check": "which uplot",
+  "install_steps": [
+    "brew install youplot",
+    "or: gem install youplot",
+    "or: nix shell nixpkgs#youplot",
+    "Verify: uplot --version",
+    "supercli plugins install ./plugins/uplot --on-conflict replace --json"
+  ],
+  "note": "Binary name is 'uplot'. Also available via guix."
+}

--- a/plugins/uplot/meta.json
+++ b/plugins/uplot/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "YouPlot (uplot) — terminal plotting tool. Bar charts, histograms, box plots, scatter plots, and more from CSV/TSV data.",
+  "tags": ["uplot", "youplot", "plot", "chart", "terminal", "data", "visualization", "ruby"],
+  "has_learn": false
+}

--- a/plugins/uplot/plugin.json
+++ b/plugins/uplot/plugin.json
@@ -1,0 +1,96 @@
+{
+  "name": "uplot",
+  "version": "0.1.0",
+  "description": "YouPlot (uplot) — terminal plotting tool. Draws bar charts, histograms, box plots, scatter plots and more right in the terminal",
+  "source": "https://github.com/red-data-tools/YouPlot",
+  "checks": [
+    { "type": "binary", "name": "uplot" }
+  ],
+  "install_guidance": {
+    "plugin": "uplot",
+    "binary": "uplot",
+    "check": "which uplot",
+    "install_steps": [
+      "brew install youplot",
+      "or: gem install youplot",
+      "Verify: uplot --version",
+      "supercli plugins install ./plugins/uplot --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "uplot",
+      "resource": "self",
+      "action": "version",
+      "description": "Print uplot version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "uplot",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install YouPlot: brew install youplot"
+      },
+      "args": []
+    },
+    {
+      "namespace": "uplot",
+      "resource": "plot",
+      "action": "bar",
+      "description": "Draw a bar chart from CSV/TSV data",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "uplot",
+        "baseArgs": ["bar"],
+        "passthrough": true,
+        "missingDependencyHelp": "Install YouPlot: brew install youplot"
+      },
+      "args": [
+        { "name": "data", "type": "string", "required": false, "description": "Data input (CSV/TSV file or pipe)" }
+      ]
+    },
+    {
+      "namespace": "uplot",
+      "resource": "plot",
+      "action": "histogram",
+      "description": "Draw a histogram from data",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "uplot",
+        "baseArgs": ["hist"],
+        "passthrough": true,
+        "missingDependencyHelp": "Install YouPlot: brew install youplot"
+      },
+      "args": [
+        { "name": "data", "type": "string", "required": false, "description": "Data input" }
+      ]
+    },
+    {
+      "namespace": "uplot",
+      "resource": "plot",
+      "action": "scatter",
+      "description": "Draw a scatter plot from CSV/TSV data",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "uplot",
+        "baseArgs": ["scatter"],
+        "passthrough": true,
+        "missingDependencyHelp": "Install YouPlot: brew install youplot"
+      },
+      "args": [
+        { "name": "data", "type": "string", "required": false, "description": "Data input" }
+      ]
+    },
+    {
+      "namespace": "uplot",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to uplot CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "uplot",
+        "passthrough": true,
+        "missingDependencyHelp": "Install YouPlot: brew install youplot"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/webi/install-guidance.json
+++ b/plugins/webi/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "webi",
+  "binary": "webi",
+  "check": "which webi",
+  "install_steps": [
+    "curl -sS https://webi.sh/webi | sh",
+    "Verify: webi --version",
+    "supercli plugins install ./plugins/webi --on-conflict replace --json"
+  ],
+  "note": "After install, use 'webi <tool>' to install other tools (e.g., 'webi go', 'webi node')."
+}

--- a/plugins/webi/meta.json
+++ b/plugins/webi/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "webi — web-based installer for dev tools. Installs via easy URLs without sudo, works on Linux/macOS/Windows.",
+  "tags": ["webi", "installer", "tools", "dev-tools", "webinstall"],
+  "has_learn": false
+}

--- a/plugins/webi/plugin.json
+++ b/plugins/webi/plugin.json
@@ -1,0 +1,62 @@
+{
+  "name": "webi",
+  "version": "0.1.0",
+  "description": "webi — web-based installer for developer tools. Installs tools via easy-to-remember URLs without sudo or a package manager",
+  "source": "https://github.com/webinstall/webi-installers",
+  "checks": [
+    { "type": "binary", "name": "webi" }
+  ],
+  "install_guidance": {
+    "plugin": "webi",
+    "binary": "webi",
+    "check": "which webi",
+    "install_steps": [
+      "curl -sS https://webi.sh/webi | sh",
+      "Verify: webi --version",
+      "supercli plugins install ./plugins/webi --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "webi",
+      "resource": "self",
+      "action": "version",
+      "description": "Print webi version",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "webi",
+        "baseArgs": ["--version"],
+        "missingDependencyHelp": "Install webi: curl -sS https://webi.sh/webi | sh"
+      },
+      "args": []
+    },
+    {
+      "namespace": "webi",
+      "resource": "install",
+      "action": "run",
+      "description": "Install a tool via webi URL",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "webi",
+        "passthrough": true,
+        "missingDependencyHelp": "Install webi: curl -sS https://webi.sh/webi | sh"
+      },
+      "args": [
+        { "name": "tool", "type": "string", "required": true, "description": "Tool name or webi URL to install" }
+      ]
+    },
+    {
+      "namespace": "webi",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to webi CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "webi",
+        "passthrough": true,
+        "missingDependencyHelp": "Install webi: curl -sS https://webi.sh/webi | sh"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #337 (am/am-f17c27-thjx5f): feat: add 5 bundled plugins — mods, goss, resvg, overmind, hivemind
    touches: plugins/goss/install-guidance.json, plugins/goss/meta.json, plugins/goss/plugin.json, plugins/hivemind/install-guidance.json, plugins/hivemind/meta.json, plugins/hivemind/plugin.json, plugins/mods/install-guidance.json, plugins/mods/meta.json, plugins/mods/plugin.json, plugins/overmind/install-guidance.json, plugins/overmind/meta.json, plugins/overmind/plugin.json (+3 more)


**Branch:** `am/am-f17c27-thk0ar`

## Summary

feat: add 5 bundled plugins — binenv, webi, hermit, chsrc, uplot

Added 5 new bundled plugins using the isolated directory convention:
- binenv (devops-works/binenv) — binary version manager that installs/manages CLI tool versions via shims
- webi (webinstall/webi-installers) — web-based installer that fetches tools via easy-to-remember URLs without sudo
- hermit (cashapp/hermit) — per-project tool manager for consistent dev/CI environments
- chsrc (RubyMetric/chsrc) — cross-platform utility to switch package manager mirrors to faster sources
- uplot (red-data-tools/YouPlot) — terminal plotting tool for bar charts, histograms, scatter plots from CSV/TSV data

These are real, useful CLI tools not already in the catalog. No overlap with open PRs or existing plugins.

**Diff:**
```
plugins/binenv/install-guidance.json | 11 +++++
 plugins/binenv/meta.json             |  5 ++
 plugins/binenv/plugin.json           | 80 ++++++++++++++++++++++++++++++
 plugins/chsrc/install-guidance.json  | 12 +++++
 plugins/chsrc/meta.json              |  5 ++
 plugins/chsrc/plugin.json            | 80 ++++++++++++++++++++++++++++++
 plugins/hermit/install-guidance.json | 11 +++++
 plugins/hermit/meta.json             |  5 ++
 plugins/hermit/plugin.json           | 76 ++++++++++++++++++++++++++++
 plugins/uplot/install-guidance.json  | 13 +++++
 plugins/uplot/meta.json              |  5 ++
 plugins/uplot/plugin.json            | 96 ++++++++++++++++++++++++++++++++++++
 plugins/webi/install-guidance.json   | 11 +++++
 plugins/webi/meta.json               |  5 ++
 plugins/webi/plugin.json             | 62 +++++++++++++++++++++++
 15 files changed, 477 insertions(+)
```
