### PR TITLE
test: add plugin routing tests for bundled sq plugin

### DIFF
--- a/__tests__/httprobe-plugin.test.js
+++ b/__tests__/httprobe-plugin.test.js
@@ -1,0 +1,69 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeHttprobeBinary(dir) {
+  const bin = path.join(dir, "httprobe")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "console.log('https://example.com');"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("httprobe plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-httprobe-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-httprobe-"))
+  writeFakeHttprobeBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/httprobe --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove httprobe --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("routes the domain probe command", () => {
+    const r = runNoServer("httprobe domain probe --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("httprobe.domain.probe")
+    expect(data.data.raw).toBe("https://example.com")
+  })
+
+  test("doctor reports httprobe dependency as healthy", () => {
+    const r = runNoServer("plugins doctor httprobe --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "httprobe" && c.ok === true)).toBe(true)
+  })
+})

--- a/__tests__/lazysql-plugin.test.js
+++ b/__tests__/lazysql-plugin.test.js
@@ -1,0 +1,89 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeLazysqlBinary(dir) {
+  const bin = path.join(dir, "lazysql")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === '--version') { console.log('lazysql v0.3.0-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("lazysql plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-lazysql-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-lazysql-"))
+  writeFakeLazysqlBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/lazysql --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove lazysql --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("routes the self version command", () => {
+    const r = runNoServer("lazysql self version --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("lazysql.self.version")
+    expect(data.data.raw).toBe("lazysql v0.3.0-test")
+  })
+
+  test("routes connection open with a positional url", () => {
+    const r = runNoServer("lazysql connection open postgres://x --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("lazysql.connection.open")
+    const inner = JSON.parse(data.data.raw)
+    expect(inner.args).toContain("postgres://x")
+  })
+
+  test("supports namespace passthrough for unknown subcommands", () => {
+    const r = runNoServer("lazysql somecmd --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("lazysql.passthrough")
+    const inner = JSON.parse(data.data.raw)
+    expect(inner.args).toContain("somecmd")
+  })
+
+  test("doctor reports lazysql dependency as healthy", () => {
+    const r = runNoServer("plugins doctor lazysql --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "lazysql" && c.ok === true)).toBe(true)
+  })
+})

--- a/__tests__/sq-plugin.test.js
+++ b/__tests__/sq-plugin.test.js
@@ -1,0 +1,82 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeSqBinary(dir) {
+  const bin = path.join(dir, "sq")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === 'version') { console.log('sq v0.48.0-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("sq plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-sq-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-sq-"))
+  writeFakeSqBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    runNoServer("plugins install ./plugins/sq --on-conflict replace --json", { env })
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove sq --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("routes a subcommand through namespace passthrough", () => {
+    const r = runNoServer("sq inspect --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("sq.passthrough")
+    expect(data.data.args).toContain("inspect")
+    expect(data.data.args).toContain("--json")
+  })
+
+  test("passes multiple arguments through in order", () => {
+    const r = runNoServer("sq .data --format json --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("sq.passthrough")
+    expect(data.data.args).toContain(".data")
+    expect(data.data.args).toContain("--format")
+    expect(data.data.args).toContain("json")
+  })
+
+  test("doctor reports sq dependency as healthy", () => {
+    const r = runNoServer("plugins doctor sq --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "sq" && c.ok === true)).toBe(true)
+  })
+})


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #350 (am/am-f17c27-ti4dig): test: add usage-validation coverage for cli/run.js
    touches: __tests__/run-command.test.js, __tests__/skills-mcp.test.js
- PR #349 (am/am-f17c27-ti47of): test: add plugin routing tests for bundled chainloop plugin
    touches: __tests__/chainloop-plugin.test.js, __tests__/overmind-plugin.test.js, __tests__/resvg-plugin.test.js
- PR #348 (am/am-f17c27-ti41r3): test: add plugin routing tests for goss, amass, and tlrc
    touches: __tests__/amass-plugin.test.js, __tests__/goss-plugin.test.js, __tests__/hivemind-plugin.test.js, __tests__/mods-plugin.test.js, __tests__/tlrc-plugin.test.js
- PR #347 (am/am-f17c27-ti3vy5): test: add plugin routing tests for bundled upx plugin
    touches: __tests__/komiser-plugin.test.js, __tests__/upx-plugin.test.js, __tests__/wtfutil-plugin.test.js
- PR #346 (am/am-f17c27-ti3q44): test: add plugin routing tests for bundled coder plugin
    touches: __tests__/coder-plugin.test.js, __tests__/pkl-plugin.test.js, __tests__/rbspy-plugin.test.js
- PR #345 (am/am-f17c27-ti2i84): test: add plugin routing tests for bundled notion-cli plugin
    touches: __tests__/diun-plugin.test.js, __tests__/notion-cli-plugin.test.js, __tests__/slim-plugin.test.js
- PR #344 (am/am-f17c27-ti2ce3): docs: align package.json description with 10,000+ plugins
    touches: __tests__/help.test.js, __tests__/mcp-diagnostics.test.js, package.json
- PR #343 (am/am-f17c27-ti1vg3): feat: add 5 bundled plugins — otree, atac, serpl, ov, dolt
    touches: plugins/atac/install-guidance.json, plugins/atac/meta.json, plugins/atac/plugin.json, plugins/dolt/install-guidance.json, plugins/dolt/meta.json, plugins/dolt/plugin.json, plugins/otree/install-guidance.json, plugins/otree/meta.json, plugins/otree/plugin.json, plugins/ov/install-guidance.json, plugins/ov/meta.json, plugins/ov/plugin.json (+3 more)


**Branch:** `am/am-f17c27-ti5ks6`

## Summary

Add plugin routing test coverage for three previously-untested bundled plugins: sq, httprobe, and lazysql. Each suite installs the plugin against a fake binary on PATH, then asserts that wrapped commands, positional args, and namespace passthrough route to the correct command name, and that plugins doctor reports the binary dependency as healthy. Fills a gap where these bundled plugins shipped with zero test coverage.

**Diff:**
```
__tests__/httprobe-plugin.test.js | 69 ++++++++++++++++++++++++++++++
 __tests__/lazysql-plugin.test.js  | 89 +++++++++++++++++++++++++++++++++++++++
 __tests__/sq-plugin.test.js       | 82 ++++++++++++++++++++++++++++++++++++
 3 files changed, 240 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for CLI routing and argument passthrough across the `httprobe`, `lazysql`, and `sq` plugins.
  * Verified plugin commands return expected output, including version, connection, inspection, and unknown subcommands.
  * Added checks confirming the plugin doctor reports required binaries as healthy.
  * Tests run with temporary isolated environments and clean up automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->