### PR TITLE
fix(#298): add go install instructions to bundled notion-cli plugin

### DIFF
--- a/plugins/notion-cli/install-guidance.json
+++ b/plugins/notion-cli/install-guidance.json
@@ -3,11 +3,11 @@
   "binary": "notion",
   "check": "which notion",
   "install_steps": [
-    "brew install 4ier/tap/notion-cli",
+    "go install github.com/4ier/notion-cli@latest",
     "Verify: notion --version",
     "Authenticate: echo 'ntn_xxxxx' | notion auth login --with-token",
     "Alternative auth: export NOTION_TOKEN=ntn_xxxxx",
     "supercli plugins install ./plugins/notion-cli --on-conflict replace --json"
   ],
-  "note": "Also available as Go binary from GitHub Releases: https://github.com/4ier/notion-cli/releases. npm: npm install -g @4ier/notion-cli. Token stored in ~/.config/notion-cli/config.json (mode 0600). Auto-detects JSON output when piped to another command."
+  "note": "Primary install is go install. Also available via Homebrew (brew install 4ier/tap/notion-cli), as a Go binary from GitHub Releases (https://github.com/4ier/notion-cli/releases), or via npm (npm install -g @4ier/notion-cli). Token stored in ~/.config/notion-cli/config.json (mode 0600). Auto-detects JSON output when piped to another command."
 }

--- a/plugins/notion-cli/plugin.json
+++ b/plugins/notion-cli/plugin.json
@@ -11,7 +11,7 @@
     "binary": "notion",
     "check": "which notion",
     "install_steps": [
-      "brew install 4ier/tap/notion-cli",
+      "go install github.com/4ier/notion-cli@latest",
       "Verify: notion --version",
       "Authenticate: echo 'ntn_xxxxx' | notion auth login --with-token",
       "supercli plugins install ./plugins/notion-cli --on-conflict replace --json"
@@ -30,7 +30,7 @@
       "adapterConfig": {
         "command": "notion",
         "baseArgs": ["--version"],
-        "missingDependencyHelp": "Install notion-cli: brew install 4ier/tap/notion-cli"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (or brew install 4ier/tap/notion-cli)"
       },
       "args": []
     },
@@ -230,7 +230,7 @@
       "adapterConfig": {
         "command": "notion",
         "passthrough": true,
-        "missingDependencyHelp": "Install notion-cli: brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (or brew install 4ier/tap/notion-cli). Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": []
     }

--- a/plugins/notion-cli/skills/quickstart/SKILL.md
+++ b/plugins/notion-cli/skills/quickstart/SKILL.md
@@ -59,10 +59,16 @@ export NOTION_TOKEN=ntn_xxxxx
 ## Installation
 
 ```bash
+go install github.com/4ier/notion-cli@latest
+```
+
+Or install with Homebrew:
+
+```bash
 brew install 4ier/tap/notion-cli
 ```
 
-Or download binary from [GitHub Releases](https://github.com/4ier/notion-cli/releases).
+Or download a binary from [GitHub Releases](https://github.com/4ier/notion-cli/releases).
 
 ## Key Features
 - **Agent-friendly**: JSON output auto-detected when piped, schema-aware, URL or ID support


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Fix GitHub issue #298 ONLY: Add 4ier/notion-cli as a bundled plugin in SuperCLI. PR title MUST reference #298.

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These open pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #367 (am/am-f17c27-dkf5c0j0zay2-eb4e39b6): fix(#298): add go install instructions to notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #366 (am/am-f17c27-dkdpk19l4133-1ade27f5): fix(#298): add go install instructions to notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #365 (am/am-f17c27-dkdoeotqzvn8-3120cd1a): fix(#335): implement `run <plugin> <resource> <action>` one-shot command
    touches: __tests__/run-command.test.js, cli/help-json.js, cli/help.js, cli/run.js, cli/supercli.js
- PR #364 (am/am-f17c27-dkdjoppajdp3-a7a89ad7): fix(#362): build sc-machin as static musl binary to fix GLIBC install failures
    touches: .github/workflows/sc-machin-release.yml, README.md, supercli-machin-cli/README.md, supercli-machin-cli/install.sh


**Branch:** `am/am-f17c27-dkfdt4lkqz9c-84d0eb58`

**Diff:**
```
plugins/notion-cli/install-guidance.json      | 4 ++--
 plugins/notion-cli/plugin.json                | 6 +++---
 plugins/notion-cli/skills/quickstart/SKILL.md | 8 +++++++-
 3 files changed, 12 insertions(+), 6 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Notion CLI installation guidance to recommend `go install` as the primary method.
  * Added GitHub Releases and npm as alternative installation options.
  * Retained and clarified Homebrew installation instructions.
  * Expanded installation guidance across setup, version-check, and command dependency documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->