### PR TITLE
feat: add agent quickstart skills for bats, tinygo, swc, pa11y, and renovate

### DIFF
--- a/plugins/bats/skills/quickstart/SKILL.md
+++ b/plugins/bats/skills/quickstart/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: bats
+description: Use this skill when the user wants to write or run Bash shell tests — TAP-compliant test suites, CI integration, mocking, and parallel test execution.
+---
+
+# bats Plugin
+
+Bash Automated Testing System. Write unit and integration tests for shell scripts with readable syntax, TAP output, and first-class CI support.
+
+## Installation
+
+```bash
+npm install -g bats
+# or
+brew install bats-core
+# Debian/Ubuntu: apt install bats
+```
+
+## Basic Usage
+
+```bash
+# Run a single test file
+bats test/example.bats
+
+# Run all tests in a directory
+bats test/
+
+# Count tests without running
+bats --count test/
+```
+
+## Common Patterns
+
+```bash
+# Filter tests by name pattern
+bats --filter "login" test/
+
+# Parallel execution
+bats --jobs 4 test/
+
+# TAP output for CI
+bats --tap test/
+
+# JUnit XML for reporting
+bats --formatter junit test/ > report.xml
+```
+
+## Writing Tests
+
+```bash
+# example.bats
+@test "addition works" {
+  result=$(echo $((2 + 2)))
+  [ "$result" -eq 4 ]
+}
+```
+
+## Usage Examples
+
+- "Run all Bash tests in the test/ directory"
+- "Filter bats tests matching 'deploy'"
+- "Output bats results in TAP format for CI"
+
+## SuperCLI
+
+```bash
+sc bats test run test/example.bats
+sc bats _ _ --filter "auth" test/
+sc plugins learn bats
+```

