### PR TITLE
test: add plugin routing tests for bundled upx plugin

### DIFF
--- a/__tests__/komiser-plugin.test.js
+++ b/__tests__/komiser-plugin.test.js
@@ -1,0 +1,72 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeBinary(dir, name) {
+  const bin = path.join(dir, name)
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === '--version') { console.log('komiser 4.0.5-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("komiser plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-komiser-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-komiser-"))
+  writeFakeBinary(fakeDir, "komiser")
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/komiser --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove komiser --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("supports namespace passthrough", () => {
+    const r = runNoServer("komiser --best --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("komiser.passthrough")
+    expect(data.data.args).toContain("--best")
+    expect(data.data.args).toContain("--json")
+  })
+
+  test("doctor reports komiser dependency as healthy", () => {
+    const r = runNoServer("plugins doctor komiser --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "komiser" && c.ok === true)).toBe(true)
+  })
+})

--- a/__tests__/upx-plugin.test.js
+++ b/__tests__/upx-plugin.test.js
@@ -1,0 +1,72 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeBinary(dir, name) {
+  const bin = path.join(dir, name)
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === '--version') { console.log('upx 4.2.4-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("upx plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-upx-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-upx-"))
+  writeFakeBinary(fakeDir, "upx")
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/upx --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove upx --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("supports namespace passthrough", () => {
+    const r = runNoServer("upx --best --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("upx.passthrough")
+    expect(data.data.args).toContain("--best")
+    expect(data.data.args).toContain("--json")
+  })
+
+  test("doctor reports upx dependency as healthy", () => {
+    const r = runNoServer("plugins doctor upx --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "upx" && c.ok === true)).toBe(true)
+  })
+})

--- a/__tests__/wtfutil-plugin.test.js
+++ b/__tests__/wtfutil-plugin.test.js
@@ -1,0 +1,72 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeBinary(dir, name) {
+  const bin = path.join(dir, name)
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === '--version') { console.log('wtfutil 0.43.0-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("wtfutil plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-wtfutil-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-wtfutil-"))
+  writeFakeBinary(fakeDir, "wtfutil")
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/wtfutil --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove wtfutil --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("supports namespace passthrough", () => {
+    const r = runNoServer("wtfutil --best --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("wtfutil.passthrough")
+    expect(data.data.args).toContain("--best")
+    expect(data.data.args).toContain("--json")
+  })
+
+  test("doctor reports wtfutil dependency as healthy", () => {
+    const r = runNoServer("plugins doctor wtfutil --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "wtfutil" && c.ok === true)).toBe(true)
+  })
+})


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #346 (am/am-f17c27-ti3q44): test: add plugin routing tests for bundled coder plugin
    touches: __tests__/coder-plugin.test.js, __tests__/pkl-plugin.test.js, __tests__/rbspy-plugin.test.js
- PR #345 (am/am-f17c27-ti2i84): test: add plugin routing tests for bundled notion-cli plugin
    touches: __tests__/diun-plugin.test.js, __tests__/notion-cli-plugin.test.js, __tests__/slim-plugin.test.js
- PR #344 (am/am-f17c27-ti2ce3): docs: align package.json description with 10,000+ plugins
    touches: __tests__/help.test.js, __tests__/mcp-diagnostics.test.js, package.json
- PR #343 (am/am-f17c27-ti1vg3): feat: add 5 bundled plugins — otree, atac, serpl, ov, dolt
    touches: plugins/atac/install-guidance.json, plugins/atac/meta.json, plugins/atac/plugin.json, plugins/dolt/install-guidance.json, plugins/dolt/meta.json, plugins/dolt/plugin.json, plugins/otree/install-guidance.json, plugins/otree/meta.json, plugins/otree/plugin.json, plugins/ov/install-guidance.json, plugins/ov/meta.json, plugins/ov/plugin.json (+3 more)


**Branch:** `am/am-f17c27-ti3vy5`

## Summary

Add jest routing tests for three recently-bundled but untested plugins: upx, komiser, and wtfutil. Each test installs the plugin against a fake binary on PATH, asserts the CLI routes 'namespace passthrough' commands correctly (command name + forwarded args), and verifies 'plugins doctor' reports the binary dependency as healthy. Mirrors the existing eza-plugin test pattern; no production code changes.

**Diff:**
```
__tests__/komiser-plugin.test.js | 72 ++++++++++++++++++++++++++++++++++++++++
 __tests__/upx-plugin.test.js     | 72 ++++++++++++++++++++++++++++++++++++++++
 __tests__/wtfutil-plugin.test.js | 72 ++++++++++++++++++++++++++++++++++++++++
 3 files changed, 216 insertions(+)
```
