### PR TITLE
fix(#298): expand bundled notion-cli command coverage

### DIFF
--- a/plugins/notion-cli/README.md
+++ b/plugins/notion-cli/README.md
@@ -41,6 +41,8 @@ supercli notion self version --json
 
 ```bash
 supercli notion auth status --json
+supercli notion auth doctor --json
+supercli notion auth logout --json
 ```
 
 ### Search
@@ -54,33 +56,78 @@ supercli notion search run "meeting notes" --json
 ```bash
 supercli notion page list --json
 supercli notion page view <pageId> --json
-supercli notion page create <dbId> --db "Name=Task" --db "Status=Todo" --json
+supercli notion page create <parentId> --title "My Page" --body "Body text" --json
+supercli notion page create <dbId> "Name=Task" "Status=Todo" --db --json
+supercli notion page archive <pageId> --json
+supercli notion page restore <pageId> --json
+supercli notion page move <pageId> --to <parentId> --json
+supercli notion page open <pageId> --json
+supercli notion page set <pageId> Status=Done Priority=High --json
+supercli notion page props <pageId> --json
+supercli notion page link <pageId> --prop "Project" --to <pageId> --json
+supercli notion page unlink <pageId> --prop "Project" --from <pageId> --json
 ```
 
 ### Databases
 
 ```bash
 supercli notion db list --json
+supercli notion db view <dbId> --json
 supercli notion db query <dbId> --filter "Status=Done" --sort "Date:desc" --json
+supercli notion db add <dbId> "Name=Task" "Status=Todo" --json
+supercli notion db add-bulk <dbId> --file items.json --json
+supercli notion db create <parentId> --title "Tasks" --props "Status:select,Date:date" --json
+supercli notion db update <dbId> --title "New Title" --add-prop "Priority:select" --json
+supercli notion db open <dbId> --json
+supercli notion db export <dbId> --format csv --output report.csv --json
 ```
 
 ### Blocks
 
 ```bash
 supercli notion block list <pageId> --md --depth 3 --json
-supercli notion block append <pageId> --file document.md --json
+supercli notion block get <blockId> --json
+supercli notion block append <parentId> "Hello world" --type h1 --json
+supercli notion block append <parentId> --file document.md --json
+supercli notion block insert <parentId> "New paragraph" --after <blockId> --json
+supercli notion block update <blockId> --text "Updated content" --json
+supercli notion block delete <blockId> --json
+supercli notion block move <blockId> --after <blockId> --json
+```
+
+### Comments
+
+```bash
+supercli notion comment list <pageId> --json
+supercli notion comment add <pageId> "This looks great" --json
+supercli notion comment get <commentId> --json
+supercli notion comment reply <commentId> "Thanks" --json
+supercli notion comment update <commentId> --text "Fixed typo" --json
+supercli notion comment delete <commentId> --json
 ```
 
 ### Users
 
 ```bash
+supercli notion user me --json
 supercli notion user list --json
+supercli notion user get <userId> --json
+```
+
+### Files
+
+```bash
+supercli notion file list --json
+supercli notion file upload ./document.pdf --json
+supercli notion file upload https://example.com/chart.png --name chart.png --json
+supercli notion file get <uploadId> --json
 ```
 
 ### Raw API Requests
 
 ```bash
 supercli notion api request GET /v1/users/me --json
+supercli notion api request POST /v1/search --body '{"query":"test"}' --json
 ```
 
 ### Full Passthrough
@@ -88,7 +135,7 @@ supercli notion api request GET /v1/users/me --json
 Run any upstream notion command through the `notion` namespace:
 
 ```bash
-supercli notion _ _ -- --help
+supercli notion _ _ -- db query <dbId> --filter "Status=Done"
 ```
 
 ## Output

--- a/plugins/notion-cli/plugin.json
+++ b/plugins/notion-cli/plugin.json
@@ -4,7 +4,10 @@
   "description": "notion-cli — full-featured Notion CLI with 39 commands for pages, databases, blocks, and the full Notion API",
   "source": "https://github.com/4ier/notion-cli",
   "checks": [
-    { "type": "binary", "name": "notion" }
+    {
+      "type": "binary",
+      "name": "notion"
+    }
   ],
   "install_guidance": {
     "plugin": "notion-cli",
@@ -15,6 +18,7 @@
       "GOBIN=$(go env GOBIN); GOPATH=$(go env GOPATH); ln -sf \"${GOBIN:-$GOPATH/bin}/notion-cli\" \"${GOBIN:-$GOPATH/bin}/notion\"",
       "Verify: notion --version",
       "Authenticate: echo 'ntn_xxxxx' | notion auth login --with-token",
+      "Alternative auth: export NOTION_TOKEN=ntn_xxxxx",
       "supercli plugins install ./plugins/notion-cli --on-conflict replace --json"
     ],
     "note": "Primary install is `go install github.com/4ier/notion-cli@latest`, which builds a binary named `notion-cli`. Link or rename it to `notion` before the `Verify` step. Also available via Homebrew (`brew install 4ier/tap/notion-cli`), npm (`npm install -g @4ier/notion-cli`), GitHub Releases (https://github.com/4ier/notion-cli/releases), or Scoop on Windows. Token stored in ~/.config/notion-cli/config.json (mode 0600). Auto-detects JSON output when piped to another command."
@@ -31,7 +35,10 @@
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
-        "baseArgs": ["--version"],
+        "baseArgs": [
+          "--version"
+        ],
+        "timeout_ms": 5000,
         "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli"
       },
       "args": []
