### PR TITLE
feat: add agent quickstart skills for binenv, webi, hermit, chsrc, uplot

### DIFF
--- a/plugins/binenv/meta.json
+++ b/plugins/binenv/meta.json
@@ -1,5 +1,5 @@
 {
   "description": "binenv — binary version manager. Installs/manages versions of CLI tools (kubectl, terraform, etc.) via shims and a lock file.",
   "tags": ["binenv", "binary", "version-manager", "cli", "tools", "devops"],
-  "has_learn": false
+  "has_learn": true
 }

--- a/plugins/binenv/plugin.json
+++ b/plugins/binenv/plugin.json
@@ -6,6 +6,9 @@
   "checks": [
     { "type": "binary", "name": "binenv" }
   ],
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "install_guidance": {
     "plugin": "binenv",
     "binary": "binenv",

--- a/plugins/binenv/skills/quickstart/SKILL.md
+++ b/plugins/binenv/skills/quickstart/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: binenv
+description: Use this skill when the user needs to install or pin specific versions of CLI binaries (kubectl, terraform, helm, etc.) with shims and a lock file — especially in CI or multi-tool dev environments.
+---
+
+# binenv Plugin
+
+Binary version manager that installs CLI tools via shims and tracks versions in a lock file. Keeps kubectl, terraform, and other binaries pinned per project.
+
+## Installation
+
+```bash
+go install github.com/devops-works/binenv@latest
+```
+
+## Basic Usage
+
+```bash
+# Install a binary (latest version)
+binenv install kubectl
+
+# Install a specific version
+binenv install kubectl 1.29.0
+
+# List installed binaries
+binenv list
+
+# Show available versions
+binenv available terraform
+```
+
+## Typical Workflow
+
+1. Add a `binenv` lock file to your repo
+2. Run `binenv install` to sync all pinned tools
+3. Shims in `~/.binenv/shims` route to the correct version
+
+## Usage Examples
+
+- "Install kubectl 1.29 for this project"
+- "List all CLI tools managed by binenv"
+- "What terraform versions are available?"
+
+## SuperCLI
+
+```bash
+sc binenv binary install kubectl 1.29.0
+sc binenv binary list
+sc plugins learn binenv
+```

--- a/plugins/chsrc/meta.json
+++ b/plugins/chsrc/meta.json
@@ -1,5 +1,5 @@
 {
   "description": "chsrc — cross-platform source mirror changer. Switches to faster mirrors for brew, pip, npm, apt, and more.",
   "tags": ["chsrc", "mirror", "source", "package-manager", "tools", "system"],
-  "has_learn": false
+  "has_learn": true
 }

--- a/plugins/chsrc/plugin.json
+++ b/plugins/chsrc/plugin.json
@@ -6,6 +6,9 @@
   "checks": [
     { "type": "binary", "name": "chsrc" }
   ],
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "install_guidance": {
     "plugin": "chsrc",
     "binary": "chsrc",

--- a/plugins/chsrc/skills/quickstart/SKILL.md
+++ b/plugins/chsrc/skills/quickstart/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: chsrc
+description: Use this skill when the user wants to switch package manager mirrors or registries — speed up npm, pip, brew, cargo, or apt downloads by pointing to a faster regional mirror.
+---
+
+# chsrc Plugin
+
+Cross-platform universal source mirror changer. Switches software sources for package managers and language toolchains (brew, pip, npm, cargo, apt, and more).
+
+## Installation
+
+```bash
+brew install chsrc
+# or download from GitHub releases
+curl -L https://github.com/RubyMetric/chsrc/releases/latest/download/chsrc-x64-linux \
+  -o /usr/local/bin/chsrc && chmod +x /usr/local/bin/chsrc
+```
+
+## Basic Usage
+
+```bash
+# List available mirrors
+chsrc list
+
+# Set a mirror for a tool (interactive selection)
+chsrc set npm
+chsrc set pip
+chsrc set brew
+
+# Reset to default mirrors
+chsrc reset npm
+```
+
+## Usage Examples
+
+- "Switch npm to a faster mirror in China"
+- "Change pip registry to Tsinghua mirror"
+- "Reset brew sources to default"
+
+## SuperCLI
+
+```bash
+sc chsrc source list
+sc chsrc source set npm
+sc plugins learn chsrc
+```

--- a/plugins/hermit/meta.json
+++ b/plugins/hermit/meta.json
@@ -1,5 +1,5 @@
 {
   "description": "hermit — per-project tool manager. Isolated tool environments per project for consistent dev and CI tooling.",
   "tags": ["hermit", "tool-manager", "project", "environment", "dev-tools", "go"],
-  "has_learn": false
+  "has_learn": true
 }

--- a/plugins/hermit/plugin.json
+++ b/plugins/hermit/plugin.json
@@ -6,6 +6,9 @@
   "checks": [
     { "type": "binary", "name": "hermit" }
   ],
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "install_guidance": {
     "plugin": "hermit",
     "binary": "hermit",

--- a/plugins/hermit/skills/quickstart/SKILL.md
+++ b/plugins/hermit/skills/quickstart/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: hermit
+description: Use this skill when the user needs per-project, isolated CLI tool versions — pin kubectl, terraform, or other binaries per repo so teams and CI share identical toolchains.
+---
+
+# hermit Plugin
+
+Per-project tool manager from Cash App. Each repo gets its own isolated set of CLI tools with pinned versions, activated automatically when you `cd` into the project.
+
+## Installation
+
+```bash
+curl -fsSL https://github.com/cashapp/hermit/releases/download/stable/get-hermit.sh | sh
+```
+
+## Basic Usage
+
+```bash
+# Initialize hermit in a project
+hermit init
+
+# Install a tool into the project
+hermit install kubectl
+hermit install terraform
+
+# List installed tools
+hermit list
+
+# Run a hermit-managed binary
+hermit kubectl version
+```
+
+Hermit stores binaries in `bin/` and auto-activates via shell hooks when entering the directory.
+
+## Usage Examples
+
+- "Pin kubectl and terraform versions for this repo"
+- "Initialize hermit in my project"
+- "List all hermit-managed tools in this directory"
+
+## SuperCLI
+
+```bash
+sc hermit env init
+sc hermit binary install kubectl
+sc plugins learn hermit
+```

--- a/plugins/uplot/meta.json
+++ b/plugins/uplot/meta.json
@@ -1,5 +1,5 @@
 {
   "description": "YouPlot (uplot) — terminal plotting tool. Bar charts, histograms, box plots, scatter plots, and more from CSV/TSV data.",
   "tags": ["uplot", "youplot", "plot", "chart", "terminal", "data", "visualization", "ruby"],
-  "has_learn": false
+  "has_learn": true
 }

--- a/plugins/uplot/plugin.json
+++ b/plugins/uplot/plugin.json
@@ -6,6 +6,9 @@
   "checks": [
     { "type": "binary", "name": "uplot" }
   ],
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "install_guidance": {
     "plugin": "uplot",
     "binary": "uplot",

--- a/plugins/uplot/skills/quickstart/SKILL.md
+++ b/plugins/uplot/skills/quickstart/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: uplot
+description: Use this skill when the user wants terminal charts from CSV or TSV data — bar charts, histograms, scatter plots, and box plots without leaving the shell or opening a GUI.
+---
+
+# uplot Plugin
+
+YouPlot (`uplot`) draws charts directly in the terminal. Pipe CSV/TSV data or pass a file to render bar charts, histograms, scatter plots, and more.
+
+## Installation
+
+```bash
+brew install youplot
+# or
+gem install youplot
+```
+
+## Basic Usage
+
+```bash
+# Bar chart from CSV
+uplot bar data.csv
+
+# Histogram
+uplot hist values.tsv
+
+# Scatter plot
+uplot scatter points.csv
+
+# Pipe data
+echo "a\n1\n2\n3" | uplot bar
+```
+
+## Usage Examples
+
+- "Draw a bar chart of these sales numbers in the terminal"
+- "Show a histogram of response times from this CSV"
+- "Plot a scatter chart from data.tsv"
+
+## SuperCLI
+
+```bash
+sc uplot plot bar data.csv
+sc uplot plot histogram values.tsv
+sc plugins learn uplot
+```

--- a/plugins/webi/meta.json
+++ b/plugins/webi/meta.json
@@ -1,5 +1,5 @@
 {
   "description": "webi — web-based installer for dev tools. Installs via easy URLs without sudo, works on Linux/macOS/Windows.",
   "tags": ["webi", "installer", "tools", "dev-tools", "webinstall"],
-  "has_learn": false
+  "has_learn": true
 }

--- a/plugins/webi/plugin.json
+++ b/plugins/webi/plugin.json
@@ -6,6 +6,9 @@
   "checks": [
     { "type": "binary", "name": "webi" }
   ],
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "install_guidance": {
     "plugin": "webi",
     "binary": "webi",

--- a/plugins/webi/skills/quickstart/SKILL.md
+++ b/plugins/webi/skills/quickstart/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: webi
+description: Use this skill when the user wants to install developer tools without sudo or a system package manager — curl-based installs via memorable URLs for ripgrep, jq, node, and hundreds of other CLI tools.
+---
+
+# webi Plugin
+
+Web-based installer for developer tools. Installs binaries via easy-to-remember URLs without root or a package manager.
+
+## Installation
+
+```bash
+curl -sS https://webi.sh/webi | sh
+```
+
+## Basic Usage
+
+```bash
+# Install a tool by name
+webi rg
+webi jq
+webi node
+
+# Install from a full URL
+webi https://webi.sh/rg
+```
+
+Tools are installed to `~/.local/opt/<tool>/` with symlinks in `~/.local/bin/`.
+
+## Usage Examples
+
+- "Install ripgrep without apt or brew"
+- "Set up jq on this machine quickly"
+- "Install node via webi"
+
+## SuperCLI
+
+```bash
+sc webi install run rg
+sc webi _ _
+sc plugins learn webi
+```


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #352 (am/am-f17c27-ti5qm6): test: add plugin routing tests for bundled irssi plugin
    touches: __tests__/dar-plugin.test.js, __tests__/irssi-plugin.test.js, __tests__/xata-plugin.test.js
- PR #351 (am/am-f17c27-ti5ks6): test: add plugin routing tests for bundled sq plugin
    touches: __tests__/httprobe-plugin.test.js, __tests__/lazysql-plugin.test.js, __tests__/sq-plugin.test.js
- PR #350 (am/am-f17c27-ti4dig): test: add usage-validation coverage for cli/run.js
    touches: __tests__/run-command.test.js, __tests__/skills-mcp.test.js
- PR #349 (am/am-f17c27-ti47of): test: add plugin routing tests for bundled chainloop plugin
    touches: __tests__/chainloop-plugin.test.js, __tests__/overmind-plugin.test.js, __tests__/resvg-plugin.test.js
- PR #348 (am/am-f17c27-ti41r3): test: add plugin routing tests for goss, amass, and tlrc
    touches: __tests__/amass-plugin.test.js, __tests__/goss-plugin.test.js, __tests__/hivemind-plugin.test.js, __tests__/mods-plugin.test.js, __tests__/tlrc-plugin.test.js
- PR #347 (am/am-f17c27-ti3vy5): test: add plugin routing tests for bundled upx plugin
    touches: __tests__/komiser-plugin.test.js, __tests__/upx-plugin.test.js, __tests__/wtfutil-plugin.test.js
- PR #346 (am/am-f17c27-ti3q44): test: add plugin routing tests for bundled coder plugin
    touches: __tests__/coder-plugin.test.js, __tests__/pkl-plugin.test.js, __tests__/rbspy-plugin.test.js
- PR #345 (am/am-f17c27-ti2i84): test: add plugin routing tests for bundled notion-cli plugin
    touches: __tests__/diun-plugin.test.js, __tests__/notion-cli-plugin.test.js, __tests__/slim-plugin.test.js


**Branch:** `am/am-f17c27-tihg2q`

**Diff:**
```
plugins/binenv/meta.json                  |  2 +-
 plugins/binenv/plugin.json                |  3 ++
 plugins/binenv/skills/quickstart/SKILL.md | 50 +++++++++++++++++++++++++++++++
 plugins/chsrc/meta.json                   |  2 +-
 plugins/chsrc/plugin.json                 |  3 ++
 plugins/chsrc/skills/quickstart/SKILL.md  | 46 ++++++++++++++++++++++++++++
 plugins/hermit/meta.json                  |  2 +-
 plugins/hermit/plugin.json                |  3 ++
 plugins/hermit/skills/quickstart/SKILL.md | 47 +++++++++++++++++++++++++++++
 plugins/uplot/meta.json                   |  2 +-
 plugins/uplot/plugin.json                 |  3 ++
 plugins/uplot/skills/quickstart/SKILL.md  | 46 ++++++++++++++++++++++++++++
 plugins/webi/meta.json                    |  2 +-
 plugins/webi/plugin.json                  |  3 ++
 plugins/webi/skills/quickstart/SKILL.md   | 42 ++++++++++++++++++++++++++
 15 files changed, 251 insertions(+), 5 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quickstart learning guides for binenv, chsrc, hermit, uplot, and webi.
  * Enabled the Learn capability for all five plugins.
  * Added guidance covering installation, core commands, workflows, examples, and SuperCLI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->