### PR TITLE
fix(#298): expand bundled notion-cli command coverage

### DIFF
--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-08-13T09:50:57.544Z",
+  "generated_at": "2026-08-14T14:18:35.844Z",
   "count": 10163,
   "plugins": [
     {
@@ -25233,7 +25233,7 @@
     },
     {
       "name": "notion-cli",
-      "checksum": "a625e9f0846e8f1c"
+      "checksum": "812a98339f0d386b"
     },
     {
       "name": "nougat",

--- a/plugins/notion-cli/plugin.json
+++ b/plugins/notion-cli/plugin.json
@@ -15,6 +15,7 @@
       "GOBIN=$(go env GOBIN); GOPATH=$(go env GOPATH); ln -sf \"${GOBIN:-$GOPATH/bin}/notion-cli\" \"${GOBIN:-$GOPATH/bin}/notion\"",
       "Verify: notion --version",
       "Authenticate: echo 'ntn_xxxxx' | notion auth login --with-token",
+      "Alternative auth: export NOTION_TOKEN=ntn_xxxxx",
       "supercli plugins install ./plugins/notion-cli --on-conflict replace --json"
     ],
     "note": "Primary install is `go install github.com/4ier/notion-cli@latest`, which builds a binary named `notion-cli`. Link or rename it to `notion` before the `Verify` step. Also available via Homebrew (`brew install 4ier/tap/notion-cli`), npm (`npm install -g @4ier/notion-cli`), GitHub Releases (https://github.com/4ier/notion-cli/releases), or Scoop on Windows. Token stored in ~/.config/notion-cli/config.json (mode 0600). Auto-detects JSON output when piped to another command."
@@ -32,6 +33,7 @@
       "adapterConfig": {
         "command": "notion",
         "baseArgs": ["--version"],
+        "timeout_ms": 5000,
         "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli"
       },
       "args": []
@@ -52,6 +54,34 @@
     },
     {
       "namespace": "notion",
+      "resource": "auth",
+      "action": "logout",
+      "description": "Log out of Notion",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["auth", "logout"],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": []
+    },
+    {
+      "namespace": "notion",
+      "resource": "auth",
+      "action": "doctor",
+      "description": "Check authentication and API connectivity",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["auth", "doctor"],
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": []
+    },
+    {
+      "namespace": "notion",
       "resource": "search",
       "action": "run",
       "description": "Search Notion pages and databases by query string",
@@ -61,10 +91,14 @@
         "baseArgs": ["search"],
         "positionalArgs": ["query"],
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": [
-        { "name": "query", "type": "string", "required": true, "description": "Search query text" }
+        { "name": "query", "type": "string", "required": true, "description": "Search query text" },
+        { "name": "type", "type": "string", "required": false, "description": "Filter by type: page, database" },
+        { "name": "limit", "type": "number", "required": false, "description": "Maximum results per page" },
+        { "name": "cursor", "type": "string", "required": false, "description": "Pagination cursor from previous results" },
+        { "name": "all", "type": "boolean", "required": false, "description": "Fetch all pages of results" }
       ]
     },
     {
@@ -78,29 +112,10 @@
         "baseArgs": ["page", "view"],
         "positionalArgs": ["pageId"],
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": [
         { "name": "pageId", "type": "string", "required": true, "description": "Page ID or full Notion URL" }
-      ]
-    },
-    {
-      "namespace": "notion",
-      "resource": "page",
-      "action": "create",
-      "description": "Create a new page in a Notion database",
-      "adapter": "process",
-      "adapterConfig": {
-        "command": "notion",
-        "baseArgs": ["page", "create"],
-        "positionalArgs": ["dbId"],
-        "passthrough": true,
-        "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
-      },
-      "args": [
-        { "name": "dbId", "type": "string", "required": true, "description": "Database ID or URL" },
-        { "name": "--db", "type": "string", "required": false, "description": "Database properties in 'Name=Value' format (e.g., 'Name=Task', 'Status=Done')" }
       ]
     },
     {
@@ -113,9 +128,103 @@
         "command": "notion",
         "baseArgs": ["page", "list"],
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
-      "args": []
+      "args": [
+        { "name": "limit", "type": "number", "required": false, "description": "Maximum results per page" },
+        { "name": "cursor", "type": "string", "required": false, "description": "Pagination cursor from previous results" },
+        { "name": "all", "type": "boolean", "required": false, "description": "Fetch all pages of results" }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "page",
+      "action": "create",
+      "description": "Create a new page under a parent page or database",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["page", "create"],
+        "positionalArgs": ["parentId"],
+        "passthrough": true,
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        { "name": "parentId", "type": "string", "required": true, "description": "Parent page or database ID/URL" },
+        { "name": "db", "type": "boolean", "required": false, "description": "Create under a database (properties as key=value args)" },
+        { "name": "title", "type": "string", "required": false, "description": "Page title (required when parent is a page)" },
+        { "name": "body", "type": "string", "required": false, "description": "Page body text" }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "page",
+      "action": "archive",
+      "description": "Archive (soft-delete) a Notion page",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["page", "archive"],
+        "positionalArgs": ["pageId"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        { "name": "pageId", "type": "string", "required": true, "description": "Page ID or full Notion URL" }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "page",
+      "action": "restore",
+      "description": "Restore an archived Notion page",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["page", "restore"],
+        "positionalArgs": ["pageId"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        { "name": "pageId", "type": "string", "required": true, "description": "Page ID or full Notion URL" }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "db",
+      "action": "list",
+      "description": "List Notion databases",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["db", "list"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        { "name": "limit", "type": "number", "required": false, "description": "Maximum results per page" },
+        { "name": "cursor", "type": "string", "required": false, "description": "Pagination cursor from previous results" },
+        { "name": "all", "type": "boolean", "required": false, "description": "Fetch all pages of results" }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "db",
+      "action": "view",
+      "description": "Show database schema",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["db", "view"],
+        "positionalArgs": ["dbId"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        { "name": "dbId", "type": "string", "required": true, "description": "Database ID or URL" }
+      ]
     },
     {
       "namespace": "notion",
@@ -129,34 +238,60 @@
         "positionalArgs": ["dbId"],
         "passthrough": true,
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": [
         { "name": "dbId", "type": "string", "required": true, "description": "Database ID or URL" },
-        { "name": "--filter", "type": "string", "required": false, "description": "Filter by property (e.g., 'Status=Done', 'Priority=High')" },
-        { "name": "--filter-json", "type": "string", "required": false, "description": "Complex filter in JSON (for OR/nesting)" },
-        { "name": "--sort", "type": "string", "required": false, "description": "Sort by property (e.g., 'Date:desc')" }
+        { "name": "filter", "type": "string", "required": false, "description": "Filter expression (e.g., 'Status=Done')" },
+        { "name": "filter-json", "type": "string", "required": false, "description": "Complex filter in JSON (for OR/nesting)" },
+        { "name": "sort", "type": "string", "required": false, "description": "Sort expression (e.g., 'Date:desc')" },
+        { "name": "limit", "type": "number", "required": false, "description": "Maximum results per page" },
+        { "name": "cursor", "type": "string", "required": false, "description": "Pagination cursor from previous results" },
+        { "name": "all", "type": "boolean", "required": false, "description": "Fetch all pages of results" }
       ]
     },
     {
       "namespace": "notion",
       "resource": "db",
-      "action": "list",
-      "description": "List Notion databases",
+      "action": "add",
+      "description": "Add a new row (page) to a database",
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
-        "baseArgs": ["db", "list"],
+        "baseArgs": ["db", "add"],
+        "positionalArgs": ["dbId"],
+        "passthrough": true,
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
-      "args": []
+      "args": [
+        { "name": "dbId", "type": "string", "required": true, "description": "Database ID or URL" }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "db",
+      "action": "create",
+      "description": "Create a new database under a parent page",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["db", "create"],
+        "positionalArgs": ["parentId"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        { "name": "parentId", "type": "string", "required": true, "description": "Parent page ID or URL" },
+        { "name": "title", "type": "string", "required": false, "description": "Database title (required)" },
+        { "name": "props", "type": "string", "required": false, "description": "Additional properties as name:type,... (e.g., Status:select,Date:date)" }
+      ]
     },
     {
       "namespace": "notion",
       "resource": "block",
       "action": "list",
-      "description": "List blocks (content) of a Notion page as Markdown",
+      "description": "List child blocks of a page or block as Markdown",
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
@@ -164,31 +299,71 @@
         "positionalArgs": ["pageId"],
         "passthrough": true,
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": [
-        { "name": "pageId", "type": "string", "required": true, "description": "Page ID or URL" },
-        { "name": "--depth", "type": "number", "required": false, "description": "Recursion depth for nested blocks (default 1)" },
-        { "name": "--md", "type": "boolean", "required": false, "description": "Output as Markdown" }
+        { "name": "pageId", "type": "string", "required": true, "description": "Page or block ID/URL" },
+        { "name": "depth", "type": "number", "required": false, "description": "Recursion depth for nested blocks (default 1)" },
+        { "name": "md", "type": "boolean", "required": false, "description": "Output as Markdown" },
+        { "name": "all", "type": "boolean", "required": false, "description": "Fetch all pages of results" },
+        { "name": "cursor", "type": "string", "required": false, "description": "Pagination cursor from previous results" }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "block",
+      "action": "get",
+      "description": "Get a specific block by ID",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["block", "get"],
+        "positionalArgs": ["blockId"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        { "name": "blockId", "type": "string", "required": true, "description": "Block ID or URL" }
       ]
     },
     {
       "namespace": "notion",
       "resource": "block",
       "action": "append",
-      "description": "Append Markdown content to a Notion page",
+      "description": "Append Markdown or blocks to a Notion page or block",
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
         "baseArgs": ["block", "append"],
-        "positionalArgs": ["pageId"],
+        "positionalArgs": ["parentId"],
         "passthrough": true,
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": [
-        { "name": "pageId", "type": "string", "required": true, "description": "Page ID or URL" },
-        { "name": "--file", "type": "string", "required": false, "description": "Markdown file to append" }
+        { "name": "parentId", "type": "string", "required": true, "description": "Page or block ID/URL" },
+        { "name": "file", "type": "string", "required": false, "description": "Markdown file to append" },
+        { "name": "type", "type": "string", "required": false, "description": "Block type: paragraph, h1, h2, h3, todo, bullet, numbered, quote, code, callout, divider" },
+        { "name": "lang", "type": "string", "required": false, "description": "Language for code blocks (e.g., go, python, bash)" },
+        { "name": "on-oversize", "type": "string", "required": false, "description": "Behavior for rich_text >2000 chars: split|truncate|fail" },
+        { "name": "caption", "type": "string", "required": false, "description": "Caption for media blocks" }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "block",
+      "action": "delete",
+      "description": "Delete one or more blocks by ID",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["block", "delete"],
+        "positionalArgs": ["blockId"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        { "name": "blockId", "type": "string", "required": true, "description": "Block ID or URL" }
       ]
     },
     {
@@ -201,9 +376,78 @@
         "command": "notion",
         "baseArgs": ["user", "list"],
         "timeout_ms": 10000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        { "name": "all", "type": "boolean", "required": false, "description": "Fetch all pages of results" },
+        { "name": "cursor", "type": "string", "required": false, "description": "Pagination cursor from previous results" }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "user",
+      "action": "me",
+      "description": "Show current bot user",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["user", "me"],
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": []
+    },
+    {
+      "namespace": "notion",
+      "resource": "comment",
+      "action": "list",
+      "description": "List comments on a Notion page or block",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["comment", "list"],
+        "positionalArgs": ["pageId"],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        { "name": "pageId", "type": "string", "required": true, "description": "Page or block ID/URL" },
+        { "name": "all", "type": "boolean", "required": false, "description": "Fetch all pages of results" },
+        { "name": "cursor", "type": "string", "required": false, "description": "Pagination cursor from previous results" }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "file",
+      "action": "list",
+      "description": "List file uploads",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["file", "list"],
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": []
+    },
+    {
+      "namespace": "notion",
+      "resource": "file",
+      "action": "upload",
+      "description": "Upload a file to Notion",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": ["file", "upload"],
+        "positionalArgs": ["source"],
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        { "name": "source", "type": "string", "required": true, "description": "Local path, http(s) URL, or - for stdin" },
+        { "name": "to", "type": "string", "required": false, "description": "Target page ID to attach file to" },
+        { "name": "name", "type": "string", "required": false, "description": "Override filename (required for stdin/URL)" }
+      ]
     },
     {
       "namespace": "notion",
@@ -216,11 +460,12 @@
         "baseArgs": ["api"],
         "positionalArgs": ["method", "path"],
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": [
         { "name": "method", "type": "string", "required": true, "description": "HTTP method (GET, POST, PATCH, DELETE)" },
-        { "name": "path", "type": "string", "required": true, "description": "API path (e.g., /v1/users/me)" }
+        { "name": "path", "type": "string", "required": true, "description": "API path (e.g., /v1/users/me)" },
+        { "name": "body", "type": "string", "required": false, "description": "JSON request body. Use @<file> to read from file, or - for stdin" }
       ]
     },
     {


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Fix GitHub issue #298 ONLY: Add 4ier/notion-cli as a bundled plugin in SuperCLI. PR title MUST reference #298.

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These open pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #378 (am/am-f17c27-dkm2q5alhgw6-a56a1e03): fix(#298): expand bundled notion-cli command coverage
    touches: plugins/notion-cli/plugin.json
- PR #374 (am/am-f17c27-dkgyo5mzmfwo-70f504ac): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #373 (am/am-f17c27-dkgvzomn2u44-23e3c40b): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #372 (am/am-f17c27-dkg9sc8fjw7x-91e45236): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #371 (am/am-f17c27-dkg1g7311cne-ca767030): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #370 (am/am-f17c27-dkfyrq5qrxmx-e42eaa25): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #369 (am/am-f17c27-dkfgj4w7jxmc-e50a95d1): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #365 (am/am-f17c27-dkdoeotqzvn8-3120cd1a): fix(#335): implement `run <plugin> <resource> <action>` one-shot command
    touches: __tests__/run-command.test.js, cli/help-json.js, cli/help.js, cli/run.js, cli/supercli.js


**Branch:** `am/am-f17c27-dkoq3d9ycsit-02242336`

**Diff:**
```
plugins/catalog.json           |   4 +-
 plugins/notion-cli/plugin.json | 313 ++++++++++++++++++++++++++++++++++++-----
 2 files changed, 281 insertions(+), 36 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Notion CLI authentication with logout and diagnostic commands.
  * Added commands for listing, archiving, and restoring pages.
  * Added database creation and page-management capabilities.
  * Added block retrieval, deletion, formatting, and deeper content listing.
  * Added current-user, comment-listing, file-listing, and file-upload commands.
  * Added pagination, filtering, sorting, and request-body options across supported commands.
* **Updates**
  * Improved authentication setup guidance and command descriptions.
  * Updated the plugin catalog metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->