### PR TITLE
feat: add 5 bundled plugins — coder, rbspy, pkl, chainloop, komiser

### DIFF
--- a/plugins/chainloop/install-guidance.json
+++ b/plugins/chainloop/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "chainloop",
+  "binary": "chainloop",
+  "check": "which chainloop",
+  "install_steps": [
+    "curl -sSL https://raw.githubusercontent.com/chainloop-dev/chainloop/main/install.sh | sh",
+    "Verify: chainloop version",
+    "supercli plugins install ./plugins/chainloop --on-conflict replace --json"
+  ],
+  "note": "Also available via brew: brew install chainloop. Pre-built binaries at https://github.com/chainloop-dev/chainloop/releases. Integrates with SLSA, in-toto, and supports attestation generation for CI/CD pipelines."
+}

--- a/plugins/chainloop/meta.json
+++ b/plugins/chainloop/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Software supply chain attestation and metadata framework for artifact integrity and provenance.",
+  "tags": ["chainloop", "supply-chain", "attestation", "provenance", "slsa", "security", "go"],
+  "has_learn": false
+}

--- a/plugins/chainloop/plugin.json
+++ b/plugins/chainloop/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "chainloop",
+  "version": "0.1.0",
+  "description": "Software supply chain attestation and metadata framework for artifact integrity and provenance.",
+  "source": "https://github.com/chainloop-dev/chainloop",
+  "checks": [
+    { "type": "binary", "name": "chainloop" }
+  ],
+  "install_guidance": {
+    "plugin": "chainloop",
+    "binary": "chainloop",
+    "check": "which chainloop",
+    "install_steps": [
+      "curl -sSL https://raw.githubusercontent.com/chainloop-dev/chainloop/main/install.sh | sh",
+      "Verify: chainloop version",
+      "supercli plugins install ./plugins/chainloop --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "chainloop",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to chainloop CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "chainloop",
+        "passthrough": true,
+        "missingDependencyHelp": "Install chainloop: curl -sSL https://raw.githubusercontent.com/chainloop-dev/chainloop/main/install.sh | sh"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/coder/install-guidance.json
+++ b/plugins/coder/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "coder",
+  "binary": "coder",
+  "check": "which coder",
+  "install_steps": [
+    "curl -L https://coder.com/install.sh | sh",
+    "Verify: coder version",
+    "supercli plugins install ./plugins/coder --on-conflict replace --json"
+  ],
+  "note": "Also available via brew: brew install coder/coder/coder. Pre-built binaries at https://github.com/coder/coder/releases. Supports VS Code, JetBrains, Jupyter and web IDEs. Templates are defined as Terraform modules."
+}

--- a/plugins/coder/meta.json
+++ b/plugins/coder/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Remote development environments on your infrastructure via Terraform, provisioners, and templates for teams.",
+  "tags": ["coder", "remote-development", "dev-environment", "terraform", "infrastructure", "go"],
+  "has_learn": false
+}

--- a/plugins/coder/plugin.json
+++ b/plugins/coder/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "coder",
+  "version": "0.1.0",
+  "description": "Remote development environments on your infrastructure via Terraform, provisioners, and templates for teams.",
+  "source": "https://github.com/coder/coder",
+  "checks": [
+    { "type": "binary", "name": "coder" }
+  ],
+  "install_guidance": {
+    "plugin": "coder",
+    "binary": "coder",
+    "check": "which coder",
+    "install_steps": [
+      "curl -L https://coder.com/install.sh | sh",
+      "Verify: coder version",
+      "supercli plugins install ./plugins/coder --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "coder",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to coder CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "coder",
+        "passthrough": true,
+        "missingDependencyHelp": "Install coder: curl -L https://coder.com/install.sh | sh"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/komiser/install-guidance.json
+++ b/plugins/komiser/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "komiser",
+  "binary": "komiser",
+  "check": "which komiser",
+  "install_steps": [
+    "brew install komiser",
+    "Verify: komiser version",
+    "supercli plugins install ./plugins/komiser --on-conflict replace --json"
+  ],
+  "note": "Pre-built binaries at https://github.com/tailwarden/komiser/releases. Supports AWS, GCP, Azure, and OCI cloud providers. Provides cost dashboards, resource inventory, and anomaly detection."
+}

--- a/plugins/komiser/meta.json
+++ b/plugins/komiser/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Cloud cost visibility and optimization tool for AWS, GCP, Azure, and OCI with dashboards.",
+  "tags": ["komiser", "cloud", "cost", "aws", "gcp", "azure", "optimization", "go"],
+  "has_learn": false
+}

