### PR TITLE
test: add plugin routing tests for bundled irssi plugin

### DIFF
--- a/__tests__/dar-plugin.test.js
+++ b/__tests__/dar-plugin.test.js
@@ -1,0 +1,73 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeDarBinary(dir) {
+  const bin = path.join(dir, "dar")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args.includes('--version')) { console.log('dar 2.7.13-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("dar plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-dar-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-dar-"))
+  writeFakeDarBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    const install = runNoServer("plugins install ./plugins/dar --on-conflict replace --json", { env })
+    expect(install.ok).toBe(true)
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove dar --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("supports namespace passthrough", () => {
+    const r = runNoServer("dar --create backup --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("dar.passthrough")
+    expect(data.data.args).toContain("--create")
+    expect(data.data.args).toContain("backup")
+  })
+
+  test("doctor reports dar dependency as healthy", () => {
+    const r = runNoServer("plugins doctor dar --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "dar" && c.ok === true)).toBe(true)
+  })
+})

--- a/__tests__/irssi-plugin.test.js
+++ b/__tests__/irssi-plugin.test.js
@@ -1,0 +1,73 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeIrssiBinary(dir) {
+  const bin = path.join(dir, "irssi")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args.includes('--version')) { console.log('irssi 1.4.5-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("irssi plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-irssi-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-irssi-"))
+  writeFakeIrssiBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    const install = runNoServer("plugins install ./plugins/irssi --on-conflict replace --json", { env })
+    expect(install.ok).toBe(true)
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove irssi --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("supports namespace passthrough", () => {
+    const r = runNoServer("irssi connect irc.libera.chat --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("irssi.passthrough")
+    expect(data.data.args).toContain("connect")
+    expect(data.data.args).toContain("irc.libera.chat")
+  })
+
+  test("doctor reports irssi dependency as healthy", () => {
+    const r = runNoServer("plugins doctor irssi --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "irssi" && c.ok === true)).toBe(true)
+  })
+})

--- a/__tests__/xata-plugin.test.js
+++ b/__tests__/xata-plugin.test.js
@@ -1,0 +1,73 @@
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execSync } = require("child_process")
+
+const CLI = path.join(__dirname, "..", "cli", "supercli.js")
+
+function runNoServer(args, options = {}) {
+  try {
+    const env = { ...process.env }
+    delete env.SUPERCLI_SERVER
+    const out = execSync(`node ${CLI} ${args}`, {
+      encoding: "utf-8",
+      timeout: 15000,
+      env: { ...env, ...(options.env || {}) }
+    })
+    return { ok: true, output: out.trim(), code: 0 }
+  } catch (err) {
+    return {
+      ok: false,
+      output: (err.stdout || "").trim(),
+      stderr: (err.stderr || "").trim(),
+      code: err.status
+    }
+  }
+}
+
+function writeFakeXataBinary(dir) {
+  const bin = path.join(dir, "xata")
+  fs.writeFileSync(bin, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args.includes('--version')) { console.log('xata 0.16.0-test'); process.exit(0); }",
+    "console.log(JSON.stringify({ ok: true, args }));"
+  ].join("\n"), "utf-8")
+  fs.chmodSync(bin, 0o755)
+  return bin
+}
+
+describe("xata plugin", () => {
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-xata-"))
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dcli-home-xata-"))
+  writeFakeXataBinary(fakeDir)
+  const env = { ...process.env, PATH: `${fakeDir}:${process.env.PATH || ""}`, SUPERCLI_HOME: tempHome }
+
+  beforeAll(() => {
+    const install = runNoServer("plugins install ./plugins/xata --on-conflict replace --json", { env })
+    expect(install.ok).toBe(true)
+  })
+
+  afterAll(() => {
+    runNoServer("plugins remove xata --json", { env })
+    fs.rmSync(fakeDir, { recursive: true, force: true })
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  test("supports namespace passthrough", () => {
+    const r = runNoServer("xata branch list --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.command).toBe("xata.passthrough")
+    expect(data.data.args).toContain("branch")
+    expect(data.data.args).toContain("list")
+  })
+
+  test("doctor reports xata dependency as healthy", () => {
+    const r = runNoServer("plugins doctor xata --json", { env })
+    expect(r.ok).toBe(true)
+    const data = JSON.parse(r.output)
+    expect(data.ok).toBe(true)
+    expect(data.checks.some(c => c.type === "binary" && c.binary === "xata" && c.ok === true)).toBe(true)
+  })
+})


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #351 (am/am-f17c27-ti5ks6): test: add plugin routing tests for bundled sq plugin
    touches: __tests__/httprobe-plugin.test.js, __tests__/lazysql-plugin.test.js, __tests__/sq-plugin.test.js
- PR #350 (am/am-f17c27-ti4dig): test: add usage-validation coverage for cli/run.js
    touches: __tests__/run-command.test.js, __tests__/skills-mcp.test.js
- PR #349 (am/am-f17c27-ti47of): test: add plugin routing tests for bundled chainloop plugin
    touches: __tests__/chainloop-plugin.test.js, __tests__/overmind-plugin.test.js, __tests__/resvg-plugin.test.js
- PR #348 (am/am-f17c27-ti41r3): test: add plugin routing tests for goss, amass, and tlrc
    touches: __tests__/amass-plugin.test.js, __tests__/goss-plugin.test.js, __tests__/hivemind-plugin.test.js, __tests__/mods-plugin.test.js, __tests__/tlrc-plugin.test.js
- PR #347 (am/am-f17c27-ti3vy5): test: add plugin routing tests for bundled upx plugin
    touches: __tests__/komiser-plugin.test.js, __tests__/upx-plugin.test.js, __tests__/wtfutil-plugin.test.js
- PR #346 (am/am-f17c27-ti3q44): test: add plugin routing tests for bundled coder plugin
    touches: __tests__/coder-plugin.test.js, __tests__/pkl-plugin.test.js, __tests__/rbspy-plugin.test.js
- PR #345 (am/am-f17c27-ti2i84): test: add plugin routing tests for bundled notion-cli plugin
    touches: __tests__/diun-plugin.test.js, __tests__/notion-cli-plugin.test.js, __tests__/slim-plugin.test.js
- PR #344 (am/am-f17c27-ti2ce3): docs: align package.json description with 10,000+ plugins
    touches: __tests__/help.test.js, __tests__/mcp-diagnostics.test.js, package.json


**Branch:** `am/am-f17c27-ti5qm6`

## Summary

Add plugin routing test coverage for three bundled passthrough plugins that previously had none: irssi, dar, and xata. Each test suite installs the plugin into an isolated temp SUPERCLI_HOME with a fake binary on PATH, then verifies namespace passthrough command resolution (command name + forwarded args) and that `plugins doctor` reports the required binary as healthy. This mirrors the existing eza/clix plugin test patterns and guards against regressions in passthrough routing and binary-check reporting.

**Diff:**
```
__tests__/dar-plugin.test.js   | 73 ++++++++++++++++++++++++++++++++++++++++++
 __tests__/irssi-plugin.test.js | 73 ++++++++++++++++++++++++++++++++++++++++++
 __tests__/xata-plugin.test.js  | 73 ++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 219 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for Dar, Irssi, and Xata plugin passthrough commands.
  * Verified command arguments are forwarded correctly, including namespaces and targets.
  * Added health checks confirming each plugin’s command-line tool is detected and reported as healthy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->