### PR TITLE
fix(#298): add go install instructions to notion-cli plugin

### DIFF
--- a/plugins/notion-cli/install-guidance.json
+++ b/plugins/notion-cli/install-guidance.json
@@ -3,11 +3,11 @@
   "binary": "notion",
   "check": "which notion",
   "install_steps": [
-    "brew install 4ier/tap/notion-cli",
+    "go install github.com/4ier/notion-cli@latest",
     "Verify: notion --version",
     "Authenticate: echo 'ntn_xxxxx' | notion auth login --with-token",
     "Alternative auth: export NOTION_TOKEN=ntn_xxxxx",
     "supercli plugins install ./plugins/notion-cli --on-conflict replace --json"
   ],
-  "note": "Also available as Go binary from GitHub Releases: https://github.com/4ier/notion-cli/releases. npm: npm install -g @4ier/notion-cli. Token stored in ~/.config/notion-cli/config.json (mode 0600). Auto-detects JSON output when piped to another command."
+  "note": "Also available via Homebrew (brew install 4ier/tap/notion-cli), as a Go binary from GitHub Releases (https://github.com/4ier/notion-cli/releases), or via npm (npm install -g @4ier/notion-cli). Token stored in ~/.config/notion-cli/config.json (mode 0600). Auto-detects JSON output when piped to another command."
 }

--- a/plugins/notion-cli/plugin.json
+++ b/plugins/notion-cli/plugin.json
@@ -11,7 +11,7 @@
     "binary": "notion",
     "check": "which notion",
     "install_steps": [
-      "brew install 4ier/tap/notion-cli",
+      "go install github.com/4ier/notion-cli@latest",
       "Verify: notion --version",
       "Authenticate: echo 'ntn_xxxxx' | notion auth login --with-token",
       "supercli plugins install ./plugins/notion-cli --on-conflict replace --json"
@@ -30,7 +30,7 @@
       "adapterConfig": {
         "command": "notion",
         "baseArgs": ["--version"],
-        "missingDependencyHelp": "Install notion-cli: brew install 4ier/tap/notion-cli"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (or brew install 4ier/tap/notion-cli)"
       },
       "args": []
     },
@@ -230,7 +230,7 @@
       "adapterConfig": {
         "command": "notion",
         "passthrough": true,
-        "missingDependencyHelp": "Install notion-cli: brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (or brew install 4ier/tap/notion-cli). Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": []
     }

--- a/plugins/notion-cli/skills/quickstart/SKILL.md
+++ b/plugins/notion-cli/skills/quickstart/SKILL.md
@@ -59,10 +59,16 @@ export NOTION_TOKEN=ntn_xxxxx
 ## Installation
 
 ```bash
+go install github.com/4ier/notion-cli@latest
+```
+
+Or install with Homebrew:
+
+```bash
 brew install 4ier/tap/notion-cli
 ```
 
-Or download binary from [GitHub Releases](https://github.com/4ier/notion-cli/releases).
+Or download a binary from [GitHub Releases](https://github.com/4ier/notion-cli/releases).
 
 ## Key Features
 - **Agent-friendly**: JSON output auto-detected when piped, schema-aware, URL or ID support


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** ISSUE FIX OBJECTIVE (GitHub Issue #298: "Add 4ier/notion-cli as bundled plugin")

ISSUE DESCRIPTION:
## Feature Request: Add Notion CLI Plugin

**Plugin**: [4ier/notion-cli](https://github.com/4ier/notion-cli)

### Why this plugin?
- Full-featured Notion CLI with 39 commands
- Complete Notion API coverage (pages, databases, blocks, comments, users, files)
- Single binary (Go), cross-platform (Linux, macOS, Windows)
- MIT licensed, actively maintained (222 stars, 8 releases)
- "Like gh for GitHub, but for Notion" - familiar CLI pattern
- AI-friendly with JSON output and schema-aware operations

### Key Features
- **Auth**: Internal integration token support
- **Pages**: view, list, create, delete, restore, move, open, set properties, edit
- **Databases**: list, view, query, create, update, add, export
- **Blocks**: full block lifecycle management
- **Search**: workspace-wide search
- **Users**: workspace member management
- **Files**: upload and manage files
- **Templates**: apply consistent page structures

### Installation
```bash
go install github.com/4ier/notion-cli@latest
```

### Use Cases
- Developer workflow automation
- AI agent integration for knowledge base operations
- Scripted Notion workspace management
- Bulk data operations on databases
- Content management and publishing workflows

### Comparison
Provides more comprehensive API coverage than alternatives like the official `ntn` CLI, with better cross-platform support (including Windows).

Generated with [Devin](https://devin.ai)

APPROACH: Minimal fix — implement the described change with the smallest safe diff. Stay as close to the issue description as possible.

PROCEDURE (follow in order, do not deviate):
1. Read the issue and orient to the affected code (at most ~4 commands, then stop).
2. Implement the fix described above — stay close to the issue description.
3. If a test suite exists, verify the fix passes it.
4. COMMIT referencing the issue: fix(#298): <brief description>
5. The PR body MUST include 'Fixes #298' so GitHub auto-closes the issue on merge.
6. One focused fix is a complete win. Do not scope-creep.

**Branch:** `am/am-f17c27-dkf5c0j0zay2-eb4e39b6`

**Diff:**
```
plugins/notion-cli/install-guidance.json      | 4 ++--
 plugins/notion-cli/plugin.json                | 6 +++---
 plugins/notion-cli/skills/quickstart/SKILL.md | 8 +++++++-
 3 files changed, 12 insertions(+), 6 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Notion CLI installation guidance to recommend Go installation, with Homebrew and GitHub Releases as alternatives.
  * Added npm installation information and clarified that GitHub Releases provide downloadable binaries.
  * Expanded guidance on token storage and piped JSON output behavior.
  * Updated installation and authentication help messages across setup and command usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->