@@ -44,9 +51,46 @@
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
-        "baseArgs": ["auth", "status"],
+        "baseArgs": [
+          "auth",
+          "status"
+        ],
         "timeout_ms": 5000,
-        "missingDependencyHelp": "Install notion-cli and authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": []
+    },
+    {
+      "namespace": "notion",
+      "resource": "auth",
+      "action": "logout",
+      "description": "Log out of Notion",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "auth",
+          "logout"
+        ],
+        "timeout_ms": 5000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": []
+    },
+    {
+      "namespace": "notion",
+      "resource": "auth",
+      "action": "doctor",
+      "description": "Check authentication and API connectivity",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "auth",
+          "doctor"
+        ],
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": []
     },
@@ -58,13 +102,46 @@
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
-        "baseArgs": ["search"],
-        "positionalArgs": ["query"],
+        "baseArgs": [
+          "search"
+        ],
+        "positionalArgs": [
+          "query"
+        ],
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": [
-        { "name": "query", "type": "string", "required": true, "description": "Search query text" }
+        {
+          "name": "query",
+          "type": "string",
+          "required": true,
+          "description": "Search query text"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "required": false,
+          "description": "Filter by type: page, database"
+        },
+        {
+          "name": "limit",
+          "type": "number",
+          "required": false,
+          "description": "Maximum results per page"
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from previous results"
+        },
+        {
+          "name": "all",
+          "type": "boolean",
+          "required": false,
+          "description": "Fetch all pages of results"
+        }
       ]
     },
     {
@@ -75,32 +152,23 @@
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
-        "baseArgs": ["page", "view"],
-        "positionalArgs": ["pageId"],
+        "baseArgs": [
+          "page",
+          "view"
+        ],
+        "positionalArgs": [
+          "pageId"
+        ],
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": [
-        { "name": "pageId", "type": "string", "required": true, "description": "Page ID or full Notion URL" }
-      ]
-    },
-    {
-      "namespace": "notion",
-      "resource": "page",
-      "action": "create",
-      "description": "Create a new page in a Notion database",
-      "adapter": "process",
-      "adapterConfig": {
-        "command": "notion",
-        "baseArgs": ["page", "create"],
-        "positionalArgs": ["dbId"],
-        "passthrough": true,
-        "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
-      },
-      "args": [
-        { "name": "dbId", "type": "string", "required": true, "description": "Database ID or URL" },
-        { "name": "--db", "type": "string", "required": false, "description": "Database properties in 'Name=Value' format (e.g., 'Name=Task', 'Status=Done')" }
+        {
+          "name": "pageId",
+          "type": "string",
+          "required": true,
+          "description": "Page ID or full Notion URL"
+        }
       ]
     },
     {
@@ -111,31 +179,323 @@
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
-        "baseArgs": ["page", "list"],
+        "baseArgs": [
+          "page",
+          "list"
+        ],
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
-      "args": []
+      "args": [
+        {
+          "name": "limit",
+          "type": "number",
+          "required": false,
+          "description": "Maximum results per page"
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from previous results"
+        },
+        {
+          "name": "all",
+          "type": "boolean",
+          "required": false,
+          "description": "Fetch all pages of results"
+        }
+      ]
     },
     {
       "namespace": "notion",
-      "resource": "db",
-      "action": "query",
-      "description": "Query a Notion database with filters and sorting",
+      "resource": "page",
+      "action": "create",
+      "description": "Create a new page under a parent page or database",
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
-        "baseArgs": ["db", "query"],
-        "positionalArgs": ["dbId"],
-        "passthrough": true,
+        "baseArgs": [
+          "page",
+          "create"
+        ],
+        "positionalArgs": [
+          "parentId"
+        ],
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": [
-        { "name": "dbId", "type": "string", "required": true, "description": "Database ID or URL" },
-        { "name": "--filter", "type": "string", "required": false, "description": "Filter by property (e.g., 'Status=Done', 'Priority=High')" },
-        { "name": "--filter-json", "type": "string", "required": false, "description": "Complex filter in JSON (for OR/nesting)" },
-        { "name": "--sort", "type": "string", "required": false, "description": "Sort by property (e.g., 'Date:desc')" }
+        {
+          "name": "parentId",
+          "type": "string",
+          "required": true,
+          "description": "Parent page or database ID/URL"
+        },
+        {
+          "name": "db",
+          "type": "boolean",
+          "required": false,
+          "description": "Create under a database (properties as key=value args)"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "description": "Page title (required when parent is a page)"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "required": false,
+          "description": "Page body text"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "page",
+      "action": "archive",
+      "description": "Archive (soft-delete) a Notion page",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "page",
+          "archive"
+        ],
+        "positionalArgs": [
+          "pageId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "pageId",
+          "type": "string",
+          "required": true,
+          "description": "Page ID or full Notion URL"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "page",
+      "action": "restore",
+      "description": "Restore an archived Notion page",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "page",
+          "restore"
+        ],
+        "positionalArgs": [
+          "pageId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "pageId",
+          "type": "string",
+          "required": true,
+          "description": "Page ID or full Notion URL"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "page",
+      "action": "move",
+      "description": "Move a page to a new parent",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "page",
+          "move"
+        ],
+        "positionalArgs": [
+          "pageId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "pageId",
+          "type": "string",
+          "required": true,
+          "description": "Page ID or full Notion URL"
+        },
+        {
+          "name": "to",
+          "type": "string",
+          "required": true,
+          "description": "Target parent page or database ID/URL"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "page",
+      "action": "open",
+      "description": "Open a page in the browser",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "page",
+          "open"
+        ],
+        "positionalArgs": [
+          "pageId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "pageId",
+          "type": "string",
+          "required": true,
+          "description": "Page ID or full Notion URL"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "page",
+      "action": "set",
+      "description": "Set one or more page properties as key=value",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "page",
+          "set"
+        ],
+        "positionalArgs": [
+          "pageId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "pageId",
+          "type": "string",
+          "required": true,
+          "description": "Page ID or full Notion URL"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "page",
+      "action": "props",
+      "description": "Show all page properties or a specific property value",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "page",
+          "props"
+        ],
+        "positionalArgs": [
+          "pageId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "pageId",
+          "type": "string",
+          "required": true,
+          "description": "Page ID or full Notion URL"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "page",
+      "action": "link",
+      "description": "Add a relation link between two pages",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "page",
+          "link"
+        ],
+        "positionalArgs": [
+          "pageId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "pageId",
+          "type": "string",
+          "required": true,
+          "description": "Page ID or full Notion URL"
+        },
+        {
+          "name": "prop",
+          "type": "string",
+          "required": true,
+          "description": "Relation property name"
+        },
+        {
+          "name": "to",
+          "type": "string",
+          "required": true,
+          "description": "Target page ID or URL to link"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "page",
+      "action": "unlink",
+      "description": "Remove a relation link from a page",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "page",
+          "unlink"
+        ],
+        "positionalArgs": [
+          "pageId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "pageId",
+          "type": "string",
+          "required": true,
+          "description": "Page ID or full Notion URL"
+        },
+        {
+          "name": "prop",
+          "type": "string",
+          "required": true,
+          "description": "Relation property name"
+        },
+        {
+          "name": "from",
+          "type": "string",
+          "required": true,
+          "description": "Target page ID or URL to unlink"
+        }
       ]
     },
     {
@@ -146,50 +506,947 @@
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
-        "baseArgs": ["db", "list"],
+        "baseArgs": [
+          "db",
+          "list"
+        ],
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
-      "args": []
+      "args": [
+        {
+          "name": "limit",
+          "type": "number",
+          "required": false,
+          "description": "Maximum results per page"
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from previous results"
+        },
+        {
+          "name": "all",
+          "type": "boolean",
+          "required": false,
+          "description": "Fetch all pages of results"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "db",
+      "action": "view",
+      "description": "Show database schema",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "db",
+          "view"
+        ],
+        "positionalArgs": [
+          "dbId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "dbId",
+          "type": "string",
+          "required": true,
+          "description": "Database ID or URL"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "db",
+      "action": "query",
+      "description": "Query a database with filters and sorting",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "db",
+          "query"
+        ],
+        "positionalArgs": [
+          "dbId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "dbId",
+          "type": "string",
+          "required": true,
+          "description": "Database ID or URL"
+        },
+        {
+          "name": "filter",
+          "type": "string",
+          "required": false,
+          "description": "Filter expression (e.g., 'Status=Done')"
+        },
+        {
+          "name": "filter-json",
+          "type": "string",
+          "required": false,
+          "description": "Complex filter in JSON (for OR/nesting)"
+        },
+        {
+          "name": "sort",
+          "type": "string",
+          "required": false,
+          "description": "Sort expression (e.g., 'Date:desc')"
+        },
+        {
+          "name": "limit",
+          "type": "number",
+          "required": false,
+          "description": "Maximum results per page"
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from previous results"
+        },
+        {
+          "name": "all",
+          "type": "boolean",
+          "required": false,
+          "description": "Fetch all pages of results"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "db",
+      "action": "add",
+      "description": "Add a new row (page) to a database",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "db",
+          "add"
+        ],
+        "positionalArgs": [
+          "dbId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "dbId",
+          "type": "string",
+          "required": true,
+          "description": "Database ID or URL"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "db",
+      "action": "add-bulk",
+      "description": "Bulk add rows to a database from a JSON file",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "db",
+          "add-bulk"
+        ],
+        "positionalArgs": [
+          "dbId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "dbId",
+          "type": "string",
+          "required": true,
+          "description": "Database ID or URL"
+        },
+        {
+          "name": "file",
+          "type": "string",
+          "required": true,
+          "description": "JSON file with rows to create"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "db",
+      "action": "create",
+      "description": "Create a new database under a parent page",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "db",
+          "create"
+        ],
+        "positionalArgs": [
+          "parentId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "parentId",
+          "type": "string",
+          "required": true,
+          "description": "Parent page ID or URL"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "description": "Database title"
+        },
+        {
+          "name": "props",
+          "type": "string",
+          "required": false,
+          "description": "Additional properties as name:type,... (e.g., Status:select,Date:date)"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "db",
+      "action": "update",
+      "description": "Update a database title or properties",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "db",
+          "update"
+        ],
+        "positionalArgs": [
+          "dbId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "dbId",
+          "type": "string",
+          "required": true,
+          "description": "Database ID or URL"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "description": "New database title"
+        },
+        {
+          "name": "add-prop",
+          "type": "string",
+          "required": false,
+          "description": "Property to add as name:type"
+        },
+        {
+          "name": "remove-prop",
+          "type": "string",
+          "required": false,
+          "description": "Property name to remove"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "db",
+      "action": "open",
+      "description": "Open a database in the browser",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "db",
+          "open"
+        ],
+        "positionalArgs": [
+          "dbId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "dbId",
+          "type": "string",
+          "required": true,
+          "description": "Database ID or URL"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "db",
+      "action": "export",
+      "description": "Export database rows to CSV, JSON, or Markdown",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "db",
+          "export"
+        ],
+        "positionalArgs": [
+          "dbId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "dbId",
+          "type": "string",
+          "required": true,
+          "description": "Database ID or URL"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "required": false,
+          "description": "Output format: csv, json, md (default csv)"
+        },
+        {
+          "name": "output",
+          "type": "string",
+          "required": false,
+          "description": "Output file path"
+        }
+      ]
     },
     {
       "namespace": "notion",
       "resource": "block",
       "action": "list",
-      "description": "List blocks (content) of a Notion page as Markdown",
+      "description": "List child blocks of a page or block as Markdown",
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
-        "baseArgs": ["block", "list"],
-        "positionalArgs": ["pageId"],
-        "passthrough": true,
+        "baseArgs": [
+          "block",
+          "list"
+        ],
+        "positionalArgs": [
+          "pageId"
+        ],
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": [
-        { "name": "pageId", "type": "string", "required": true, "description": "Page ID or URL" },
-        { "name": "--depth", "type": "number", "required": false, "description": "Recursion depth for nested blocks (default 1)" },
-        { "name": "--md", "type": "boolean", "required": false, "description": "Output as Markdown" }
+        {
+          "name": "pageId",
+          "type": "string",
+          "required": true,
+          "description": "Page or block ID/URL"
+        },
+        {
+          "name": "depth",
+          "type": "number",
+          "required": false,
+          "description": "Recursion depth for nested blocks (default 1)"
+        },
+        {
+          "name": "md",
+          "type": "boolean",
+          "required": false,
+          "description": "Output as Markdown"
+        },
+        {
+          "name": "all",
+          "type": "boolean",
+          "required": false,
+          "description": "Fetch all pages of results"
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from previous results"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "block",
+      "action": "get",
+      "description": "Get a specific block by ID",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "block",
+          "get"
+        ],
+        "positionalArgs": [
+          "blockId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "blockId",
+          "type": "string",
+          "required": true,
+          "description": "Block ID or URL"
+        }
       ]
     },
     {
       "namespace": "notion",
       "resource": "block",
       "action": "append",
-      "description": "Append Markdown content to a Notion page",
+      "description": "Append Markdown or blocks to a Notion page or block",
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
-        "baseArgs": ["block", "append"],
-        "positionalArgs": ["pageId"],
-        "passthrough": true,
+        "baseArgs": [
+          "block",
+          "append"
+        ],
+        "positionalArgs": [
+          "parentId"
+        ],
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": [
-        { "name": "pageId", "type": "string", "required": true, "description": "Page ID or URL" },
-        { "name": "--file", "type": "string", "required": false, "description": "Markdown file to append" }
+        {
+          "name": "parentId",
+          "type": "string",
+          "required": true,
+          "description": "Page or block ID/URL"
+        },
+        {
+          "name": "file",
+          "type": "string",
+          "required": false,
+          "description": "Markdown file to append"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "required": false,
+          "description": "Block type: paragraph, h1, h2, h3, todo, bullet, numbered, quote, code, callout, divider"
+        },
+        {
+          "name": "lang",
+          "type": "string",
+          "required": false,
+          "description": "Language for code blocks (e.g., go, python, bash)"
+        },
+        {
+          "name": "on-oversize",
+          "type": "string",
+          "required": false,
+          "description": "Behavior for rich_text >2000 chars: split|truncate|fail"
+        },
+        {
+          "name": "caption",
+          "type": "string",
+          "required": false,
+          "description": "Caption for media blocks"
+        },
+        {
+          "name": "image-url",
+          "type": "string",
+          "required": false,
+          "description": "External image URL"
+        },
+        {
+          "name": "image-file",
+          "type": "string",
+          "required": false,
+          "description": "Local image file to upload and embed"
+        },
+        {
+          "name": "image-upload",
+          "type": "string",
+          "required": false,
+          "description": "Existing file_upload ID to embed as image"
+        },
+        {
+          "name": "file-url",
+          "type": "string",
+          "required": false,
+          "description": "External file URL"
+        },
+        {
+          "name": "file-file",
+          "type": "string",
+          "required": false,
+          "description": "Local file to upload and embed"
+        },
+        {
+          "name": "file-upload",
+          "type": "string",
+          "required": false,
+          "description": "Existing file_upload ID to embed as file"
+        },
+        {
+          "name": "pdf-url",
+          "type": "string",
+          "required": false,
+          "description": "External PDF URL"
+        },
+        {
+          "name": "pdf-file",
+          "type": "string",
+          "required": false,
+          "description": "Local PDF file to upload and embed"
+        },
+        {
+          "name": "pdf-upload",
+          "type": "string",
+          "required": false,
+          "description": "Existing file_upload ID to embed as PDF"
+        },
+        {
+          "name": "audio-url",
+          "type": "string",
+          "required": false,
+          "description": "External audio URL"
+        },
+        {
+          "name": "audio-file",
+          "type": "string",
+          "required": false,
+          "description": "Local audio file to upload and embed"
+        },
+        {
+          "name": "audio-upload",
+          "type": "string",
+          "required": false,
+          "description": "Existing file_upload ID to embed as audio"
+        },
+        {
+          "name": "video-url",
+          "type": "string",
+          "required": false,
+          "description": "External video URL"
+        },
+        {
+          "name": "video-file",
+          "type": "string",
+          "required": false,
+          "description": "Local video file to upload and embed"
+        },
+        {
+          "name": "video-upload",
+          "type": "string",
+          "required": false,
+          "description": "Existing file_upload ID to embed as video"
+        }
       ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "block",
+      "action": "insert",
+      "description": "Insert content after a specific child block",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "block",
+          "insert"
+        ],
+        "positionalArgs": [
+          "parentId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "parentId",
+          "type": "string",
+          "required": true,
+          "description": "Page or block ID/URL"
+        },
+        {
+          "name": "after",
+          "type": "string",
+          "required": true,
+          "description": "Block ID to position after"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "required": false,
+          "description": "Block type: paragraph, h1, h2, h3, todo, bullet, numbered, quote, code, callout, divider"
+        },
+        {
+          "name": "lang",
+          "type": "string",
+          "required": false,
+          "description": "Language for code blocks"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "block",
+      "action": "update",
+      "description": "Update a block's content in place",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "block",
+          "update"
+        ],
+        "positionalArgs": [
+          "blockId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "blockId",
+          "type": "string",
+          "required": true,
+          "description": "Block ID or URL"
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "required": false,
+          "description": "New text content"
+        },
+        {
+          "name": "file",
+          "type": "string",
+          "required": false,
+          "description": "Read markdown from file"
+        },
+        {
+          "name": "markdown",
+          "type": "boolean",
+          "required": false,
+          "description": "Parse --text as markdown"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "required": false,
+          "description": "Block type"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "block",
+      "action": "delete",
+      "description": "Delete one or more blocks by ID",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "block",
+          "delete"
+        ],
+        "positionalArgs": [
+          "blockId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "blockId",
+          "type": "string",
+          "required": true,
+          "description": "Block ID or URL"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "block",
+      "action": "move",
+      "description": "Move a block within its parent or to a different parent",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "block",
+          "move"
+        ],
+        "positionalArgs": [
+          "blockId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "blockId",
+          "type": "string",
+          "required": true,
+          "description": "Block ID or URL"
+        },
+        {
+          "name": "after",
+          "type": "string",
+          "required": false,
+          "description": "Block ID to position after"
+        },
+        {
+          "name": "before",
+          "type": "string",
+          "required": false,
+          "description": "Block ID to position before"
+        },
+        {
+          "name": "parent",
+          "type": "string",
+          "required": false,
+          "description": "New parent block/page ID to move to"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "comment",
+      "action": "list",
+      "description": "List comments on a Notion page or block",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "comment",
+          "list"
+        ],
+        "positionalArgs": [
+          "pageId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "pageId",
+          "type": "string",
+          "required": true,
+          "description": "Page or block ID/URL"
+        },
+        {
+          "name": "all",
+          "type": "boolean",
+          "required": false,
+          "description": "Fetch all pages of results"
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from previous results"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "comment",
+      "action": "add",
+      "description": "Add a comment to a Notion page",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "comment",
+          "add"
+        ],
+        "positionalArgs": [
+          "pageId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "pageId",
+          "type": "string",
+          "required": true,
+          "description": "Page or block ID/URL"
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "required": false,
+          "description": "Comment text"
+        },
+        {
+          "name": "mention-user",
+          "type": "string",
+          "required": false,
+          "description": "Mention a Notion user by ID (repeatable; pass multiple with --mention-user u1 --mention-user u2)"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "comment",
+      "action": "get",
+      "description": "Get a comment by ID",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "comment",
+          "get"
+        ],
+        "positionalArgs": [
+          "commentId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "commentId",
+          "type": "string",
+          "required": true,
+          "description": "Comment ID"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "comment",
+      "action": "reply",
+      "description": "Reply to a comment",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "comment",
+          "reply"
+        ],
+        "positionalArgs": [
+          "commentId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "commentId",
+          "type": "string",
+          "required": true,
+          "description": "Comment ID"
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "required": false,
+          "description": "Reply text"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "comment",
+      "action": "update",
+      "description": "Update a comment",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "comment",
+          "update"
+        ],
+        "positionalArgs": [
+          "commentId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "commentId",
+          "type": "string",
+          "required": true,
+          "description": "Comment ID"
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "required": false,
+          "description": "New comment text"
+        },
+        {
+          "name": "mention-user",
+          "type": "string",
+          "required": false,
+          "description": "Mention a Notion user by ID"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "comment",
+      "action": "delete",
+      "description": "Delete one or more comments by ID",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "comment",
+          "delete"
+        ],
+        "positionalArgs": [
+          "commentId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "commentId",
+          "type": "string",
+          "required": true,
+          "description": "Comment ID"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "user",
+      "action": "me",
+      "description": "Show current bot user",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "user",
+          "me"
+        ],
+        "timeout_ms": 10000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": []
     },
     {
       "namespace": "notion",
@@ -199,11 +1456,137 @@
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
-        "baseArgs": ["user", "list"],
+        "baseArgs": [
+          "user",
+          "list"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "all",
+          "type": "boolean",
+          "required": false,
+          "description": "Fetch all pages of results"
+        },
+        {
+          "name": "cursor",
+          "type": "string",
+          "required": false,
+          "description": "Pagination cursor from previous results"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "user",
+      "action": "get",
+      "description": "Get a user by ID",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "user",
+          "get"
+        ],
+        "positionalArgs": [
+          "userId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "userId",
+          "type": "string",
+          "required": true,
+          "description": "User ID"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "file",
+      "action": "list",
+      "description": "List file uploads",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "file",
+          "list"
+        ],
         "timeout_ms": 10000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": []
+    },
+    {
+      "namespace": "notion",
+      "resource": "file",
+      "action": "upload",
+      "description": "Upload a file to Notion",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "file",
+          "upload"
+        ],
+        "positionalArgs": [
+          "source"
+        ],
+        "timeout_ms": 60000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "source",
+          "type": "string",
+          "required": true,
+          "description": "Local path, http(s) URL, or - for stdin"
+        },
+        {
+          "name": "to",
+          "type": "string",
+          "required": false,
+          "description": "Target page ID to attach file to"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "description": "Override filename (required for stdin/URL)"
+        }
+      ]
+    },
+    {
+      "namespace": "notion",
+      "resource": "file",
+      "action": "get",
+      "description": "Get a file upload by ID",
+      "adapter": "process",
+      "adapterConfig": {
+        "command": "notion",
+        "baseArgs": [
+          "file",
+          "get"
+        ],
+        "positionalArgs": [
+          "uploadId"
+        ],
+        "timeout_ms": 15000,
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
+      },
+      "args": [
+        {
+          "name": "uploadId",
+          "type": "string",
+          "required": true,
+          "description": "File upload ID"
+        }
+      ]
     },
     {
       "namespace": "notion",
@@ -213,14 +1596,35 @@
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
-        "baseArgs": ["api"],
-        "positionalArgs": ["method", "path"],
+        "baseArgs": [
+          "api"
+        ],
+        "positionalArgs": [
+          "method",
+          "path"
+        ],
         "timeout_ms": 15000,
-        "missingDependencyHelp": "Install notion-cli and authenticate"
+        "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": [
-        { "name": "method", "type": "string", "required": true, "description": "HTTP method (GET, POST, PATCH, DELETE)" },
-        { "name": "path", "type": "string", "required": true, "description": "API path (e.g., /v1/users/me)" }
+        {
+          "name": "method",
+          "type": "string",
+          "required": true,
+          "description": "HTTP method (GET, POST, PATCH, DELETE)"
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "required": true,
+          "description": "API path (e.g., /v1/users/me)"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "required": false,
+          "description": "JSON request body. Use @<file> to read from file, or - for stdin"
+        }
       ]
     },
     {
@@ -231,7 +1635,9 @@
       "adapter": "process",
       "adapterConfig": {
         "command": "notion",
+        "baseArgs": [],
         "passthrough": true,
+        "timeout_ms": 30000,
         "missingDependencyHelp": "Install notion-cli: go install github.com/4ier/notion-cli@latest (the binary will be named notion-cli; symlink or rename it to notion) or brew install 4ier/tap/notion-cli. Authenticate: echo 'ntn_xxxx' | notion auth login --with-token"
       },
       "args": []

--- a/plugins/notion-cli/skills/quickstart/SKILL.md
+++ b/plugins/notion-cli/skills/quickstart/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: notion-cli
-description: Use this skill when the user wants to search, create, read, or manage Notion pages and databases — search workspace, query databases, create pages, read/write page content as Markdown, manage blocks, users, and files.
+description: Use this skill when the user wants to search, create, read, update, or manage Notion pages, databases, blocks, comments, files, and users.
 ---
 
 # Notion CLI Plugin
 
-Like `gh` for GitHub, but for Notion. 39 commands. One binary. Full Notion API coverage.
+Like `gh` for GitHub, but for Notion. Manage the full Notion API from a single Go binary.
 
 ## Prerequisites
 
-Requires a Notion API token (Integration token). Create one at https://www.notion.so/profile/integrations
+Requires a Notion API token (integration token). Create one at https://www.notion.so/profile/integrations
 
 ```bash
-# Authenticate
+# Authenticate via stdin
 echo "ntn_xxxxx" | notion auth login --with-token
 # or
 export NOTION_TOKEN=ntn_xxxxx
@@ -20,8 +20,13 @@ export NOTION_TOKEN=ntn_xxxxx
 
 ## Commands
 
+### Version
+- `notion self version` — Print notion-cli version
+
 ### Auth
 - `notion auth status` — Check authentication status
+- `notion auth doctor` — Check authentication and API connectivity
+- `notion auth logout` — Log out of Notion
 
 ### Search
 - `notion search run "query"` — Search pages and databases
@@ -29,24 +34,61 @@ export NOTION_TOKEN=ntn_xxxxx
 ### Pages
 - `notion page view <pageId>` — View page details
 - `notion page list` — List recent pages
-- `notion page create <dbId> --db "Name=Task" "Status=Todo"` — Create page in database
+- `notion page create <parentId> --title "My Page" --body "Body text"` — Create page under a page
+- `notion page create <dbId> "Name=Task" "Status=Todo" --db` — Create page in a database (place `--db` after property pairs)
+- `notion page archive <pageId>` — Archive (soft-delete) a page
+- `notion page restore <pageId>` — Restore an archived page
+- `notion page move <pageId> --to <parentId>` — Move a page to a new parent
+- `notion page open <pageId>` — Open a page in the browser
+- `notion page set <pageId> Status=Done Priority=High` — Set page properties
+- `notion page props <pageId>` — Show page properties
+- `notion page link <pageId> --prop "Project" --to <pageId>` — Link a page via a relation property
+- `notion page unlink <pageId> --prop "Project" --from <pageId>` — Remove a relation link
 
 ### Databases
 - `notion db list` — List databases
+- `notion db view <dbId>` — Show database schema
 - `notion db query <dbId> --filter 'Status=Done' --sort 'Date:desc'` — Query with filters
+- `notion db add <dbId> "Name=Task" "Status=Todo"` — Add a row to a database
+- `notion db add-bulk <dbId> --file items.json` — Bulk add rows from a JSON file
+- `notion db create <parentId> --title "Tasks" --props "Status:select,Date:date"` — Create a database
+- `notion db update <dbId> --title "New Title" --add-prop "Priority:select"` — Update a database
+- `notion db open <dbId>` — Open a database in the browser
+- `notion db export <dbId> --format csv --output report.csv` — Export database rows
 
 ### Blocks (Content)
 - `notion block list <pageId> --md --depth 3` — Read page as Markdown
-- `notion block append <pageId> --file document.md` — Append Markdown content
+- `notion block get <blockId>` — Get a specific block
+- `notion block append <parentId> "Hello world" --type h1` — Append blocks to a page
+- `notion block append <parentId> --file document.md` — Append Markdown from a file
+- `notion block insert <parentId> "New paragraph" --after <blockId>` — Insert after a block
+- `notion block update <blockId> --text "Updated content"` — Update a block
+- `notion block delete <blockId> ...` — Delete one or more blocks
+- `notion block move <blockId> --after <blockId>` — Move a block
+
+### Comments
+- `notion comment list <pageId>` — List comments on a page
+- `notion comment add <pageId> "This looks great"` — Add a comment
+- `notion comment get <commentId>` — Get a comment by ID
+- `notion comment reply <commentId> "Thanks"` — Reply to a comment
+- `notion comment update <commentId> --text "Fixed typo"` — Update a comment
+- `notion comment delete <commentId> ...` — Delete comments
 
 ### Users
+- `notion user me` — Show current bot user
 - `notion user list` — List workspace members
+- `notion user get <userId>` — Get a user by ID
 
-### API
+### Files
+- `notion file list` — List file uploads
+- `notion file upload <file-path|url|->` — Upload a file to Notion
+- `notion file get <uploadId>` — Retrieve a file upload by ID
+
+### Raw API
 - `notion api request GET /v1/users/me` — Raw Notion API request
 
 ### Full Access
-- `notion _ _` — Passthrough for any notion command (comment, file, block insert/update, etc.)
+- `notion _ _` — Passthrough for any notion command not covered above
 
 ## Usage Examples
 - "Search my Notion for meeting notes"
@@ -55,6 +97,9 @@ export NOTION_TOKEN=ntn_xxxxx
 - "Query the Projects database for items with Status = Done"
 - "List all my Notion databases"
 - "Append notes.md to my Weekly Review page"
+- "Archive the page with ID abc123"
+- "Move page abc123 under parent def456"
+- "Export my Tasks database to CSV"
 
 ## Installation
 


### PR DESCRIPTION
Automated maintenance run by automaintainer.

**Focus:** == ASSIGNED OBJECTIVE ==
Fix GitHub issue #298 ONLY: Add 4ier/notion-cli as a bundled plugin in SuperCLI. PR title MUST reference #298.

----
OPEN PR AWARENESS (secondary — do not replace the ASSIGNED OBJECTIVE):
These open pull requests are already open and awaiting review. Do NOT start UNRELATED work on the files they touch. If your ASSIGNED OBJECTIVE requires editing one of those files, complete the objective anyway. Never abandon the objective to pick a different GitHub issue just to avoid overlap.

- PR #381 (am/am-f17c27-dkoq3d9ycsit-02242336): fix(#298): expand bundled notion-cli command coverage
    touches: plugins/catalog.json, plugins/notion-cli/plugin.json
- PR #378 (am/am-f17c27-dkm2q5alhgw6-a56a1e03): fix(#298): expand bundled notion-cli command coverage
    touches: plugins/notion-cli/plugin.json
- PR #374 (am/am-f17c27-dkgyo5mzmfwo-70f504ac): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #373 (am/am-f17c27-dkgvzomn2u44-23e3c40b): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #372 (am/am-f17c27-dkg9sc8fjw7x-91e45236): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #371 (am/am-f17c27-dkg1g7311cne-ca767030): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #370 (am/am-f17c27-dkfyrq5qrxmx-e42eaa25): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md
- PR #369 (am/am-f17c27-dkfgj4w7jxmc-e50a95d1): fix(#298): add go install instructions to bundled notion-cli plugin
    touches: plugins/notion-cli/install-guidance.json, plugins/notion-cli/plugin.json, plugins/notion-cli/skills/quickstart/SKILL.md


**Branch:** `am/am-f17c27-dkpbnppmorbb-33d86c7f`

**Diff:**
```
plugins/notion-cli/README.md                  |   53 +-
 plugins/notion-cli/plugin.json                | 1524 ++++++++++++++++++++++++-
 plugins/notion-cli/skills/quickstart/SKILL.md |   61 +-
 3 files changed, 1568 insertions(+), 70 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Notion CLI support for page, database, block, comment, user, file, search, and raw API operations.
  * Added authentication diagnostics and logout commands.
  * Added resource management actions, including archiving, restoring, moving, exporting, and bulk database operations.
  * Added explicit command options and improved passthrough request support.

* **Documentation**
  * Updated examples and quickstart guidance to cover the expanded command set, authentication, connectivity checks, and common workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->