### PR TITLE
feat: add agent quickstart skills for otree, atac, serpl, ov, dolt

### DIFF
--- a/plugins/atac/meta.json
+++ b/plugins/atac/meta.json
@@ -1,5 +1,5 @@
 {
   "description": "Arc-inspired API client for the terminal — send HTTP requests from a TUI, manage collections and environments.",
   "tags": ["atac", "http", "api-client", "rest", "tui", "postman", "rust"],
-  "has_learn": false
+  "has_learn": true
 }

--- a/plugins/atac/plugin.json
+++ b/plugins/atac/plugin.json
@@ -6,6 +6,9 @@
   "checks": [
     { "type": "binary", "name": "atac" }
   ],
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "install_guidance": {
     "plugin": "atac",
     "binary": "atac",

--- a/plugins/atac/skills/quickstart/SKILL.md
+++ b/plugins/atac/skills/quickstart/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: atac
+description: Use this skill when the user wants to send HTTP requests from the terminal — test REST APIs, manage collections and environments, or replace Postman/Insomnia with a TUI client.
+---
+
+# atac Plugin
+
+Arc-inspired API client for the terminal. Send HTTP requests, manage collections, and switch environments without leaving the shell.
+
+## Installation
+
+```bash
+cargo install atac
+```
+
+Download binaries from [GitHub Releases](https://github.com/Julien-cpsn/ATAC/releases).
+
+## Basic Usage
+
+```bash
+# Launch the TUI
+atac
+
+# Import existing collections
+atac import postman collection.json
+atac import insomnia collection.json
+```
+
+## Features
+
+- HTTP methods (GET, POST, PUT, PATCH, DELETE)
+- Request headers, query params, and body editing
+- Environment variables for base URLs and tokens
+- Collection and folder organization
+- Postman and Insomnia collection import
+
+## Usage Examples
+
+- "Test this API endpoint from the terminal"
+- "Import my Postman collection and send a GET request"
+- "Switch to the staging environment and hit /health"
+
+## SuperCLI
+
+```bash
+sc atac _ _
+sc plugins learn atac
+```

--- a/plugins/dolt/meta.json
+++ b/plugins/dolt/meta.json
@@ -1,5 +1,5 @@
 {
   "description": "Git for data — a SQL database with version control: branch, diff, merge, and clone your tables like a Git repository.",
   "tags": ["dolt", "database", "sql", "version-control", "git", "mysql", "go"],
-  "has_learn": false
+  "has_learn": true
 }

--- a/plugins/dolt/plugin.json
+++ b/plugins/dolt/plugin.json
@@ -6,6 +6,9 @@
   "checks": [
     { "type": "binary", "name": "dolt" }
   ],
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "install_guidance": {
     "plugin": "dolt",
     "binary": "dolt",

--- a/plugins/dolt/skills/quickstart/SKILL.md
+++ b/plugins/dolt/skills/quickstart/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: dolt
+description: Use this skill when the user wants a SQL database with Git-style version control — branch tables, diff schemas, merge data changes, or clone/fork datasets like a Git repository.
+---
+
+# dolt Plugin
+
+Git for data — a MySQL-compatible SQL database you can fork, clone, branch, merge, push, and pull. Version-control tabular data with familiar Git workflows.
+
+## Installation
+
+```bash
+curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash
+# or
+brew install dolt
+```
+
+## Basic Usage
+
+```bash
+# Initialize a new database repo
+dolt init
+
+# Start a SQL shell (MySQL-compatible)
+dolt sql
+
+# Run a query
+dolt sql -q "SELECT * FROM my_table"
+
+# Version control operations
+dolt status
+dolt add .
+dolt commit -m "Add initial data"
+dolt branch feature
+dolt checkout feature
+dolt diff
+dolt merge main
+```
+
+## Remote Workflows
+
+```bash
+# Clone from DoltHub
+dolt clone dolthub/my-org/my-database
+
+# Push and pull
+dolt remote add origin dolthub/my-org/my-database
+dolt push origin main
+dolt pull origin main
+```
+
+## Usage Examples
+
+- "Create a versioned SQL database for this dataset"
+- "Show me the diff between branches"
+- "Query this table and commit the changes"
+- "Clone a Dolt database from DoltHub"
+
+## SuperCLI
+
+```bash
+sc dolt _ _ sql -q "SHOW TABLES"
+sc plugins learn dolt
+```

--- a/plugins/otree/meta.json
+++ b/plugins/otree/meta.json
@@ -1,5 +1,5 @@
 {
   "description": "Interactive TUI to view structured data (JSON, YAML, TOML) as a navigable tree.",
   "tags": ["otree", "json", "yaml", "toml", "tui", "viewer", "rust"],
-  "has_learn": false
+  "has_learn": true
 }

--- a/plugins/otree/plugin.json
+++ b/plugins/otree/plugin.json
@@ -6,6 +6,9 @@
   "checks": [
     { "type": "binary", "name": "otree" }
   ],
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "install_guidance": {
     "plugin": "otree",
     "binary": "otree",

--- a/plugins/otree/skills/quickstart/SKILL.md
+++ b/plugins/otree/skills/quickstart/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: otree
+description: Use this skill when the user wants to explore or navigate structured data (JSON, YAML, TOML) interactively in the terminal — inspect large config files, API responses, or nested documents as a collapsible tree.
+---
+
+# otree Plugin
+
+Interactive TUI to view JSON, YAML, and TOML as a navigable tree. Faster than scrolling raw text for deeply nested documents.
+
+## Installation
+
+```bash
+cargo install otree
+# or
+brew install otree
+```
+
+Download binaries from [GitHub Releases](https://github.com/fioncat/otree/releases).
+
+## Basic Usage
+
+```bash
+# Open a file
+otree config.json
+
+# Pipe structured data
+curl -s https://api.example.com/data | otree
+
+# YAML or TOML
+otree docker-compose.yml
+otree Cargo.toml
+```
+
+## Key Bindings
+
+- `j/k` or `↓/↑` — Move cursor
+- `h/l` or `←/→` — Collapse/expand node
+- `Enter` — Toggle expand/collapse
+- `/` — Search
+- `q` — Quit
+
+## Usage Examples
+
+- "Show me this JSON response as a tree"
+- "Navigate the nested keys in package.json"
+- "Inspect this YAML config interactively"
+
+## SuperCLI
+
+```bash
+sc otree _ _ config.json
+sc plugins learn otree
+```

--- a/plugins/ov/meta.json
+++ b/plugins/ov/meta.json
@@ -1,5 +1,5 @@
 {
   "description": "Feature-rich terminal pager with column mode, incremental search, multicolor highlighting, and follow mode.",
   "tags": ["ov", "pager", "less", "viewer", "terminal", "tail", "go"],
-  "has_learn": false
+  "has_learn": true
 }

--- a/plugins/ov/plugin.json
+++ b/plugins/ov/plugin.json
@@ -6,6 +6,9 @@
   "checks": [
     { "type": "binary", "name": "ov" }
   ],
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "install_guidance": {
     "plugin": "ov",
     "binary": "ov",

--- a/plugins/ov/skills/quickstart/SKILL.md
+++ b/plugins/ov/skills/quickstart/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: ov
+description: Use this skill when the user wants a modern terminal pager — view logs with follow mode, search incrementally, highlight matches, or display CSV/TSV in column mode instead of less or more.
+---
+
+# ov Plugin
+
+Feature-rich terminal pager with column mode, incremental search, multicolor highlighting, and follow mode. A modern replacement for `less` and `more`.
+
+## Installation
+
+```bash
+go install github.com/noborus/ov@latest
+# or
+brew install noborus/tap/ov
+```
+
+Download binaries from [GitHub Releases](https://github.com/noborus/ov/releases).
+
+## Basic Usage
+
+```bash
+# Page a file
+ov large.log
+
+# Pipe output
+kubectl logs deployment/api | ov
+
+# Follow logs (like tail -f)
+ov --follow /var/log/syslog
+
+# Column mode for CSV/TSV
+ov --column-mode data.csv
+```
+
+## Key Features
+
+- Incremental search (`/`) with highlight
+- Follow mode for live log streaming
+- Column mode for tabular data
+- Section headers and multicolor syntax
+- Mouse and keyboard navigation
+
+## Usage Examples
+
+- "Page this log file with search"
+- "Follow nginx access logs in real time"
+- "View this CSV in aligned columns"
+
+## SuperCLI
+
+```bash
+sc ov _ _ large.log
+sc plugins learn ov
+```

--- a/plugins/serpl/meta.json
+++ b/plugins/serpl/meta.json
@@ -1,5 +1,5 @@
 {
   "description": "Terminal UI for search and replace across files, powered by ripgrep — a TUI alternative to VS Code's find-and-replace.",
   "tags": ["serpl", "search", "replace", "ripgrep", "tui", "refactor", "rust"],
-  "has_learn": false
+  "has_learn": true
 }

--- a/plugins/serpl/plugin.json
+++ b/plugins/serpl/plugin.json
@@ -6,6 +6,9 @@
   "checks": [
     { "type": "binary", "name": "serpl" }
   ],
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "install_guidance": {
     "plugin": "serpl",
     "binary": "serpl",

--- a/plugins/serpl/skills/quickstart/SKILL.md
+++ b/plugins/serpl/skills/quickstart/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: serpl
+description: Use this skill when the user wants to search and replace text across files interactively in the terminal — refactor code, rename symbols, or batch-edit with ripgrep-powered preview.
+---
+
+# serpl Plugin
+
+Terminal UI for search and replace across files, powered by ripgrep. A TUI alternative to VS Code's find-and-replace with per-match preview before applying changes.
+
+## Prerequisites
+
+Requires [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`) installed and on PATH.
+
+## Installation
+
+```bash
+cargo install serpl
+```
+
+Download binaries from [GitHub Releases](https://github.com/yassinebridi/serpl/releases).
+
+## Basic Usage
+
+```bash
+# Launch interactive search/replace in current directory
+serpl
+
+# Limit to a path or glob
+serpl ./src
+```
+
+## Features
+
+- Regex, case-sensitive, and whole-word matching
+- Per-match preview before replace
+- Ripgrep-speed file scanning
+- Interactive confirmation for each replacement
+
+## Usage Examples
+
+- "Find and replace this function name across the repo"
+- "Rename this import in all TypeScript files"
+- "Search for a regex pattern and preview matches before replacing"
+
+## SuperCLI
+
+```bash
+sc serpl _ _
+sc plugins learn serpl
+```


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #352 (am/am-f17c27-ti5qm6): test: add plugin routing tests for bundled irssi plugin
    touches: __tests__/dar-plugin.test.js, __tests__/irssi-plugin.test.js, __tests__/xata-plugin.test.js
- PR #351 (am/am-f17c27-ti5ks6): test: add plugin routing tests for bundled sq plugin
    touches: __tests__/httprobe-plugin.test.js, __tests__/lazysql-plugin.test.js, __tests__/sq-plugin.test.js
- PR #350 (am/am-f17c27-ti4dig): test: add usage-validation coverage for cli/run.js
    touches: __tests__/run-command.test.js, __tests__/skills-mcp.test.js
- PR #349 (am/am-f17c27-ti47of): test: add plugin routing tests for bundled chainloop plugin
    touches: __tests__/chainloop-plugin.test.js, __tests__/overmind-plugin.test.js, __tests__/resvg-plugin.test.js
- PR #348 (am/am-f17c27-ti41r3): test: add plugin routing tests for goss, amass, and tlrc
    touches: __tests__/amass-plugin.test.js, __tests__/goss-plugin.test.js, __tests__/hivemind-plugin.test.js, __tests__/mods-plugin.test.js, __tests__/tlrc-plugin.test.js
- PR #347 (am/am-f17c27-ti3vy5): test: add plugin routing tests for bundled upx plugin
    touches: __tests__/komiser-plugin.test.js, __tests__/upx-plugin.test.js, __tests__/wtfutil-plugin.test.js
- PR #346 (am/am-f17c27-ti3q44): test: add plugin routing tests for bundled coder plugin
    touches: __tests__/coder-plugin.test.js, __tests__/pkl-plugin.test.js, __tests__/rbspy-plugin.test.js
- PR #345 (am/am-f17c27-ti2i84): test: add plugin routing tests for bundled notion-cli plugin
    touches: __tests__/diun-plugin.test.js, __tests__/notion-cli-plugin.test.js, __tests__/slim-plugin.test.js


**Branch:** `am/am-f17c27-tihcdj`

**Diff:**
```
plugins/atac/meta.json                   |  2 +-
 plugins/atac/plugin.json                 |  3 ++
 plugins/atac/skills/quickstart/SKILL.md  | 48 ++++++++++++++++++++++++
 plugins/dolt/meta.json                   |  2 +-
 plugins/dolt/plugin.json                 |  3 ++
 plugins/dolt/skills/quickstart/SKILL.md  | 64 ++++++++++++++++++++++++++++++++
 plugins/otree/meta.json                  |  2 +-
 plugins/otree/plugin.json                |  3 ++
 plugins/otree/skills/quickstart/SKILL.md | 53 ++++++++++++++++++++++++++
 plugins/ov/meta.json                     |  2 +-
 plugins/ov/plugin.json                   |  3 ++
 plugins/ov/skills/quickstart/SKILL.md    | 55 +++++++++++++++++++++++++++
 plugins/serpl/meta.json                  |  2 +-
 plugins/serpl/plugin.json                |  3 ++
 plugins/serpl/skills/quickstart/SKILL.md | 50 +++++++++++++++++++++++++
 15 files changed, 290 insertions(+), 5 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added learn-enabled quickstart guidance for ATAC, Dolt, Otree, Ov, and Serpl.
  - Each plugin now links to its dedicated learning content, making installation, basic usage, key features, and example commands easier to discover.
  - Added practical tutorials covering API requests, version-controlled databases, structured-data navigation, terminal paging, and search-and-replace workflows.

- **Documentation**
  - Added step-by-step usage examples and SuperCLI invocation guidance for all five plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->