### PR TITLE
test: add plugin routing tests for goss, amass, and tlrc

### DIFF
--- a/__tests__/amass-plugin.test.js
+++ b/__tests__/amass-plugin.test.js
@@ -1,0 +1,73 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeAmassBinary(dir) {
+  const bin = path.join(dir, "amass")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === '--version') { console.log('amass v5.0.0-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("amass plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-amass-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-amass-"))
+  writeFakeAmassBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/amass --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove amass --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("supports namespace passthrough", () => {
+    const r = runNoServer("amass enum -d example.com --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("amass.passthrough")
+    expect(data.data.args).toContain("enum")
+    expect(data.data.args).toContain("-d")
+    expect(data.data.args).toContain("example.com")
+  })
+
+  test("doctor reports amass dependency as healthy", () => {
+    const r = runNoServer("plugins doctor amass --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "amass" && c.ok === true)).toBe(true)
+  })
+})

--- a/__tests__/goss-plugin.test.js
+++ b/__tests__/goss-plugin.test.js
@@ -1,0 +1,73 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeGossBinary(dir) {
+  const bin = path.join(dir, "goss")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === '--version') { console.log('goss 0.4.9-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("goss plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-goss-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-goss-"))
+  writeFakeGossBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/goss --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove goss --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("supports namespace passthrough", () => {
+    const r = runNoServer("goss validate --format documentation --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("goss.passthrough")
+    expect(data.data.args).toContain("validate")
+    expect(data.data.args).toContain("--format")
+    expect(data.data.args).toContain("documentation")
+  })
+
+  test("doctor reports goss dependency as healthy", () => {
+    const r = runNoServer("plugins doctor goss --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "goss" && c.ok === true)).toBe(true)
+  })
+})

--- a/__tests__/hivemind-plugin.test.js
+++ b/__tests__/hivemind-plugin.test.js
@@ -1,0 +1,71 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeHivemindBinary(dir) {
+  const bin = path.join(dir, "hivemind")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === '--version') { console.log('Hivemind 1.1.0-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("hivemind plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-hivemind-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-hivemind-"))
+  writeFakeHivemindBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/hivemind --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove hivemind --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("supports namespace passthrough", () => {
+    const r = runNoServer("hivemind Procfile.dev --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("hivemind.passthrough")
+    expect(data.data.args).toContain("Procfile.dev")
+  })
+
+  test("doctor reports hivemind dependency as healthy", () => {
+    const r = runNoServer("plugins doctor hivemind --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "hivemind" && c.ok === true)).toBe(true)
+  })
+})

--- a/__tests__/mods-plugin.test.js
+++ b/__tests__/mods-plugin.test.js
@@ -1,0 +1,72 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeModsBinary(dir) {
+  const bin = path.join(dir, "mods")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === '--version') { console.log('mods version 1.7.0-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("mods plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-mods-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-mods-"))
+  writeFakeModsBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/mods --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove mods --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("supports namespace passthrough", () => {
+    const r = runNoServer("mods --model gpt-4 --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("mods.passthrough")
+    expect(data.data.args).toContain("--model")
+    expect(data.data.args).toContain("gpt-4")
+  })
+
+  test("doctor reports mods dependency as healthy", () => {
+    const r = runNoServer("plugins doctor mods --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "mods" && c.ok === true)).toBe(true)
+  })
+})

--- a/__tests__/tlrc-plugin.test.js
+++ b/__tests__/tlrc-plugin.test.js
@@ -1,0 +1,81 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+// tlrc ships the official tldr client, so the binary on PATH is named `tldr`.
+function writeFakeTldrBinary(dir) {
+  const bin = path.join(dir, "tldr")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === '--version') { console.log('tlrc 1.11.0-test'); process.exit(0); }",
+    "if (args[0] === '--list') { console.log('tar\\nzip\\ngit'); process.exit(0); }",
+    "console.log('Page for ' + args.join(' '));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("tlrc plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-tlrc-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-tlrc-"))
+  writeFakeTldrBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/tlrc --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove tlrc --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("routes self version wrapped command", () => {
+    const r = runNoServer("tldr self version --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("tldr.self.version")
+    expect(data.data.raw).toBe("tlrc 1.11.0-test")
+  })
+
+  test("routes cache list wrapped command", () => {
+    const r = runNoServer("tldr cache list --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("tldr.cache.list")
+    expect(data.data.raw).toContain("git")
+  })
+
+  test("doctor reports tldr dependency as healthy", () => {
+    const r = runNoServer("plugins doctor tlrc --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "tldr" && c.ok === true)).toBe(true)
+  })
+})


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #347 (am/am-f17c27-ti3vy5): test: add plugin routing tests for bundled upx plugin
    touches: __tests__/komiser-plugin.test.js, __tests__/upx-plugin.test.js, __tests__/wtfutil-plugin.test.js
- PR #346 (am/am-f17c27-ti3q44): test: add plugin routing tests for bundled coder plugin
    touches: __tests__/coder-plugin.test.js, __tests__/pkl-plugin.test.js, __tests__/rbspy-plugin.test.js
- PR #345 (am/am-f17c27-ti2i84): test: add plugin routing tests for bundled notion-cli plugin
    touches: __tests__/diun-plugin.test.js, __tests__/notion-cli-plugin.test.js, __tests__/slim-plugin.test.js
- PR #344 (am/am-f17c27-ti2ce3): docs: align package.json description with 10,000+ plugins
    touches: __tests__/help.test.js, __tests__/mcp-diagnostics.test.js, package.json
- PR #343 (am/am-f17c27-ti1vg3): feat: add 5 bundled plugins — otree, atac, serpl, ov, dolt
    touches: plugins/atac/install-guidance.json, plugins/atac/meta.json, plugins/atac/plugin.json, plugins/dolt/install-guidance.json, plugins/dolt/meta.json, plugins/dolt/plugin.json, plugins/otree/install-guidance.json, plugins/otree/meta.json, plugins/otree/plugin.json, plugins/ov/install-guidance.json, plugins/ov/meta.json, plugins/ov/plugin.json (+3 more)


**Branch:** `am/am-f17c27-ti41r3`

## Summary

Added plugin routing test coverage for five bundled plugins that previously had none: goss, amass, tlrc, hivemind, and mods. Each suite installs the plugin against a fake binary on PATH, then asserts command routing (namespace passthrough plus tlrc's wrapped self-version/cache-list commands) and that `plugins doctor` reports the binary dependency as healthy. This guards against regressions in the process-adapter routing for these wrappers. Committed as three separate, non-overlapping commits.

**Diff:**
```
__tests__/amass-plugin.test.js    | 73 +++++++++++++++++++++++++++++++++++
 __tests__/goss-plugin.test.js     | 73 +++++++++++++++++++++++++++++++++++
 __tests__/hivemind-plugin.test.js | 71 ++++++++++++++++++++++++++++++++++
 __tests__/mods-plugin.test.js     | 72 ++++++++++++++++++++++++++++++++++
 __tests__/tlrc-plugin.test.js     | 81 +++++++++++++++++++++++++++++++++++++++
 5 files changed, 370 insertions(+)
```
