### PR TITLE
fix(#298): align notion-cli README command examples with supercli

### DIFF
--- a/plugins/notion-cli/README.md
+++ b/plugins/notion-cli/README.md
@@ -1,6 +1,6 @@
 # Notion CLI Plugin Harness
 
-This plugin integrates [4ier/notion-cli](https://github.com/4ier/notion-cli) into dcli. It wraps the most agent-friendly Notion commands and provides a full namespace passthrough for the upstream CLI.
+This plugin integrates [4ier/notion-cli](https://github.com/4ier/notion-cli) into SuperCLI. It wraps the most agent-friendly Notion commands and provides a full namespace passthrough for the upstream CLI.
 
 ## Prerequisites
 
@@ -34,53 +34,53 @@ Other install methods include Homebrew (`brew install 4ier/tap/notion-cli`), npm
 ### Version
 
 ```bash
-dcli notion self version --json
+supercli notion self version --json
 ```
 
 ### Auth
 
 ```bash
-dcli notion auth status --json
+supercli notion auth status --json
 ```
 
 ### Search
 
 ```bash
-dcli notion search run "meeting notes" --json
+supercli notion search run "meeting notes" --json
 ```
 
 ### Pages
 
 ```bash
-dcli notion page list --json
-dcli notion page view <pageId> --json
-dcli notion page create <dbId> --db "Name=Task" --db "Status=Todo" --json
+supercli notion page list --json
+supercli notion page view <pageId> --json
+supercli notion page create <dbId> --db "Name=Task" --db "Status=Todo" --json
 ```
 
 ### Databases
 
 ```bash
-dcli notion db list --json
-dcli notion db query <dbId> --filter "Status=Done" --sort "Date:desc" --json
+supercli notion db list --json
+supercli notion db query <dbId> --filter "Status=Done" --sort "Date:desc" --json
 ```
 
 ### Blocks
 
 ```bash
-dcli notion block list <pageId> --md --depth 3 --json
-dcli notion block append <pageId> --file document.md --json
+supercli notion block list <pageId> --md --depth 3 --json
+supercli notion block append <pageId> --file document.md --json
 ```
 
 ### Users
 
 ```bash
-dcli notion user list --json
+supercli notion user list --json
 ```
 
 ### Raw API Requests
 
 ```bash
-dcli notion api request GET /v1/users/me --json
+supercli notion api request GET /v1/users/me --json
 ```
 
 ### Full Passthrough
@@ -88,12 +88,12 @@ dcli notion api request GET /v1/users/me --json
 Run any upstream notion command through the `notion` namespace:
 
 ```bash
-dcli notion _ _ -- --help
+supercli notion _ _ -- --help
 ```
 
 ## Output
 
-Wrapped commands return a dcli JSON envelope when `--json` is used. The upstream CLI auto-detects JSON output when piped.
+Wrapped commands return a SuperCLI JSON envelope when `--json` is used. The upstream CLI auto-detects JSON output when piped.
 
 ## Key Features
 


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Fix GitHub issue #298 ONLY: Add 4ier/notion-cli as a bundled plugin in SuperCLI. PR title MUST reference #298.

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These open pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #378 (am/am-f17c27-dkm2q5alhgw6-a56a1e03): fix(#298): expand bundled notion-cli command coverage
    touches: plugins/notion-cli/plugin.json
- PR #374 (am/am-f17c27-dkgyo5mzmfwo-70f504ac): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #373 (am/am-f17c27-dkgvzomn2u44-23e3c40b): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #372 (am/am-f17c27-dkg9sc8fjw7x-91e45236): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #371 (am/am-f17c27-dkg1g7311cne-ca767030): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #370 (am/am-f17c27-dkfyrq5qrxmx-e42eaa25): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #369 (am/am-f17c27-dkfgj4w7jxmc-e50a95d1): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #365 (am/am-f17c27-dkdoeotqzvn8-3120cd1a): fix(#335): implement `run <plugin> <resource> <action>` one-shot command
    touches: __tests__/run-command.test.js, cli/help-json.js, cli/help.js, cli/run.js, cli/supercli.js


**Branch:** `am/am-f17c27-dknp7phlv32g-1340b521`

**Diff:**
```
plugins/notion-cli/README.md | 30 +++++++++++++++---------------
 1 file changed, 15 insertions(+), 15 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Notion CLI documentation to use the `supercli notion` command namespace.
  * Revised command examples and JSON output descriptions to reflect SuperCLI terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->