### PR TITLE
fix(#298): add go install instructions to bundled notion-cli plugin

### DIFF
--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-07-21T00:50:41.717Z",
+  "generated_at": "2026-08-06T09:09:00.123Z",
   "count": 10163,
   "plugins": [
     {
@@ -25233,7 +25233,7 @@
     },
     {
       "name": "notion-cli",
-      "checksum": "92bb1f65b65e4baf"
+      "checksum": "8c346fb660a44194"
     },
     {
       "name": "nougat",

--- a/plugins/notion-cli/install-guidance.json
+++ b/plugins/notion-cli/install-guidance.json
@@ -3,11 +3,12 @@
   "binary": "notion",
   "check": "which notion",
   "install_steps": [
-    "brew install 4ier/tap/notion-cli",
+    "go install github.com/4ier/notion-cli@latest",
+    "GOBIN=$(go env GOBIN); GOPATH=$(go env GOPATH); ln -sf \"${GOBIN:-$GOPATH/bin}/notion-cli\" \"${GOBIN:-$GOPATH/bin}/notion\"",
     "Verify: notion --version",
     "Authenticate: echo 'ntn_xxxxx' | notion auth login --with-token",
     "Alternative auth: export NOTION_TOKEN=ntn_xxxxx",
     "supercli plugins install ./plugins/notion-cli --on-conflict replace --json"
   ],
-  "note": "Also available as Go binary from GitHub Releases: https://github.com/4ier/notion-cli/releases. npm: npm install -g @4ier/notion-cli. Token stored in ~/.config/notion-cli/config.json (mode 0600). Auto-detects JSON output when piped to another command."
+  "note": "Primary install is go install github.com/4ier/notion-cli@latest, which builds a binary named notion-cli. Link or rename it to notion before the Verify step. Also available via Homebrew (brew install 4ier/tap/notion-cli), npm (npm install -g @4ier/notion-cli), GitHub Releases (https://github.com/4ier/notion-cli/releases), or Scoop on Windows. Token stored in ~/.config/notion-cli/config.json (mode 0600). Auto-detects JSON output when piped to another command."
 }

--- a/plugins/notion-cli/plugin.json
+++ b/plugins/notion-cli/plugin.json
@@ -11,7 +11,8 @@
     "binary": "notion",
     "check": "which notion",
     "install_steps": [
-      "brew install 4ier/tap/notion-cli",
+      "go install github.com/4ier/notion-cli@latest",
+      "GOBIN=$(go env GOBIN); GOPATH=$(go env GOPATH); ln -sf \"${GOBIN:-$GOPATH/bin}/notion-cli\" \"${GOBIN:-$GOPATH/bin}/notion\"",
       "Verify: notion --version",
       "Authenticate: echo 'ntn_xxxxx' | notion auth login --with-token",
       "supercli plugins install ./plugins/notion-cli --on-conflict replace --json"
@@ -30,7 +31,7 @@
       "adapterConfig": {
         "command": "notion",
         "baseArgs": ["--version"],
-        "missingDependencyHelp": "Install notion-cli: brew install 4ier/tap/notion-cli"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli"
       },
       "args": []
     },
@@ -230,7 +231,7 @@
       "adapterConfig": {
         "command": "notion",
         "passthrough": true,
-        "missingDependencyHelp": "Install notion-cli: brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": []
     }

--- a/plugins/notion-cli/skills/quickstart/SKILL.md
+++ b/plugins/notion-cli/skills/quickstart/SKILL.md
@@ -58,11 +58,26 @@ export NOTION_TOKEN=ntn_xxxxx
 
 ## Installation
 
+The recommended install is with `go install`. The resulting binary is named `notion-cli`, so symlink or rename it to `notion` before running any commands:
+
+```bash
+go install github.com/4ier/notion-cli@latest
+GOBIN=$(go env GOBIN); GOPATH=$(go env GOPATH); ln -sf "${GOBIN:-$GOPATH/bin}/notion-cli" "${GOBIN:-$GOPATH/bin}/notion"
+```
+
+Or install with Homebrew:
+
 ```bash
 brew install 4ier/tap/notion-cli
 ```
 
-Or download binary from [GitHub Releases](https://github.com/4ier/notion-cli/releases).
+Or install with npm:
+
+```bash
+npm install -g @4ier/notion-cli
+```
+
+Or download a binary from [GitHub Releases](https://github.com/4ier/notion-cli/releases).
 
 ## Key Features
 - **Agent-friendly**: JSON output auto-detected when piped, schema-aware, URL or ID support


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Fix GitHub issue #298 ONLY: Add 4ier/notion-cli as a bundled plugin in SuperCLI. PR title MUST reference #298.

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These open pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #374 (am/am-f17c27-dkgyo5mzmfwo-70f504ac): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #373 (am/am-f17c27-dkgvzomn2u44-23e3c40b): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #372 (am/am-f17c27-dkg9sc8fjw7x-91e45236): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #371 (am/am-f17c27-dkg1g7311cne-ca767030): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #370 (am/am-f17c27-dkfyrq5qrxmx-e42eaa25): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #369 (am/am-f17c27-dkfgj4w7jxmc-e50a95d1): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #365 (am/am-f17c27-dkdoeotqzvn8-3120cd1a): fix(#335): implement `run <plugin> <resource> <action>` one-shot command
    touches: __tests__/run-command.test.js, cli/help-json.js, cli/help.js, cli/run.js, cli/supercli.js
- PR #364 (am/am-f17c27-dkdjoppajdp3-a7a89ad7): fix(#362): build sc-machin as static musl binary to fix GLIBC install failures
    touches: .github/workflows/sc-machin-release.yml, README.md, supercli-machin-cli/README.md, supercli-machin-cli/install.sh


**Branch:** `am/am-f17c27-dkhqnrk3bv9y-8c231631`

**Diff:**
```
plugins/catalog.json                          |  4 ++--
 plugins/notion-cli/install-guidance.json      |  5 +++--
 plugins/notion-cli/plugin.json                |  7 ++++---
 plugins/notion-cli/skills/quickstart/SKILL.md | 17 ++++++++++++++++-
 4 files changed, 25 insertions(+), 8 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Notion CLI installation guidance with Go as the primary option.
  * Added instructions for renaming or linking the installed `notion-cli` binary to `notion`.
  * Documented npm, Homebrew, GitHub Releases, and Scoop installation alternatives.
  * Clarified token storage, JSON output, version checks, and command setup requirements.
* **Chores**
  * Refreshed the plugin catalog metadata and checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->