### PR TITLE
test: add plugin routing tests for bundled chainloop plugin

### DIFF
--- a/__tests__/chainloop-plugin.test.js
+++ b/__tests__/chainloop-plugin.test.js
@@ -1,0 +1,81 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeChainloopBinary(dir) {
+  const bin = path.join(dir, "chainloop")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === 'version') { console.log('chainloop 0.1.0-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("chainloop plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-chainloop-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-chainloop-"))
+  writeFakeChainloopBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/chainloop --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove chainloop --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("routes namespace passthrough to the chainloop binary", () => {
+    const r = runNoServer("chainloop version --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("chainloop.passthrough")
+    expect(data.data.raw).toBe("chainloop 0.1.0-test")
+  })
+
+  test("forwards arbitrary flags through passthrough", () => {
+    const r = runNoServer("chainloop workflow list --output json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("chainloop.passthrough")
+    expect(data.data.args).toContain("workflow")
+    expect(data.data.args).toContain("list")
+    expect(data.data.args).toContain("--output")
+  })
+
+  test("doctor reports chainloop dependency as healthy", () => {
+    const r = runNoServer("plugins doctor chainloop --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "chainloop" && c.ok === true)).toBe(true)
+  })
+})

--- a/__tests__/overmind-plugin.test.js
+++ b/__tests__/overmind-plugin.test.js
@@ -1,0 +1,81 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeOvermindBinary(dir) {
+  const bin = path.join(dir, "overmind")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === 'version') { console.log('overmind 2.5.1-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("overmind plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-overmind-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-overmind-"))
+  writeFakeOvermindBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/overmind --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove overmind --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("routes namespace passthrough to the overmind binary", () => {
+    const r = runNoServer("overmind version --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("overmind.passthrough")
+    expect(data.data.raw).toBe("overmind 2.5.1-test")
+  })
+
+  test("forwards subcommands and flags through passthrough", () => {
+    const r = runNoServer("overmind start -f ./Procfile.dev", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("overmind.passthrough")
+    expect(data.data.args).toContain("start")
+    expect(data.data.args).toContain("-f")
+    expect(data.data.args).toContain("./Procfile.dev")
+  })
+
+  test("doctor reports overmind dependency as healthy", () => {
+    const r = runNoServer("plugins doctor overmind --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "overmind" && c.ok === true)).toBe(true)
+  })
+})

--- a/__tests__/resvg-plugin.test.js
+++ b/__tests__/resvg-plugin.test.js
@@ -1,0 +1,81 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeResvgBinary(dir) {
+  const bin = path.join(dir, "resvg")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === 'version') { console.log('resvg 0.44.0-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("resvg plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-resvg-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-resvg-"))
+  writeFakeResvgBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/resvg --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove resvg --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("routes namespace passthrough to the resvg binary", () => {
+    const r = runNoServer("resvg version --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("resvg.passthrough")
+    expect(data.data.raw).toBe("resvg 0.44.0-test")
+  })
+
+  test("forwards conversion arguments through passthrough", () => {
+    const r = runNoServer("resvg input.svg output.png --width 512", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("resvg.passthrough")
+    expect(data.data.args).toContain("input.svg")
+    expect(data.data.args).toContain("output.png")
+    expect(data.data.args).toContain("--width")
+  })
+
+  test("doctor reports resvg dependency as healthy", () => {
+    const r = runNoServer("plugins doctor resvg --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "resvg" && c.ok === true)).toBe(true)
+  })
+})


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #348 (am/am-f17c27-ti41r3): test: add plugin routing tests for goss, amass, and tlrc
    touches: __tests__/amass-plugin.test.js, __tests__/goss-plugin.test.js, __tests__/hivemind-plugin.test.js, __tests__/mods-plugin.test.js, __tests__/tlrc-plugin.test.js
- PR #347 (am/am-f17c27-ti3vy5): test: add plugin routing tests for bundled upx plugin
    touches: __tests__/komiser-plugin.test.js, __tests__/upx-plugin.test.js, __tests__/wtfutil-plugin.test.js
- PR #346 (am/am-f17c27-ti3q44): test: add plugin routing tests for bundled coder plugin
    touches: __tests__/coder-plugin.test.js, __tests__/pkl-plugin.test.js, __tests__/rbspy-plugin.test.js
- PR #345 (am/am-f17c27-ti2i84): test: add plugin routing tests for bundled notion-cli plugin
    touches: __tests__/diun-plugin.test.js, __tests__/notion-cli-plugin.test.js, __tests__/slim-plugin.test.js
- PR #344 (am/am-f17c27-ti2ce3): docs: align package.json description with 10,000+ plugins
    touches: __tests__/help.test.js, __tests__/mcp-diagnostics.test.js, package.json
- PR #343 (am/am-f17c27-ti1vg3): feat: add 5 bundled plugins — otree, atac, serpl, ov, dolt
    touches: plugins/atac/install-guidance.json, plugins/atac/meta.json, plugins/atac/plugin.json, plugins/dolt/install-guidance.json, plugins/dolt/meta.json, plugins/dolt/plugin.json, plugins/otree/install-guidance.json, plugins/otree/meta.json, plugins/otree/plugin.json, plugins/ov/install-guidance.json, plugins/ov/meta.json, plugins/ov/plugin.json (+3 more)


**Branch:** `am/am-f17c27-ti47of`

## Summary

Add plugin routing tests for three bundled passthrough plugins: chainloop, overmind, and resvg. Each suite spins up a fake binary on PATH, installs the plugin into an isolated SUPERCLI_HOME, and verifies namespace passthrough routing (command name + raw output), argument forwarding, and that 'plugins doctor' reports the binary dependency as healthy. These plugins previously had no test coverage; the tests follow the existing eza/goose plugin-test conventions.

**Diff:**
```
__tests__/chainloop-plugin.test.js | 81 ++++++++++++++++++++++++++++++++++++++
 __tests__/overmind-plugin.test.js  | 81 ++++++++++++++++++++++++++++++++++++++
 __tests__/resvg-plugin.test.js     | 81 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 243 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the Chainloop, Overmind, and Resvg command-line plugins.
  * Verified version commands, subcommands, flags, and conversion arguments are forwarded correctly.
  * Added checks confirming each plugin reports healthy command-line dependencies through the diagnostic command.
  * Improved confidence in plugin behavior when running without the server environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->