--- a/plugins/komiser/plugin.json
+++ b/plugins/komiser/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "komiser",
+  "version": "0.1.0",
+  "description": "Cloud cost visibility and optimization tool for AWS, GCP, Azure, and OCI with dashboards.",
+  "source": "https://github.com/tailwarden/komiser",
+  "checks": [
+    { "type": "binary", "name": "komiser" }
+  ],
+  "install_guidance": {
+    "plugin": "komiser",
+    "binary": "komiser",
+    "check": "which komiser",
+    "install_steps": [
+      "brew install komiser",
+      "Verify: komiser version",
+      "supercli plugins install ./plugins/komiser --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "komiser",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to komiser CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "komiser",
+        "passthrough": true,
+        "missingDependencyHelp": "Install komiser: brew install komiser"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/pkl/install-guidance.json
+++ b/plugins/pkl/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "pkl",
+  "binary": "pkl",
+  "check": "which pkl",
+  "install_steps": [
+    "brew install pkl",
+    "Verify: pkl --version",
+    "supercli plugins install ./plugins/pkl --on-conflict replace --json"
+  ],
+  "note": "Also available as a Java JAR or via direct download from https://github.com/apple/pkl/releases. Outputs JSON, YAML, XML, text, and Java properties. Supports IntelliJ and VS Code via language server."
+}

--- a/plugins/pkl/meta.json
+++ b/plugins/pkl/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Apple's configuration-as-code language with rich validation, IDE support, and multi-format output.",
+  "tags": ["pkl", "configuration", "config", "apple", "iac", "kotlin", "validation"],
+  "has_learn": false
+}

--- a/plugins/pkl/plugin.json
+++ b/plugins/pkl/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "pkl",
+  "version": "0.1.0",
+  "description": "Apple's configuration-as-code language with rich validation, IDE support, and multi-format output.",
+  "source": "https://github.com/apple/pkl",
+  "checks": [
+    { "type": "binary", "name": "pkl" }
+  ],
+  "install_guidance": {
+    "plugin": "pkl",
+    "binary": "pkl",
+    "check": "which pkl",
+    "install_steps": [
+      "brew install pkl",
+      "Verify: pkl --version",
+      "supercli plugins install ./plugins/pkl --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "pkl",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to pkl CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "pkl",
+        "passthrough": true,
+        "missingDependencyHelp": "Install pkl: brew install pkl"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/rbspy/install-guidance.json
+++ b/plugins/rbspy/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "rbspy",
+  "binary": "rbspy",
+  "check": "which rbspy",
+  "install_steps": [
+    "curl -L https://raw.githubusercontent.com/rbspy/rbspy/main/install.sh | sh",
+    "Verify: rbspy --version",
+    "supercli plugins install ./plugins/rbspy --on-conflict replace --json"
+  ],
+  "note": "Also available via brew: brew install rbspy, and via cargo: cargo install rbspy. Pre-built binaries at https://github.com/rbspy/rbspy/releases. Works by using ptrace to sample Ruby process stack traces — no library installation needed."
+}

--- a/plugins/rbspy/meta.json
+++ b/plugins/rbspy/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Sampling CPU profiler for Ruby, generating flamegraphs and call graphs with minimal overhead.",
+  "tags": ["rbspy", "ruby", "profiler", "performance", "flamegraph", "rust", "debugging"],
+  "has_learn": false
+}

