### PR TITLE
feat: add 5 bundled plugins — otree, atac, serpl, ov, dolt

### DIFF
--- a/plugins/atac/install-guidance.json
+++ b/plugins/atac/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "atac",
+  "binary": "atac",
+  "check": "which atac",
+  "install_steps": [
+    "cargo install atac (or download a release from https://github.com/Julien-cpsn/ATAC/releases)",
+    "Verify: atac --version",
+    "supercli plugins install ./plugins/atac --on-conflict replace --json"
+  ],
+  "note": "A free, open-source Postman/Insomnia alternative that runs entirely in the terminal. Supports Postman and Insomnia collection imports."
+}

--- a/plugins/atac/meta.json
+++ b/plugins/atac/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Arc-inspired API client for the terminal — send HTTP requests from a TUI, manage collections and environments.",
+  "tags": ["atac", "http", "api-client", "rest", "tui", "postman", "rust"],
+  "has_learn": false
+}

--- a/plugins/atac/plugin.json
+++ b/plugins/atac/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "atac",
+  "version": "0.1.0",
+  "description": "Arc-inspired API client for the terminal — send HTTP requests from a TUI, manage collections and environments.",
+  "source": "https://github.com/Julien-cpsn/ATAC",
+  "checks": [
+    { "type": "binary", "name": "atac" }
+  ],
+  "install_guidance": {
+    "plugin": "atac",
+    "binary": "atac",
+    "check": "which atac",
+    "install_steps": [
+      "cargo install atac (or download a release from https://github.com/Julien-cpsn/ATAC/releases)",
+      "Verify: atac --version",
+      "supercli plugins install ./plugins/atac --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "atac",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to atac CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "atac",
+        "passthrough": true,
+        "missingDependencyHelp": "Install atac: cargo install atac"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/dolt/install-guidance.json
+++ b/plugins/dolt/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "dolt",
+  "binary": "dolt",
+  "check": "which dolt",
+  "install_steps": [
+    "curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash (or brew install dolt)",
+    "Verify: dolt --version",
+    "supercli plugins install ./plugins/dolt --on-conflict replace --json"
+  ],
+  "note": "Also installable via 'brew install dolt'. Dolt is a MySQL-compatible SQL database you can fork, clone, branch, merge, push and pull just like a Git repository. Hosted on DoltHub."
+}

--- a/plugins/dolt/meta.json
+++ b/plugins/dolt/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Git for data — a SQL database with version control: branch, diff, merge, and clone your tables like a Git repository.",
+  "tags": ["dolt", "database", "sql", "version-control", "git", "mysql", "go"],
+  "has_learn": false
+}

--- a/plugins/dolt/plugin.json
+++ b/plugins/dolt/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "dolt",
+  "version": "0.1.0",
+  "description": "Git for data — a SQL database with version control: branch, diff, merge, and clone your tables like a Git repository.",
+  "source": "https://github.com/dolthub/dolt",
+  "checks": [
+    { "type": "binary", "name": "dolt" }
+  ],
+  "install_guidance": {
+    "plugin": "dolt",
+    "binary": "dolt",
+    "check": "which dolt",
+    "install_steps": [
+      "curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash (or brew install dolt)",
+      "Verify: dolt --version",
+      "supercli plugins install ./plugins/dolt --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "dolt",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to dolt CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "dolt",
+        "passthrough": true,
+        "missingDependencyHelp": "Install dolt: curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/otree/install-guidance.json
+++ b/plugins/otree/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "otree",
+  "binary": "otree",
+  "check": "which otree",
+  "install_steps": [
+    "cargo install otree (or download a release from https://github.com/fioncat/otree/releases)",
+    "Verify: otree --version",
+    "supercli plugins install ./plugins/otree --on-conflict replace --json"
+  ],
+  "note": "Also installable via 'brew install otree'. Navigate large JSON/YAML/TOML documents as a collapsible tree in your terminal."
+}

--- a/plugins/otree/meta.json
+++ b/plugins/otree/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Interactive TUI to view structured data (JSON, YAML, TOML) as a navigable tree.",
+  "tags": ["otree", "json", "yaml", "toml", "tui", "viewer", "rust"],
+  "has_learn": false
+}

--- a/plugins/otree/plugin.json
+++ b/plugins/otree/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "otree",
+  "version": "0.1.0",
+  "description": "Interactive TUI to view structured data (JSON, YAML, TOML) as a navigable tree.",
+  "source": "https://github.com/fioncat/otree",
+  "checks": [
+    { "type": "binary", "name": "otree" }
+  ],
+  "install_guidance": {
+    "plugin": "otree",
+    "binary": "otree",
+    "check": "which otree",
+    "install_steps": [
+      "cargo install otree (or download a release from https://github.com/fioncat/otree/releases)",
+      "Verify: otree --version",
+      "supercli plugins install ./plugins/otree --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "otree",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to otree CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "otree",
+        "passthrough": true,
+        "missingDependencyHelp": "Install otree: cargo install otree"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/ov/install-guidance.json
+++ b/plugins/ov/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "ov",
+  "binary": "ov",
+  "check": "which ov",
+  "install_steps": [
+    "go install github.com/noborus/ov@latest (or download a release from https://github.com/noborus/ov/releases)",
+    "Verify: ov --version",
+    "supercli plugins install ./plugins/ov --on-conflict replace --json"
+  ],
+  "note": "Also installable via 'brew install noborus/tap/ov'. A modern less/more replacement that can view CSV/TSV in column mode and follow logs like tail -f."
+}

--- a/plugins/ov/meta.json
+++ b/plugins/ov/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Feature-rich terminal pager with column mode, incremental search, multicolor highlighting, and follow mode.",
+  "tags": ["ov", "pager", "less", "viewer", "terminal", "tail", "go"],
+  "has_learn": false
+}

