### PR TITLE
fix(#362): build sc-machin as static musl binary to fix GLIBC install failures

### DIFF
--- a/.github/workflows/sc-machin-release.yml
+++ b/.github/workflows/sc-machin-release.yml
@@ -46,7 +46,12 @@ jobs:
       - name: Build sc-machin
         working-directory: ./supercli-machin-cli
         run: |
-          bash build.sh
+          if [ "${{ matrix.os }}" = "linux" ]; then
+            sudo apt-get update && sudo apt-get install -y musl-tools
+            CC=musl-gcc bash build.sh --static
+          else
+            bash build.sh
+          fi
           mv sc-machin "sc-machin-${{ matrix.os }}-${{ matrix.arch }}"
           ls -lh "sc-machin-${{ matrix.os }}-${{ matrix.arch }}"
 
@@ -59,6 +64,10 @@ jobs:
             exit 1
           fi
           ./"$BINARY" --version || { echo "✗ Binary failed to run"; exit 1; }
+          if [ "${{ matrix.os }}" = "linux" ] && ! file "$BINARY" | grep -q "statically linked"; then
+            echo "✗ Linux binary is not statically linked"
+            exit 1
+          fi
           echo "✓ Binary verified: $BINARY"
 
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ curl -sSL https://github.com/javimosch/supercli/releases/download/v0.1.0-zig/ins
 ### Option 2: Machin Version (MCP Server, Single Binary)
 
 ```bash
-curl -sSL https://github.com/javimosch/supercli/releases/download/v0.2.0-machin/install.sh | bash
+curl -sSL https://github.com/javimosch/supercli/releases/download/v0.2.1-machin/install.sh | bash
 ```
 
 - ✅ Single binary (~71KB), no Node.js required

--- a/supercli-machin-cli/README.md
+++ b/supercli-machin-cli/README.md
@@ -24,7 +24,7 @@ orchestration, no cgo).
 ### Quick install (curl)
 
 ```bash
-curl -sSL https://github.com/javimosch/supercli/releases/download/v0.2.0-machin/install.sh | bash
+curl -sSL https://github.com/javimosch/supercli/releases/download/v0.2.1-machin/install.sh | bash
 ```
 
 Installs as `sc-machin` (co-exists with `sc` / `sc-zig`). Add `--replace`

--- a/supercli-machin-cli/install.sh
+++ b/supercli-machin-cli/install.sh
@@ -5,7 +5,7 @@
 # cross-compile grid like sc-zig's).
 set -e
 
-VERSION="${SC_MACHIN_VERSION:-v0.2.0-machin}"
+VERSION="${SC_MACHIN_VERSION:-v0.2.1-machin}"
 REPO="javimosch/supercli"
 REPLACE_SC=false
 CUSTOM_PATH=""


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #362: "Cannot install")

ISSUE DESCRIPTION:
```
(base) root@ukhan-ai:~# curl -sSL https://github.com/javimosch/supercli/releases/download/v0.2.0-machin/install.sh | bash
SuperCLI (machin) Installer
===========================

Detected: linux-amd64
Downloading from: https://github.com/javimosch/supercli/releases/download/v0.2.0-machin/sc-machin-linux-amd64
Installing to: /usr/local/bin/sc-machin

Testing installation...
Installation test failed

(base) root@ukhan-ai:~# sc-machin
sc-machin: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by sc-machin)
```

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#362): <brief description>
5. The PR body MUST include 'Fixes #362' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-f17c27-dkdjoppajdp3-a7a89ad7`

**Diff:**
```
.github/workflows/sc-machin-release.yml | 11 ++++++++++-
 README.md                               |  2 +-
 supercli-machin-cli/README.md           |  2 +-
 supercli-machin-cli/install.sh          |  2 +-
 4 files changed, 13 insertions(+), 4 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Linux releases now produce and verify statically linked binaries for improved portability.

* **Documentation**
  * Updated installation instructions and quick-install commands to reference the latest Machin release, v0.2.1.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->