### PR TITLE
fix(#298): align notion-cli bundled plugin description and tags with standards

### DIFF
--- a/plugins/notion-cli/meta.json
+++ b/plugins/notion-cli/meta.json
@@ -1,5 +1,5 @@
 {
-  "description": "Notion CLI — like gh for GitHub, but for Notion. 39 commands covering pages, databases, blocks, comments, users, files, and search. Full Notion API in a single Go binary. Auto-detects JSON output when piped — perfect for agents. Schema-aware database queries with human-friendly filters. Markdown I/O for reading/writing page content.",
-  "tags": ["notion", "cli", "knowledge-base", "docs", "productivity", "database", "api", "agentic", "go"],
+  "description": "notion-cli — full-featured Notion CLI with 39 commands for pages, databases, blocks, and the full Notion API",
+  "tags": ["notion-cli", "api", "productivity", "note-taking", "go", "database", "cli"],
   "has_learn": true
 }

--- a/plugins/notion-cli/plugin.json
+++ b/plugins/notion-cli/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "notion-cli",
   "version": "0.1.0",
-  "description": "Notion CLI — like gh for GitHub, but for Notion. 39 commands covering pages, databases, blocks, comments, users, files, and search. Full Notion API in a single Go binary. JSON output when piped, schema-aware queries, Markdown I/O. Built for developers and AI agents.",
+  "description": "notion-cli — full-featured Notion CLI with 39 commands for pages, databases, blocks, and the full Notion API",
   "source": "https://github.com/4ier/notion-cli",
   "checks": [
     { "type": "binary", "name": "notion" }


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Fix GitHub issue #298 ONLY: Add 4ier/notion-cli as a bundled plugin in SuperCLI. PR title MUST reference #298.

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These open pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #374 (am/am-f17c27-dkgyo5mzmfwo-70f504ac): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #373 (am/am-f17c27-dkgvzomn2u44-23e3c40b): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #372 (am/am-f17c27-dkg9sc8fjw7x-91e45236): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #371 (am/am-f17c27-dkg1g7311cne-ca767030): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #370 (am/am-f17c27-dkfyrq5qrxmx-e42eaa25): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #369 (am/am-f17c27-dkfgj4w7jxmc-e50a95d1): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #365 (am/am-f17c27-dkdoeotqzvn8-3120cd1a): fix(#335): implement `run <plugin> <resource> <action>` one-shot command
    touches: __tests__/run-command.test.js, cli/help-json.js, cli/help.js, cli/run.js, cli/supercli.js


**Branch:** `am/am-f17c27-dklx5jo9qfio-8788a5d0`

**Diff:**
```
plugins/notion-cli/meta.json   | 4 ++--
 plugins/notion-cli/plugin.json | 2 +-
 2 files changed, 3 insertions(+), 3 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Notion CLI plugin description to highlight its 39 commands and broad Notion API coverage.
  * Refined plugin tags and messaging to emphasize productivity use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->