--- a/plugins/ov/plugin.json
+++ b/plugins/ov/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "ov",
+  "version": "0.1.0",
+  "description": "Feature-rich terminal pager with column mode, incremental search, multicolor highlighting, and follow mode.",
+  "source": "https://github.com/noborus/ov",
+  "checks": [
+    { "type": "binary", "name": "ov" }
+  ],
+  "install_guidance": {
+    "plugin": "ov",
+    "binary": "ov",
+    "check": "which ov",
+    "install_steps": [
+      "go install github.com/noborus/ov@latest (or download a release from https://github.com/noborus/ov/releases)",
+      "Verify: ov --version",
+      "supercli plugins install ./plugins/ov --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "ov",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to ov CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "ov",
+        "passthrough": true,
+        "missingDependencyHelp": "Install ov: go install github.com/noborus/ov@latest"
+      },
+      "args": []
+    }
+  ]
+}

--- a/plugins/serpl/install-guidance.json
+++ b/plugins/serpl/install-guidance.json
@@ -1,0 +1,11 @@
+{
+  "plugin": "serpl",
+  "binary": "serpl",
+  "check": "which serpl",
+  "install_steps": [
+    "cargo install serpl (or download a release from https://github.com/yassinebridi/serpl/releases)",
+    "Verify: serpl --version",
+    "supercli plugins install ./plugins/serpl --on-conflict replace --json"
+  ],
+  "note": "Requires ripgrep (rg) to be installed. Supports regex, match case, whole word, and per-match preview before replacing."
+}

--- a/plugins/serpl/meta.json
+++ b/plugins/serpl/meta.json
@@ -1,0 +1,5 @@
+{
+  "description": "Terminal UI for search and replace across files, powered by ripgrep — a TUI alternative to VS Code's find-and-replace.",
+  "tags": ["serpl", "search", "replace", "ripgrep", "tui", "refactor", "rust"],
+  "has_learn": false
+}

--- a/plugins/serpl/plugin.json
+++ b/plugins/serpl/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "serpl",
+  "version": "0.1.0",
+  "description": "Terminal UI for search and replace across files, powered by ripgrep — a TUI alternative to VS Code's find-and-replace.",
+  "source": "https://github.com/yassinebridi/serpl",
+  "checks": [
+    { "type": "binary", "name": "serpl" }
+  ],
+  "install_guidance": {
+    "plugin": "serpl",
+    "binary": "serpl",
+    "check": "which serpl",
+    "install_steps": [
+      "cargo install serpl (or download a release from https://github.com/yassinebridi/serpl/releases)",
+      "Verify: serpl --version",
+      "supercli plugins install ./plugins/serpl --on-conflict replace --json"
+    ]
+  },
+  "commands": [
+    {
+      "namespace": "serpl",
+      "resource": "_",
+      "action": "_",
+      "description": "Passthrough to serpl CLI",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "serpl",
+        "passthrough": true,
+        "missingDependencyHelp": "Install serpl: cargo install serpl (requires ripgrep)"
+      },
+      "args": []
+    }
+  ]
+}


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** OBJECTIVE: grow the plugin catalog toward 12000. Each run, add up to 5 new plugins (a directory under plugins/<name>/ with plugin.json, meta.json, install-guidance.json matching the existing schema) for real, useful CLI tools NOT already present. Strictly additive; do not modify existing plugins; single PR.

**Branch:** `am/am-f17c27-ti1vg3`

## Summary

Added 5 new bundled plugins to the SuperCLI catalog: otree (JSON/YAML/TOML tree viewer), atac (terminal API client), serpl (ripgrep search-and-replace TUI), ov (feature-rich pager), and dolt (Git-for-data SQL database). Each follows the existing plugin.json/meta.json/install-guidance.json schema with binary checks and process passthrough. Strictly additive; no existing plugins modified.

**Diff:**
```
plugins/atac/install-guidance.json  | 11 +++++++++++
 plugins/atac/meta.json              |  5 +++++
 plugins/atac/plugin.json            | 34 ++++++++++++++++++++++++++++++++++
 plugins/dolt/install-guidance.json  | 11 +++++++++++
 plugins/dolt/meta.json              |  5 +++++
 plugins/dolt/plugin.json            | 34 ++++++++++++++++++++++++++++++++++
 plugins/otree/install-guidance.json | 11 +++++++++++
 plugins/otree/meta.json             |  5 +++++
 plugins/otree/plugin.json           | 34 ++++++++++++++++++++++++++++++++++
 plugins/ov/install-guidance.json    | 11 +++++++++++
 plugins/ov/meta.json                |  5 +++++
 plugins/ov/plugin.json              | 34 ++++++++++++++++++++++++++++++++++
 plugins/serpl/install-guidance.json | 11 +++++++++++
 plugins/serpl/meta.json             |  5 +++++
 plugins/serpl/plugin.json           | 34 ++++++++++++++++++++++++++++++++++
 15 files changed, 250 insertions(+)
```
