### PR TITLE
fix(#298): add README to bundled notion-cli plugin

### DIFF
--- a/plugins/notion-cli/README.md
+++ b/plugins/notion-cli/README.md
@@ -1,0 +1,104 @@
+# Notion CLI Plugin Harness
+
+This plugin integrates [4ier/notion-cli](https://github.com/4ier/notion-cli) into dcli. It wraps the most agent-friendly Notion commands and provides a full namespace passthrough for the upstream CLI.
+
+## Prerequisites
+
+A Notion integration token is required. Create one at https://www.notion.so/profile/integrations and authenticate:
+
+```bash
+echo "ntn_xxxxx" | notion auth login --with-token
+# or
+export NOTION_TOKEN=ntn_xxxxx
+```
+
+Verify the binary is available:
+
+```bash
+notion --version
+```
+
+## Installation
+
+`go install` builds a binary named `notion-cli`. Symlink or rename it to `notion`:
+
+```bash
+go install github.com/4ier/notion-cli@latest
+GOBIN=$(go env GOBIN); GOPATH=$(go env GOPATH); ln -sf "${GOBIN:-$GOPATH/bin}/notion-cli" "${GOBIN:-$GOPATH/bin}/notion"
+```
+
+Other install methods include Homebrew (`brew install 4ier/tap/notion-cli`), npm (`npm install -g @4ier/notion-cli`), GitHub Releases, or Scoop on Windows.
+
+## Available Commands
+
+### Version
+
+```bash
+dcli notion self version --json
+```
+
+### Auth
+
+```bash
+dcli notion auth status --json
+```
+
+### Search
+
+```bash
+dcli notion search run "meeting notes" --json
+```
+
+### Pages
+
+```bash
+dcli notion page list --json
+dcli notion page view <pageId> --json
+dcli notion page create <dbId> --db "Name=Task" --db "Status=Todo" --json
+```
+
+### Databases
+
+```bash
+dcli notion db list --json
+dcli notion db query <dbId> --filter "Status=Done" --sort "Date:desc" --json
+```
+
+### Blocks
+
+```bash
+dcli notion block list <pageId> --md --depth 3 --json
+dcli notion block append <pageId> --file document.md --json
+```
+
+### Users
+
+```bash
+dcli notion user list --json
+```
+
+### Raw API Requests
+
+```bash
+dcli notion api request GET /v1/users/me --json
+```
+
+### Full Passthrough
+
+Run any upstream notion command through the `notion` namespace:
+
+```bash
+dcli notion _ _ -- --help
+```
+
+## Output
+
+Wrapped commands return a dcli JSON envelope when `--json` is used. The upstream CLI auto-detects JSON output when piped.
+
+## Key Features
+
+- Full Notion API coverage in a single binary
+- JSON output when piped, colored tables in terminal
+- Schema-aware database queries with human-friendly filters
+- Markdown I/O for reading and writing page content
+- URL or ID support for pages and databases


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Fix GitHub issue #298 ONLY: Add 4ier/notion-cli as a bundled plugin in SuperCLI. PR title MUST reference #298.

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These open pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #374 (am/am-f17c27-dkgyo5mzmfwo-70f504ac): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #373 (am/am-f17c27-dkgvzomn2u44-23e3c40b): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #372 (am/am-f17c27-dkg9sc8fjw7x-91e45236): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #371 (am/am-f17c27-dkg1g7311cne-ca767030): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #370 (am/am-f17c27-dkfyrq5qrxmx-e42eaa25): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #369 (am/am-f17c27-dkfgj4w7jxmc-e50a95d1): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #365 (am/am-f17c27-dkdoeotqzvn8-3120cd1a): fix(#335): implement `run <plugin> <resource> <action>` one-shot command
    touches: __tests__/run-command.test.js, cli/help-json.js, cli/help.js, cli/run.js, cli/supercli.js


**Branch:** `am/am-f17c27-dkl69r15q5up-8de7f2ca`

**Diff:**
```
plugins/notion-cli/README.md | 104 +++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 104 insertions(+)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup and usage guidance for the Notion CLI plugin harness.
  * Documented prerequisites, authentication, installation, supported commands, command passthrough, output behavior, and key features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->