--- a/plugins/rbspy/plugin.json
+++ b/plugins/rbspy/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "rbspy",
+  "version": "0.1.0",
+  "description": "Sampling CPU profiler for Ruby, generating flamegraphs and call graphs with minimal overhead.",
+  "source": "https://github.com/rbspy/rbspy",
+  "checks": [
+    { "type": "binary", "name": "rbspy" }
+  ],
+  "install_guidance": {
+    "plugin": "rbspy",
+    "binary": "rbspy",
+    "check": "which rbspy",
+    "install_steps": [
+      "curl -L https://raw.githubusercontent.com/rbspy/rbspy/main/install.sh | sh",
+      "Verify: rbspy --version",
+      "supercli plugins install ./plugins/rbspy --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "rbspy",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to rbspy CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "rbspy",
+        "passthrough": true,
+        "missingDependencyHelp": "Install rbspy: curl -L https://raw.githubusercontent.com/rbspy/rbspy/main/install.sh | sh"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #341 (am/am-f17c27-thkae4): feat: add 5 bundled plugins — sq, upx, wtfutil, amass, s-tui
    touches: plugins/amass/install-guidance.json, plugins/amass/meta.json, plugins/amass/plugin.json, plugins/s-tui/install-guidance.json, plugins/s-tui/meta.json, plugins/s-tui/plugin.json, plugins/sq/install-guidance.json, plugins/sq/meta.json, plugins/sq/plugin.json, plugins/upx/install-guidance.json, plugins/upx/meta.json, plugins/upx/plugin.json (+3 more)
- PR #340 (am/am-f17c27-thk78s): feat: add 5 bundled plugins — httprobe, tlrc, diun, slim, lazysql
    touches: plugins/diun/install-guidance.json, plugins/diun/meta.json, plugins/diun/plugin.json, plugins/httprobe/install-guidance.json, plugins/httprobe/meta.json, plugins/httprobe/plugin.json, plugins/lazysql/install-guidance.json, plugins/lazysql/meta.json, plugins/lazysql/plugin.json, plugins/slim/install-guidance.json, plugins/slim/meta.json, plugins/slim/plugin.json (+3 more)
- PR #339 (am/am-f17c27-thk3tg): feat: add 3 bundled plugins — xata, irssi, dar
    touches: plugins/dar/install-guidance.json, plugins/dar/meta.json, plugins/dar/plugin.json, plugins/irssi/install-guidance.json, plugins/irssi/meta.json, plugins/irssi/plugin.json, plugins/xata/install-guidance.json, plugins/xata/meta.json, plugins/xata/plugin.json
- PR #338 (am/am-f17c27-thk0ar): feat: add 5 bundled plugins — binenv, webi, hermit, chsrc, uplot
    touches: plugins/binenv/install-guidance.json, plugins/binenv/meta.json, plugins/binenv/plugin.json, plugins/chsrc/install-guidance.json, plugins/chsrc/meta.json, plugins/chsrc/plugin.json, plugins/hermit/install-guidance.json, plugins/hermit/meta.json, plugins/hermit/plugin.json, plugins/uplot/install-guidance.json, plugins/uplot/meta.json, plugins/uplot/plugin.json (+3 more)
- PR #337 (am/am-f17c27-thjx5f): feat: add 5 bundled plugins — mods, goss, resvg, overmind, hivemind
    touches: plugins/goss/install-guidance.json, plugins/goss/meta.json, plugins/goss/plugin.json, plugins/hivemind/install-guidance.json, plugins/hivemind/meta.json, plugins/hivemind/plugin.json, plugins/mods/install-guidance.json, plugins/mods/meta.json, plugins/mods/plugin.json, plugins/overmind/install-guidance.json, plugins/overmind/meta.json, plugins/overmind/plugin.json (+3 more)


**Branch:** `am/am-f17c27-thkdg5`

## Summary

Added 5 new bundled plugins: coder (remote dev environments), rbspy (Ruby sampling profiler), pkl (Apple config-as-code), chainloop (supply chain attestation), komiser (cloud cost visibility). Each has plugin.json, meta.json, and install-guidance.json following the standard schema.

**Diff:**
```
plugins/chainloop/install-guidance.json | 11 +++++++++++
 plugins/chainloop/meta.json             |  5 +++++
 plugins/chainloop/plugin.json           | 34 +++++++++++++++++++++++++++++++++
 plugins/coder/install-guidance.json     | 11 +++++++++++
 plugins/coder/meta.json                 |  5 +++++
 plugins/coder/plugin.json               | 34 +++++++++++++++++++++++++++++++++
 plugins/komiser/install-guidance.json   | 11 +++++++++++
 plugins/komiser/meta.json               |  5 +++++
 plugins/komiser/plugin.json             | 34 +++++++++++++++++++++++++++++++++
 plugins/pkl/install-guidance.json       | 11 +++++++++++
 plugins/pkl/meta.json                   |  5 +++++
 plugins/pkl/plugin.json                 | 34 +++++++++++++++++++++++++++++++++
 plugins/rbspy/install-guidance.json     | 11 +++++++++++
 plugins/rbspy/meta.json                 |  5 +++++
 plugins/rbspy/plugin.json               | 34 +++++++++++++++++++++++++++++++++
 15 files changed, 250 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for several new plugins: `chainloop`, `coder`, `komiser`, `pkl`, and `rbspy`.
  * Each plugin now includes command access, dependency checks, and guided installation steps.
  * Added plugin descriptions and tags to improve discoverability and browsing.
  * Expanded setup notes with alternative install options and verification steps for supported tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->