--- a/plugins/pa11y/plugin.json
+++ b/plugins/pa11y/plugin.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Automated accessibility testing tool",
   "source": "https://github.com/pa11y/pa11y",
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "checks": [
     {
       "type": "binary",

--- a/plugins/pa11y/skills/quickstart/SKILL.md
+++ b/plugins/pa11y/skills/quickstart/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: pa11y
+description: Use this skill when the user wants automated accessibility (a11y) testing — WCAG compliance checks on URLs or HTML with CI-friendly JSON reports.
+---
+
+# pa11y Plugin
+
+pa11y runs automated accessibility audits against web pages. Detects WCAG violations with actionable output — ideal for CI pipelines and pre-release checks.
+
+## Installation
+
+```bash
+npm install -g pa11y
+```
+
+## Basic Usage
+
+```bash
+# Test a live URL
+pa11y https://example.com
+
+# Test local HTML file
+pa11y ./index.html
+
+# JSON output for CI
+pa11y --reporter json https://example.com
+```
+
+## Common Patterns
+
+```bash
+# WCAG 2.1 AA standard
+pa11y --standard WCAG2AA https://example.com
+
+# Ignore known issues via config
+pa11y --config .pa11yci.json https://example.com
+
+# Screenshot on failure
+pa11y --screen-capture error.png https://example.com
+
+# Run against multiple URLs (pa11y-ci)
+pa11y-ci --sitemap https://example.com/sitemap.xml
+```
+
+## Usage Examples
+
+- "Check https://mysite.com for WCAG 2.1 AA violations"
+- "Run pa11y with JSON output in CI"
+- "Audit local index.html for accessibility issues"
+
+## SuperCLI
+
+```bash
+sc pa11y self version
+sc pa11y _ _ --standard WCAG2AA https://example.com
+sc plugins learn pa11y
+```

--- a/plugins/renovate/plugin.json
+++ b/plugins/renovate/plugin.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Automated dependency update tool",
   "source": "https://github.com/renovatebot/renovate",
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "checks": [
     {
       "type": "binary",

--- a/plugins/renovate/skills/quickstart/SKILL.md
+++ b/plugins/renovate/skills/quickstart/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: renovate
+description: Use this skill when the user wants automated dependency updates — scan package.json, Dockerfiles, GitHub Actions, and 60+ other managers to open update PRs.
+---
+
+# renovate Plugin
+
+Renovate automatically detects outdated dependencies across your repo and opens pull requests with updates, changelogs, and compatibility notes. Supports npm, Docker, Terraform, Helm, and many more.
+
+## Installation
+
+```bash
+npm install -g renovate
+# or run via npx without global install
+npx renovate --version
+```
+
+## Basic Usage
+
+```bash
+# Dry-run locally (no PRs created)
+renovate --platform=local
+
+# Run against a GitHub repo (requires token)
+RENOVATE_TOKEN=ghp_xxx renovate myorg/myrepo
+
+# Print config validation
+renovate-config-validator
+```
+
+## Common Patterns
+
+```bash
+# Limit to specific base branches
+renovate --base-branches=main myorg/myrepo
+
+# On-demand local scan
+renovate --platform=local --repository-cache=reset
+
+# Configure via renovate.json in repo root
+# { "extends": ["config:recommended"], "schedule": ["before 4am on monday"] }
+```
+
+## Usage Examples
+
+- "Run renovate dry-run on this repo locally"
+- "Configure renovate to group devDependencies updates"
+- "Validate my renovate.json config"
+
+## SuperCLI
+
+```bash
+sc renovate self version
+sc renovate _ _ --platform=local
+sc plugins learn renovate
+```

--- a/plugins/swc/plugin.json
+++ b/plugins/swc/plugin.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Fast Rust-based JS/TS compiler",
   "source": "https://github.com/swc-project/swc",
+  "learn": {
+    "file": "skills/quickstart/SKILL.md"
+  },
   "checks": [
     {
       "type": "binary",

--- a/plugins/swc/skills/quickstart/SKILL.md
+++ b/plugins/swc/skills/quickstart/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: swc
+description: Use this skill when the user wants to transpile or minify JavaScript/TypeScript fast — a Rust-based drop-in Babel replacement with bundling and source maps.
+---
+
+# swc Plugin
+
+SWC is a fast Rust-based compiler for JavaScript and TypeScript. Transpile modern syntax, minify bundles, and resolve modules — typically 10–20× faster than Babel.
+
+## Installation
+
+```bash
+npm install -g @swc/cli @swc/core
+```
+
+## Basic Usage
+
+```bash
+# Transpile a file
+swc src/index.js -o dist/index.js
+
+# Transpile a directory
+swc src -d dist
+
+# Minify output
+swc src/index.js -o dist/index.min.js --minify
+```
+
+## Common Patterns
+
+```bash
+# Use a config file (.swcrc)
+swc src -d dist --config-file .swcrc
+
+# Watch mode during development
+swc src -d dist --watch
+
+# Source maps for debugging
+swc src -d dist --source-maps
+```
+
+## Usage Examples
+
+- "Transpile TypeScript to ES2015 with swc"
+- "Minify this JS bundle using swc"
+- "Set up swc watch mode for src/"
+
+## SuperCLI
+
+```bash
+sc swc self version
+sc swc _ _ src -d dist
+sc plugins learn swc
+```

--- a/plugins/tinygo/skills/quickstart/SKILL.md
+++ b/plugins/tinygo/skills/quickstart/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: tinygo
+description: Use this skill when the user wants to compile Go for microcontrollers, WebAssembly, or constrained environments — smaller binaries than standard Go with board-specific targets.
+---
+
+# tinygo Plugin
+
+TinyGo is a Go compiler for microcontrollers, WebAssembly, and systems with tight memory limits. Produces smaller binaries than `go build` and supports dozens of embedded boards.
+
+## Installation
+
+```bash
+brew install tinygo
+# or download from https://tinygo.org/getting-started/
+```
+
+## Basic Usage
+
+```bash
+# Check version and supported targets
+tinygo version
+
+# Build for WebAssembly
+tinygo build -o app.wasm -target=wasm main.go
+
+# Flash to a microcontroller (example: Arduino Nano 33)
+tinygo flash -target=arduino-nano33 main.go
+```
+
+## Common Patterns
+
+```bash
+# List available boards/targets
+tinygo targets
+
+# Build with size optimization
+tinygo build -size=short -o firmware.elf main.go
+
+# Run on host (simulator)
+tinygo run main.go
+```
+
+## Usage Examples
+
+- "Compile this Go program to WebAssembly with tinygo"
+- "Flash firmware to an Arduino Nano 33"
+- "List tinygo supported targets"
+
+## SuperCLI
+
+```bash
+sc tinygo _ _ version
+sc tinygo _ _ build -o out.wasm -target=wasm main.go
+sc plugins learn tinygo
+```


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** 

----
WORK ALREADY IN FLIGHT — do not overlap:
These automaintainer pull requests are already open and awaiting review. Do NOT re-implement, refactor, or restructure the files they touch — pick non-overlapping work, and never recreate a change an open PR already makes. If your objective unavoidably overlaps one of these, choose a different, complementary improvement instead.

- PR #352 (am/am-f17c27-ti5qm6): test: add plugin routing tests for bundled irssi plugin
    touches: __tests__/dar-plugin.test.js, __tests__/irssi-plugin.test.js, __tests__/xata-plugin.test.js
- PR #351 (am/am-f17c27-ti5ks6): test: add plugin routing tests for bundled sq plugin
    touches: __tests__/httprobe-plugin.test.js, __tests__/lazysql-plugin.test.js, __tests__/sq-plugin.test.js
- PR #350 (am/am-f17c27-ti4dig): test: add usage-validation coverage for cli/run.js
    touches: __tests__/run-command.test.js, __tests__/skills-mcp.test.js
- PR #349 (am/am-f17c27-ti47of): test: add plugin routing tests for bundled chainloop plugin
    touches: __tests__/chainloop-plugin.test.js, __tests__/overmind-plugin.test.js, __tests__/resvg-plugin.test.js
- PR #348 (am/am-f17c27-ti41r3): test: add plugin routing tests for goss, amass, and tlrc
    touches: __tests__/amass-plugin.test.js, __tests__/goss-plugin.test.js, __tests__/hivemind-plugin.test.js, __tests__/mods-plugin.test.js, __tests__/tlrc-plugin.test.js
- PR #347 (am/am-f17c27-ti3vy5): test: add plugin routing tests for bundled upx plugin
    touches: __tests__/komiser-plugin.test.js, __tests__/upx-plugin.test.js, __tests__/wtfutil-plugin.test.js
- PR #346 (am/am-f17c27-ti3q44): test: add plugin routing tests for bundled coder plugin
    touches: __tests__/coder-plugin.test.js, __tests__/pkl-plugin.test.js, __tests__/rbspy-plugin.test.js
- PR #345 (am/am-f17c27-ti2i84): test: add plugin routing tests for bundled notion-cli plugin
    touches: __tests__/diun-plugin.test.js, __tests__/notion-cli-plugin.test.js, __tests__/slim-plugin.test.js


**Branch:** `am/am-f17c27-tihwy0`

**Diff:**
```
plugins/bats/skills/quickstart/SKILL.md     | 70 +++++++++++++++++++++++++++++
 plugins/pa11y/plugin.json                   |  3 ++
 plugins/pa11y/skills/quickstart/SKILL.md    | 57 +++++++++++++++++++++++
 plugins/renovate/plugin.json                |  3 ++
 plugins/renovate/skills/quickstart/SKILL.md | 56 +++++++++++++++++++++++
 plugins/swc/plugin.json                     |  3 ++
 plugins/swc/skills/quickstart/SKILL.md      | 54 ++++++++++++++++++++++
 plugins/tinygo/skills/quickstart/SKILL.md   | 55 +++++++++++++++++++++++
 8 files changed, 301 insertions(+)
```
